### PR TITLE
rConnect no parameters

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -3,4 +3,3 @@ applyKotlinJS()
 dependencies {
     compile project(':kotlin-react-dom')
 }
-

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -3,3 +3,4 @@ applyKotlinJS()
 dependencies {
     compile project(':kotlin-react-dom')
 }
+

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
@@ -3,6 +3,21 @@ package react.redux
 import kotlinext.js.*
 import react.*
 
+fun <A, R> rConnect(
+        options: (Options<Any, RProps, RProps, DispatchProps<A, R>>.() -> Unit) = {}
+): HOC<DispatchProps<A, R>, RProps> {
+    return connect<Any, A, R, RProps, RProps, RProps, DispatchProps<A, R>>(
+            undefined,
+            undefined,
+            undefined,
+            js {
+                getDisplayName = { name: String -> "RConnect($name)" }
+                methodName = "rConnect"
+                options(this)
+            }.unsafeCast<Options<Any, RProps, RProps, DispatchProps<A, R>>>()
+    )
+}
+
 fun <S, OP : RProps, P : RProps> rConnect(
     mapStateToProps: P.(S, OP) -> Unit,
     options: (Options<S, OP, P, P>.() -> Unit) = {}

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Types.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Types.kt
@@ -28,3 +28,7 @@ external interface FactoryOptions<P : RProps> {
 typealias Selector<S, OP, P> = (S, OP) -> P
 
 typealias SelectorFactory<S, A, R, OP, P> = ((A) -> R, FactoryOptions<P>) -> Selector<S, OP, P>
+
+interface DispatchProps<A, R> : RProps {
+    var dispatch: (A) -> R
+}


### PR DESCRIPTION
connect supports using no parameters to pass dispatch as props to connected component. This adds support for this behavior using rConnect.