### PR TITLE
HOC enhancement

### DIFF
--- a/kotlin-react-redux/README.md
+++ b/kotlin-react-redux/README.md
@@ -35,7 +35,7 @@ val connectedComponent: RClass<ConnectedComponentProps> =
         eventHandler1 = { dispatch(SomeAction()) }
         // ...
     }
-    )(WrappedComponent::class.js as RClass<WrappedComponentProps>)
+    )(WrappedComponent::class.rClass)
 
 // ...
 

--- a/kotlin-react/src/main/kotlin/react/HOC.kt
+++ b/kotlin-react/src/main/kotlin/react/HOC.kt
@@ -20,3 +20,6 @@ operator fun <P : RProps, R : RProps> HOC<P, R>.invoke(config: Any, component: R
             component(props)
         }
     }, config)
+
+fun <P : RProps> allOf(vararg hocs: HOC<P, P>): (component: RClass<P>) -> RClass<P> =
+    { hocs.fold(it) { acc, hoc -> hoc(acc) } }

--- a/kotlin-react/src/main/kotlin/react/React.kt
+++ b/kotlin-react/src/main/kotlin/react/React.kt
@@ -3,6 +3,7 @@ package react
 import kotlinext.js.*
 import kotlinx.coroutines.*
 import kotlin.js.*
+import kotlin.reflect.*
 
 external interface Child
 
@@ -36,6 +37,9 @@ inline fun <P : RProps> cloneElement(
 
 fun clone(element: dynamic, props: dynamic, child: Any? = null): ReactElement =
     cloneElement(element, props, *Children.toArray(child))
+
+val <P : RProps, T : RComponent<P, *>> KClass<T>.rClass get() =
+    js.unsafeCast<RClass<P>>()
 
 // 16.6+
 fun <P : RProps> rLazy(loadComponent: suspend () -> RClass<P>): RClass<P> {


### PR DESCRIPTION
## Changes
- Added an `rClass` extension property to `KClass<RComponent<*,*>>`. This will help to reduce to boilerplate to call `rConnect` (and any other `HOC`)
- Added an `allOf` function to `HOC.kt` that will take a list of wrapper functions, chain them to the given component, and return the resulting `RClass`.

## Example usage:
```kotlin
private val wrappedMyComponent = 
    allOf<MyComponentProps>(withTheme(), withSnackbar())(MyComponent::class.rClass)

fun RBuilder.myComponent(...) = wrappedMyComponent { // this: RElementBuilder<MyComponentProps>
    // render something here
}
```

Imports for `withTheme`:
```kotlin
@JsModule("@material-ui/core/styles")
external val materialUiCoreStyles: dynamic

fun <P : WithTheme> withTheme() = materialUiCoreStyles.withTheme().unsafeCast<HOC<P, P>>()

external interface WithTheme : RProps { val theme: Theme }
external interface Theme {
    val spacing: Spacing
    interface Spacing { val unit: Int }
}
```

Imports for for `withSnackbar`:
```kotlin
@JsModule("notistack")
external val notistack: dynamic

fun <P : WithSnackbar> withSnackbar() = notistack.withSnackbar.unsafeCast<HOC<P, P>>()

interface WithSnackbar : RProps {
    val enqueueSnackbar: (message: String, options: Options?) -> String
    val closeSnackbar: (key: String) -> Unit
    interface Options { var variantValue: String }
}
```