### PR TITLE
Redux build script problems

### DIFF
--- a/kotlin-redux/build.gradle
+++ b/kotlin-redux/build.gradle
@@ -1,3 +1,4 @@
+applyKotlinJS()
 apply plugin: 'kotlinx-serialization'
 
 configurePublishingWithNPM(redux_version)

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,7 @@ ext {
     // External dependencies
     kotlin_version = '1.2.60'
     kotlinx_html_version = '0.6.11'
-    kotlinx_serialization_version = '0.4.1'
+    kotlinx_serialization_version = '0.6.1-SNAPSHOT'
     node_plugin_version = '1.2.0'
     bintray_plugin_version = '1.8.0'
 


### PR DESCRIPTION
Hi, it appears that I forgot to apply kotlin2js to the gradle build of kotlin-redux, and the version of kotlinx serialization was not compatible with the current kotlin version. This was causing an empty jar to be published. It should work now.