### PR TITLE
Fix Apache-2.0 SPDX identifier

### DIFF
--- a/kotlin-css/kotlin-css-js/package.json
+++ b/kotlin-css/kotlin-css-js/package.json
@@ -14,5 +14,5 @@
     "kotlin": "^$kotlin_version"
   },
   "author": "Leonid Khachaturov",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-css/kotlin-css-jvm/package.json
+++ b/kotlin-css/kotlin-css-jvm/package.json
@@ -13,5 +13,5 @@
     "kotlin": "^$kotlin_version"
   },
   "author": "Leonid Khachaturov",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-css/package.json
+++ b/kotlin-css/package.json
@@ -13,5 +13,5 @@
     "kotlin": "^$kotlin_version"
   },
   "author": "Leonid Khachaturov",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-extensions/package.json
+++ b/kotlin-extensions/package.json
@@ -13,5 +13,5 @@
     "kotlin": "^$kotlin_version"
   },
   "author": "Filipp Riabchun",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-mocha/package.json
+++ b/kotlin-mocha/package.json
@@ -14,5 +14,5 @@
     "mocha": "^3.0.0"
   },
   "author": "Filipp Riabchun",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-react-dom/package.json
+++ b/kotlin-react-dom/package.json
@@ -15,5 +15,5 @@
     "react-dom": ">=15.x.x <=16.x.x"
   },
   "author": "Filipp Riabchun",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-react-redux/package.json
+++ b/kotlin-react-redux/package.json
@@ -18,5 +18,5 @@
     "react-redux": "^5.0.7"
   },
   "author": "Aidan Heller",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-react-router-dom/package.json
+++ b/kotlin-react-router-dom/package.json
@@ -15,5 +15,5 @@
     "react-router-dom": "^4.3.1"
   },
   "author": "Andrius Semionovas",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-react/package.json
+++ b/kotlin-react/package.json
@@ -15,5 +15,5 @@
     "react": ">=15.x.x <=16.x.x"
   },
   "author": "Filipp Riabchun",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-redux/package.json
+++ b/kotlin-redux/package.json
@@ -16,5 +16,5 @@
     "redux": "^4.0.0"
   },
   "author": "Aidan Heller",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }

--- a/kotlin-styled/package.json
+++ b/kotlin-styled/package.json
@@ -19,5 +19,5 @@
     "styled-components": "^4.3.2"
   },
   "author": "Leonid Khachaturov",
-  "license": "Apache-2-0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
https://spdx.org/licenses/Apache-2.0.html

Using standard identifiers helps downstream folks correctly identify the license your project (and npm packages) are under.