### PR TITLE
Fix useCallback hook type definition

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -125,7 +125,7 @@ external fun rawUseLayoutEffect(effect: () -> dynamic)
 external fun <T> useContext(context: RContext<T>): T
 
 // Callback Hook (16.8+)
-external fun useCallback(callback: () -> Unit, dependencies: RDependenciesArray): () -> Unit
+external fun <T: Function<*>> useCallback(callback: T, dependencies: RDependenciesArray): T
 
 // Memo Hook (16.8+)
 external fun <T> useMemo(callback: () -> T, dependencies: RDependenciesArray): T


### PR DESCRIPTION
The TypeScript definition of the `useCallback` hook is

```typescript
function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
```
I have modified the Kotlin wrapper definition to match it.