### PR TITLE
Significantly reduce StyledElement object memory consumption

### DIFF
--- a/kotlin-css/src/main/kotlin/kotlinx/css/StyledElement.kt
+++ b/kotlin-css/src/main/kotlin/kotlinx/css/StyledElement.kt
@@ -8,185 +8,186 @@ import kotlin.reflect.*
 open class StyledElement {
     val declarations = LinkedHashMap<String, Any>()
 
-    inner class WithDefault<T : Any>(val default: () -> T) {
-        operator fun getValue(thisRef: Any, property: KProperty<*>): T {
-            val ex = declarations.containsKey(property.name)
-            if (!ex) {
-                declarations[property.name] = default()
-            }
-            @Suppress("UNCHECKED_CAST")
-            return declarations[property.name] as T
-        }
-
-        operator fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
-            declarations[property.name] = value
-        }
-    }
-
-    var alignContent: Align by declarations
-    var alignItems: Align by declarations
-    var alignSelf: Align by declarations
-    var animation by WithDefault { Animations() }
-
-    var background: String by declarations
-    var backgroundAttachment: BackgroundAttachment by declarations
-    var backgroundClip: BackgroundClip by declarations
-    var backgroundColor: Color by declarations
-    var backgroundImage: Image by declarations
-    var backgroundOrigin: BackgroundOrigin by declarations
-    var backgroundPosition: String by declarations
-    var backgroundRepeat: BackgroundRepeat by declarations
-    var backgroundSize: String by declarations
-
-    var border: String by declarations
-    var borderTop: String by declarations
-    var borderRight: String by declarations
-    var borderBottom: String by declarations
-    var borderLeft: String by declarations
-    var borderSpacing: LinearDimension by declarations
-
-    var borderRadius: LinearDimension by declarations
-    var borderTopLeftRadius: LinearDimension by declarations
-    var borderTopRightRadius: LinearDimension by declarations
-    var borderBottomLeftRadius: LinearDimension by declarations
-    var borderBottomRightRadius: LinearDimension by declarations
-
-    var borderStyle: BorderStyle by declarations
-    var borderTopStyle: BorderStyle by declarations
-    var borderRightStyle: BorderStyle by declarations
-    var borderBottomStyle: BorderStyle by declarations
-    var borderLeftStyle: BorderStyle by declarations
-
-    var borderWidth: LinearDimension by declarations
-    var borderTopWidth: LinearDimension by declarations
-    var borderRightWidth: LinearDimension by declarations
-    var borderBottomWidth: LinearDimension by declarations
-    var borderLeftWidth: LinearDimension by declarations
-
-    var borderColor: Color by declarations
-    var borderTopColor: Color by declarations
-    var borderRightColor: Color by declarations
-    var borderBottomColor: Color by declarations
-    var borderLeftColor: Color by declarations
-
-    var bottom: LinearDimension by declarations
-    var boxSizing: BoxSizing by declarations
-    var boxShadow by WithDefault { BoxShadows() }
-
-    var clear: Clear by declarations
-    var color: Color by declarations
-    var columnGap: ColumnGap by declarations
-    var contain: Contain by declarations
-    var content: QuotedString by declarations
-    var cursor: Cursor by declarations
-
-    var direction: Direction by declarations
-    var display: Display by declarations
-
-    var filter: String by declarations
-    var flexDirection: FlexDirection by declarations
-    var flexGrow: Double by declarations
-    var flexShrink: Double by declarations
-    var flexBasis: FlexBasis by declarations
-    var flexWrap: FlexWrap by declarations
-    var float: Float by declarations
-    var fontFamily: String by declarations
-    var fontSize: LinearDimension by declarations
-    var fontWeight: FontWeight by declarations
-    var fontStyle: FontStyle by declarations
-
-    var gap: Gap by declarations
-    var gridAutoColumns: GridAutoColumns by declarations
-    var gridAutoFlow: GridAutoFlow by declarations
-    var gridAutoRows: GridAutoRows by declarations
-    var gridColumn: GridColumn by declarations
-    var gridColumnEnd: GridColumnEnd by declarations
-    @Deprecated("The gridColumnGap property is deprecated.", ReplaceWith("Use columnGap instead"))
-    var gridColumnGap: GridColumnGap by declarations
-    var gridColumnStart: GridColumnStart by declarations
-    @Deprecated("The gridGap property is deprecated.", ReplaceWith("Use gap instead"))
-    var gridGap: GridGap by declarations
-    var gridRow: GridRow by declarations
-    var gridRowEnd: GridRowEnd by declarations
-    @Deprecated("The gridRowGap property is deprecated.", ReplaceWith("Use rowGap instead"))
-    var gridRowGap: GridRowGap by declarations
-    var gridRowStart: GridRowStart by declarations
-    var gridTemplate: GridTemplate by declarations
-    var gridTemplateAreas: GridTemplateAreas by declarations
-    var gridTemplateColumns: GridTemplateColumns by declarations
-    var gridTemplateRows: GridTemplateRows by declarations
-
-    var height: LinearDimension by declarations
-
-    var hyphens: Hyphens by declarations
-
-    var justifyContent: JustifyContent by declarations
-
-    var left: LinearDimension by declarations
-    var letterSpacing: LinearDimension by declarations
-    var lineHeight: LineHeight by declarations
-    var listStyleType: ListStyleType by declarations
-
-    var margin: String by declarations
-    var marginTop: LinearDimension by declarations
-    var marginRight: LinearDimension by declarations
-    var marginBottom: LinearDimension by declarations
-    var marginLeft: LinearDimension by declarations
-    var minWidth: LinearDimension by declarations
-    var maxWidth: LinearDimension by declarations
-    var minHeight: LinearDimension by declarations
-    var maxHeight: LinearDimension by declarations
-
-    var objectFit: ObjectFit by declarations
-    var objectPosition: String by declarations
-    var opacity: Number by declarations
-    var outline: Outline by declarations
-    var overflow: Overflow by declarations
-    var overflowX: Overflow by declarations
-    var overflowY: Overflow by declarations
-    var overflowWrap: OverflowWrap by declarations
-    var overscrollBehavior: OverscrollBehavior by declarations
-
-    var padding: String by declarations
-    var paddingTop: LinearDimension by declarations
-    var paddingRight: LinearDimension by declarations
-    var paddingBottom: LinearDimension by declarations
-    var paddingLeft: LinearDimension by declarations
-    var pointerEvents: PointerEvents by declarations
-    var position: Position by declarations
-
-    var right: LinearDimension by declarations
-    var rowGap: RowGap by declarations
-
-    var scrollBehavior: ScrollBehavior by declarations
-
-    var textAlign: TextAlign by declarations
-    var textDecoration: TextDecoration by declarations
-    var textOverflow: TextOverflow by declarations
-    var textTransform: TextTransform by declarations
-    var top: LinearDimension by declarations
-    var transform by WithDefault { Transforms() }
-    var transition by WithDefault { Transitions() }
-
-    var verticalAlign: VerticalAlign by declarations
-    var visibility: Visibility by declarations
-
-    var whiteSpace: WhiteSpace by declarations
-    var width: LinearDimension by declarations
-    var wordBreak: WordBreak by declarations
-    var wordWrap: WordWrap by declarations
-
-    var userSelect: UserSelect by declarations
-
-    var tableLayout: TableLayout by declarations
-    var borderCollapse: BorderCollapse by declarations
-
-    var zIndex: Int by declarations
-
     fun put(key: String, value: String) {
         declarations[key] = value
     }
 }
+
+private class CSSProperty<T>(private val default: (() -> T)? = null) {
+    operator fun getValue(thisRef: StyledElement, property: KProperty<*>): T {
+        default?.let { default ->
+            if (!thisRef.declarations.containsKey(property.name)) {
+                thisRef.declarations[property.name] = default() as Any
+            }
+        }
+        
+        return thisRef.declarations[property.name] as T
+    }
+
+    operator fun setValue(thisRef: StyledElement, property: KProperty<*>, value: T) {
+        thisRef.declarations[property.name] = value as Any
+    }
+}
+
+var StyledElement.alignContent: Align by CSSProperty()
+var StyledElement.alignItems: Align by CSSProperty()
+var StyledElement.alignSelf: Align by CSSProperty()
+var StyledElement.animation by CSSProperty { Animations() }
+
+var StyledElement.background: String by CSSProperty()
+var StyledElement.backgroundAttachment: BackgroundAttachment by CSSProperty()
+var StyledElement.backgroundClip: BackgroundClip by CSSProperty()
+var StyledElement.backgroundColor: Color by CSSProperty()
+var StyledElement.backgroundImage: Image by CSSProperty()
+var StyledElement.backgroundOrigin: BackgroundOrigin by CSSProperty()
+var StyledElement.backgroundPosition: String by CSSProperty()
+var StyledElement.backgroundRepeat: BackgroundRepeat by CSSProperty()
+var StyledElement.backgroundSize: String by CSSProperty()
+
+var StyledElement.border: String by CSSProperty()
+var StyledElement.borderTop: String by CSSProperty()
+var StyledElement.borderRight: String by CSSProperty()
+var StyledElement.borderBottom: String by CSSProperty()
+var StyledElement.borderLeft: String by CSSProperty()
+var StyledElement.borderSpacing: LinearDimension by CSSProperty()
+
+var StyledElement.borderRadius: LinearDimension by CSSProperty()
+var StyledElement.borderTopLeftRadius: LinearDimension by CSSProperty()
+var StyledElement.borderTopRightRadius: LinearDimension by CSSProperty()
+var StyledElement.borderBottomLeftRadius: LinearDimension by CSSProperty()
+var StyledElement.borderBottomRightRadius: LinearDimension by CSSProperty()
+
+var StyledElement.borderStyle: BorderStyle by CSSProperty()
+var StyledElement.borderTopStyle: BorderStyle by CSSProperty()
+var StyledElement.borderRightStyle: BorderStyle by CSSProperty()
+var StyledElement.borderBottomStyle: BorderStyle by CSSProperty()
+var StyledElement.borderLeftStyle: BorderStyle by CSSProperty()
+
+var StyledElement.borderWidth: LinearDimension by CSSProperty()
+var StyledElement.borderTopWidth: LinearDimension by CSSProperty()
+var StyledElement.borderRightWidth: LinearDimension by CSSProperty()
+var StyledElement.borderBottomWidth: LinearDimension by CSSProperty()
+var StyledElement.borderLeftWidth: LinearDimension by CSSProperty()
+
+var StyledElement.borderColor: Color by CSSProperty()
+var StyledElement.borderTopColor: Color by CSSProperty()
+var StyledElement.borderRightColor: Color by CSSProperty()
+var StyledElement.borderBottomColor: Color by CSSProperty()
+var StyledElement.borderLeftColor: Color by CSSProperty()
+
+var StyledElement.bottom: LinearDimension by CSSProperty()
+var StyledElement.boxSizing: BoxSizing by CSSProperty()
+var StyledElement.boxShadow by CSSProperty { BoxShadows() }
+
+var StyledElement.clear: Clear by CSSProperty()
+var StyledElement.color: Color by CSSProperty()
+var StyledElement.columnGap: ColumnGap by CSSProperty()
+var StyledElement.contain: Contain by CSSProperty()
+var StyledElement.content: QuotedString by CSSProperty()
+var StyledElement.cursor: Cursor by CSSProperty()
+
+var StyledElement.direction: Direction by CSSProperty()
+var StyledElement.display: Display by CSSProperty()
+
+var StyledElement.filter: String by CSSProperty()
+var StyledElement.flexDirection: FlexDirection by CSSProperty()
+var StyledElement.flexGrow: Double by CSSProperty()
+var StyledElement.flexShrink: Double by CSSProperty()
+var StyledElement.flexBasis: FlexBasis by CSSProperty()
+var StyledElement.flexWrap: FlexWrap by CSSProperty()
+var StyledElement.float: Float by CSSProperty()
+var StyledElement.fontFamily: String by CSSProperty()
+var StyledElement.fontSize: LinearDimension by CSSProperty()
+var StyledElement.fontWeight: FontWeight by CSSProperty()
+var StyledElement.fontStyle: FontStyle by CSSProperty()
+
+var StyledElement.gap: Gap by CSSProperty()
+var StyledElement.gridAutoColumns: GridAutoColumns by CSSProperty()
+var StyledElement.gridAutoFlow: GridAutoFlow by CSSProperty()
+var StyledElement.gridAutoRows: GridAutoRows by CSSProperty()
+var StyledElement.gridColumn: GridColumn by CSSProperty()
+var StyledElement.gridColumnEnd: GridColumnEnd by CSSProperty()
+@Deprecated("The gridColumnGap property is deprecated.", ReplaceWith("Use columnGap instead"))
+var StyledElement.gridColumnGap: GridColumnGap by CSSProperty()
+var StyledElement.gridColumnStart: GridColumnStart by CSSProperty()
+@Deprecated("The gridGap property is deprecated.", ReplaceWith("Use gap instead"))
+var StyledElement.gridGap: GridGap by CSSProperty()
+var StyledElement.gridRow: GridRow by CSSProperty()
+var StyledElement.gridRowEnd: GridRowEnd by CSSProperty()
+@Deprecated("The gridRowGap property is deprecated.", ReplaceWith("Use rowGap instead"))
+var StyledElement.gridRowGap: GridRowGap by CSSProperty()
+var StyledElement.gridRowStart: GridRowStart by CSSProperty()
+var StyledElement.gridTemplate: GridTemplate by CSSProperty()
+var StyledElement.gridTemplateAreas: GridTemplateAreas by CSSProperty()
+var StyledElement.gridTemplateColumns: GridTemplateColumns by CSSProperty()
+var StyledElement.gridTemplateRows: GridTemplateRows by CSSProperty()
+
+var StyledElement.height: LinearDimension by CSSProperty()
+
+var StyledElement.hyphens: Hyphens by CSSProperty()
+
+var StyledElement.justifyContent: JustifyContent by CSSProperty()
+
+var StyledElement.left: LinearDimension by CSSProperty()
+var StyledElement.letterSpacing: LinearDimension by CSSProperty()
+var StyledElement.lineHeight: LineHeight by CSSProperty()
+var StyledElement.listStyleType: ListStyleType by CSSProperty()
+
+var StyledElement.margin: String by CSSProperty()
+var StyledElement.marginTop: LinearDimension by CSSProperty()
+var StyledElement.marginRight: LinearDimension by CSSProperty()
+var StyledElement.marginBottom: LinearDimension by CSSProperty()
+var StyledElement.marginLeft: LinearDimension by CSSProperty()
+var StyledElement.minWidth: LinearDimension by CSSProperty()
+var StyledElement.maxWidth: LinearDimension by CSSProperty()
+var StyledElement.minHeight: LinearDimension by CSSProperty()
+var StyledElement.maxHeight: LinearDimension by CSSProperty()
+
+var StyledElement.objectFit: ObjectFit by CSSProperty()
+var StyledElement.objectPosition: String by CSSProperty()
+var StyledElement.opacity: Number by CSSProperty()
+var StyledElement.outline: Outline by CSSProperty()
+var StyledElement.overflow: Overflow by CSSProperty()
+var StyledElement.overflowX: Overflow by CSSProperty()
+var StyledElement.overflowY: Overflow by CSSProperty()
+var StyledElement.overflowWrap: OverflowWrap by CSSProperty()
+var StyledElement.overscrollBehavior: OverscrollBehavior by CSSProperty()
+
+var StyledElement.padding: String by CSSProperty()
+var StyledElement.paddingTop: LinearDimension by CSSProperty()
+var StyledElement.paddingRight: LinearDimension by CSSProperty()
+var StyledElement.paddingBottom: LinearDimension by CSSProperty()
+var StyledElement.paddingLeft: LinearDimension by CSSProperty()
+var StyledElement.pointerEvents: PointerEvents by CSSProperty()
+var StyledElement.position: Position by CSSProperty()
+
+var StyledElement.right: LinearDimension by CSSProperty()
+var StyledElement.rowGap: RowGap by CSSProperty()
+
+var StyledElement.scrollBehavior: ScrollBehavior by CSSProperty()
+
+var StyledElement.textAlign: TextAlign by CSSProperty()
+var StyledElement.textDecoration: TextDecoration by CSSProperty()
+var StyledElement.textOverflow: TextOverflow by CSSProperty()
+var StyledElement.textTransform: TextTransform by CSSProperty()
+var StyledElement.top: LinearDimension by CSSProperty()
+var StyledElement.transform by CSSProperty { Transforms() }
+var StyledElement.transition by CSSProperty { Transitions() }
+
+var StyledElement.verticalAlign: VerticalAlign by CSSProperty()
+var StyledElement.visibility: Visibility by CSSProperty()
+
+var StyledElement.whiteSpace: WhiteSpace by CSSProperty()
+var StyledElement.width: LinearDimension by CSSProperty()
+var StyledElement.wordBreak: WordBreak by CSSProperty()
+var StyledElement.wordWrap: WordWrap by CSSProperty()
+
+var StyledElement.userSelect: UserSelect by CSSProperty()
+
+var StyledElement.tableLayout: TableLayout by CSSProperty()
+var StyledElement.borderCollapse: BorderCollapse by CSSProperty()
+
+var StyledElement.zIndex: Int by CSSProperty()
 
 fun StyledElement.flex(flexGrow: Double = 0.0, flexShrink: Double = 0.0, flexBasis: FlexBasis? = null) {
     this.flexGrow = flexGrow


### PR DESCRIPTION
If you take a look on the compiled code you would notice that `StyledElement` has a huge constructor:

```
  function StyledElement() {
    this.declarations = LinkedHashMap_init();
    this.alignContent_7m0jmp$_0 = this.declarations;
    this.alignItems_9mpmew$_0 = this.declarations;
    this.alignSelf_dai5xs$_0 = this.declarations;
    this.animation_9ca8n1$_0 = new StyledElement$WithDefault(this, StyledElement$animation$lambda);
    this.background_dt9zfp$_0 = this.declarations;
    this.backgroundAttachment_lerym6$_0 = this.declarations;
    this.backgroundClip_v98mrv$_0 = this.declarations;
    this.backgroundColor_piuh1o$_0 = this.declarations;
    this.backgroundImage_sbtf4k$_0 = this.declarations;
    this.backgroundOrigin_pp8gf5$_0 = this.declarations;
    this.backgroundPosition_jdky2s$_0 = this.declarations;
    this.backgroundRepeat_ca6fii$_0 = this.declarations;
    this.backgroundSize_v0hhwc$_0 = this.declarations;
    this.border_uj5qsn$_0 = this.declarations;
    this.borderTop_ybtec8$_0 = this.declarations;
    this.borderRight_u1zlf5$_0 = this.declarations;
    this.borderBottom_ae6zt0$_0 = this.declarations;
    this.borderLeft_1eydpc$_0 = this.declarations;
    this.borderSpacing_v4gap6$_0 = this.declarations;
    this.borderRadius_4h72k5$_0 = this.declarations;
    this.borderTopLeftRadius_r45t5r$_0 = this.declarations;
    this.borderTopRightRadius_1h9xwu$_0 = this.declarations;
    this.borderBottomLeftRadius_va7gar$_0 = this.declarations;
    this.borderBottomRightRadius_bdj8qe$_0 = this.declarations;
    this.borderStyle_upeipo$_0 = this.declarations;
    this.borderTopStyle_hm0yl1$_0 = this.declarations;
    this.borderRightStyle_7neimm$_0 = this.declarations;
    this.borderBottomStyle_ail53b$_0 = this.declarations;
    this.borderLeftStyle_uf8tyb$_0 = this.declarations;
    this.borderWidth_wf611j$_0 = this.declarations;
    this.borderTopWidth_fw9g96$_0 = this.declarations;
    this.borderRightWidth_5xn0ar$_0 = this.declarations;
    this.borderBottomWidth_c8cnf6$_0 = this.declarations;
    this.borderLeftWidth_w50ca6$_0 = this.declarations;
    this.borderColor_n1pd56$_0 = this.declarations;
    this.borderTopColor_p9q45j$_0 = this.declarations;
    this.borderRightColor_fb3o74$_0 = this.declarations;
    this.borderBottomColor_2uvzit$_0 = this.declarations;
    this.borderLeftColor_mrjodt$_0 = this.declarations;
    this.bottom_ukjr2g$_0 = this.declarations;
    this.boxSizing_usvozc$_0 = this.declarations;
    this.boxShadow_ty01xy$_0 = new StyledElement$WithDefault(this, StyledElement$boxShadow$lambda);
    this.clear_ccaz1o$_0 = this.declarations;
    this.color_caitz6$_0 = this.declarations;
    this.columnGap_uohhen$_0 = this.declarations;
    this.contain_krgpcj$_0 = this.declarations;
    this.content_kre1js$_0 = this.declarations;
    this.cursor_mz0idf$_0 = this.declarations;
    this.direction_7uxgv6$_0 = this.declarations;
    this.display_6nw2v5$_0 = this.declarations;
    this.filter_facjkr$_0 = this.declarations;
    this.flexDirection_2fvpq3$_0 = this.declarations;
    this.flexGrow_qznie1$_0 = this.declarations;
    this.flexShrink_hx0sfl$_0 = this.declarations;
    this.flexBasis_d1lijg$_0 = this.declarations;
    this.flexWrap_qqv3g0$_0 = this.declarations;
    this.float_awzpy3$_0 = this.declarations;
    this.fontFamily_23st9c$_0 = this.declarations;
    this.fontSize_n8a6ql$_0 = this.declarations;
    this.fontWeight_yvk984$_0 = this.declarations;
    this.fontStyle_9nlzc1$_0 = this.declarations;
    this.gap_d58nl7$_0 = this.declarations;
    this.gridAutoColumns_zd991j$_0 = this.declarations;
    this.gridAutoFlow_41l45s$_0 = this.declarations;
    this.gridAutoRows_488q2t$_0 = this.declarations;
    this.gridColumn_zhoz87$_0 = this.declarations;
    this.gridColumnEnd_w44giq$_0 = this.declarations;
    this.gridColumnGap_w45h53$_0 = this.declarations;
    this.gridColumnStart_tn230l$_0 = this.declarations;
    this.gridGap_64hne7$_0 = this.declarations;
    this.gridRow_64abzn$_0 = this.declarations;
    this.gridRowEnd_sblvo4$_0 = this.declarations;
    this.gridRowGap_sbkv1r$_0 = this.declarations;
    this.gridRowStart_6b0lmj$_0 = this.declarations;
    this.gridTemplate_9q8vlf$_0 = this.declarations;
    this.gridTemplateAreas_r67ekb$_0 = this.declarations;
    this.gridTemplateColumns_9hhrcs$_0 = this.declarations;
    this.gridTemplateRows_jgrcm2$_0 = this.declarations;
    this.height_sc11v8$_0 = this.declarations;
    this.hyphens_d89c9s$_0 = this.declarations;
    this.justifyContent_m0kemu$_0 = this.declarations;
    this.left_ileno4$_0 = this.declarations;
    this.letterSpacing_m13ack$_0 = this.declarations;
    this.lineHeight_66bepk$_0 = this.declarations;
    this.listStyleType_s12qzw$_0 = this.declarations;
    this.margin_rqe0d7$_0 = this.declarations;
    this.marginTop_ya859i$_0 = this.declarations;
    this.marginRight_aba7n7$_0 = this.declarations;
    this.marginBottom_gvymwq$_0 = this.declarations;
    this.marginLeft_2j3dum$_0 = this.declarations;
    this.minWidth_7dk9j3$_0 = this.declarations;
    this.maxWidth_5ecmr3$_0 = this.declarations;
    this.minHeight_6ou62w$_0 = this.declarations;
    this.maxHeight_y6xcsq$_0 = this.declarations;
    this.objectFit_ls7sbz$_0 = this.declarations;
    this.objectPosition_r7k1rp$_0 = this.declarations;
    this.opacity_lrx962$_0 = this.declarations;
    this.outline_aa924h$_0 = this.declarations;
    this.overflow_a5qwrz$_0 = this.declarations;
    this.overflowX_utpzf9$_0 = this.declarations;
    this.overflowY_utpzee$_0 = this.declarations;
    this.overflowWrap_x0afaf$_0 = this.declarations;
    this.overscrollBehavior_ns2vmo$_0 = this.declarations;
    this.padding_1erndc$_0 = this.declarations;
    this.paddingTop_wpf5zj$_0 = this.declarations;
    this.paddingRight_xwju08$_0 = this.declarations;
    this.paddingBottom_x4zpln$_0 = this.declarations;
    this.paddingLeft_jbwhc9$_0 = this.declarations;
    this.pointerEvents_387511$_0 = this.declarations;
    this.position_unodoq$_0 = this.declarations;
    this.right_5a8lp7$_0 = this.declarations;
    this.rowGap_iopk7d$_0 = this.declarations;
    this.scrollBehavior_gmz364$_0 = this.declarations;
    this.textAlign_q4h755$_0 = this.declarations;
    this.textDecoration_64ihsa$_0 = this.declarations;
    this.textOverflow_f1huuc$_0 = this.declarations;
    this.textTransform_oinaji$_0 = this.declarations;
    this.top_d5h8ss$_0 = this.declarations;
    this.transform_oeyh0r$_0 = new StyledElement$WithDefault(this, StyledElement$transform$lambda);
    this.transition_pya44e$_0 = new StyledElement$WithDefault(this, StyledElement$transition$lambda);
    this.verticalAlign_azdc3y$_0 = this.declarations;
    this.visibility_cn948v$_0 = this.declarations;
    this.whiteSpace_sqw8tm$_0 = this.declarations;
    this.width_2x262t$_0 = this.declarations;
    this.wordBreak_kjny6k$_0 = this.declarations;
    this.wordWrap_h0tf8f$_0 = this.declarations;
    this.userSelect_e7wpjg$_0 = this.declarations;
    this.tableLayout_v4ft9l$_0 = this.declarations;
    this.borderCollapse_h74sze$_0 = this.declarations;
    this.zIndex_9l7h23$_0 = this.declarations;
  }
```

This code is executed every time when a new `StyledElement` is created. Besides that `StyledElement` consumes a lot of memory for storing the properties most of that won't be needed. Thus, every time a user writes

```
css {
    backgroundColor = Color.red;
}
```

this object is created.

I suggest making all these properties extension ones. This breaks an API a little: library consumers should write `import kotlinx.css.*` from now on.