### PR TITLE
Assign static class names to an element even if they are applied under `specific`

### DIFF
--- a/kotlin-styled/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyleSheet.kt
@@ -44,18 +44,24 @@ open class StyleSheet(var name: String, val isStatic: Boolean = false) {
 
 class CssHolder(private val sheet: StyleSheet, internal vararg val ruleSets: RuleSet) {
     operator fun getValue(thisRef: Any?, property: KProperty<*>): RuleSet = {
-        if (sheet.isStatic && allowClasses) {
+        if (sheet.isStatic) {
+            +(sheet.getClassName(property))
             sheet.inject()
-            +"${sheet.name}-${property.name}"
-        } else {
-            styleName.add("${sheet.name}-${property.name}")
+        }
+
+        if (!sheet.isStatic || !allowClasses) {
+            styleName.add(sheet.getClassName(property))
             ruleSets.forEach { it() }
         }
     }
 }
 
 fun <T : StyleSheet> T.getClassName(getClass: (T) -> KProperty0<RuleSet>): String {
-    return "$name-${getClass(this).name}"
+    return getClassName(getClass(this))
+}
+
+private fun StyleSheet.getClassName(property: KProperty<*>): String {
+    return "$name-${property.name}"
 }
 
 fun <T : StyleSheet> T.getClassSelector(getClass: (T) -> KProperty0<RuleSet>): String {


### PR DESCRIPTION
For example, the following code

```
styledDiv {
    css {
        specific {
            +SomeStaticStyleSheet.someClass
        }
    }
}
```

produces something like `<div class="SomeStaticStyleSheet-someClass hFRAPv"></div>` from now on
instead of just `<div class="hFRAPv"></div>`.

It allows overriding some properties of the static class from the outside

```
object OverridingStyleSheet : StyleSheet("OverridingStyleSheet", isStatic = true) {
    val greenText by css {
    	descendants(SomeStaticStyleSheet.getClassSelector { it::someClass }) {
            color = Color.green
        }
    }
}
```

and not being afraid that `SomeStaticStyleSheet-someClass` won't be applied to the element because of nesting.