### PR TITLE
Return HOC from connect, connectAdvanced, and rConnect

### DIFF
--- a/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
@@ -6,7 +6,7 @@ import react.*
 fun <S, OP : RProps, P : RProps> rConnect(
     mapStateToProps: P.(S, OP) -> Unit,
     options: (Options<S, OP, P, P>.() -> Unit) = {}
-): (RClass<P>) -> RClass<OP> {
+): HOC<P, OP> {
     return connect<S, Any, Any, OP, P, RProps, P>(
         { state: S, ownProps: OP ->
             js {
@@ -26,7 +26,7 @@ fun <S, OP : RProps, P : RProps> rConnect(
 fun <A, R, OP : RProps, P : RProps> rConnect(
     mapDispatchToProps: P.((A) -> R, OP) -> Unit,
     options: (Options<Any, OP, RProps, P>.() -> Unit) = {}
-): (RClass<P>) -> RClass<OP> {
+): HOC<P, OP> {
     return connect<Any, A, R, OP, RProps, P, P>(
         undefined,
         { dispatch, ownProps ->
@@ -47,7 +47,7 @@ fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> rConnect(
     mapStateToProps: SP.(S, OP) -> Unit,
     mapDispatchToProps: DP.((A) -> R, OP) -> Unit,
     options: (Options<S, OP, SP, P>.() -> Unit) = {}
-): (RClass<P>) -> RClass<OP> {
+): HOC<P, OP> {
     return connect<S, A, R, OP, SP, DP, P>(
         { state, ownProps ->
             js {
@@ -73,7 +73,7 @@ fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> rConnect(
     mapDispatchToProps: DP.((A) -> R, OP) -> Unit,
     mergeProps: P.(SP, DP, OP) -> Unit,
     options: (Options<S, OP, SP, P>.() -> Unit) = {}
-): (RClass<P>) -> RClass<OP> {
+): HOC<P, OP> {
     return connect<S, A, R, OP, SP, DP, P>(
         { state, ownProps ->
             js {

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
@@ -18,9 +18,9 @@ external fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> connec
     mapDispatchToProps: (((A) -> R, OP) -> DP)? = definedExternally,
     mergeProps: ((SP, DP, OP) -> P)? = definedExternally,
     options: Options<S, OP, SP, P>? = definedExternally
-): (RClass<P>) -> RClass<OP>
+): HOC<P, OP>
 
 external fun <S, A, R, OP : RProps, P : RProps> connectAdvanced(
     selectorFactory: SelectorFactory<S, A, R, OP, P>,
     options: ConnectOptions<P> = definedExternally
-): (RClass<P>) -> RClass<OP>
+): HOC<P, OP>


### PR DESCRIPTION
Changes the return type of connect, connectAdvanced, and rConnect from `(RClass<P>) -> RClass<OP>` to `HOC<P, OP>`. Not a breaking change 👍 