### PR TITLE
Kotlin DSL. Standard publishing convensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,8 @@
-import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
-
 plugins {
     id "org.jetbrains.kotlin.multiplatform" version "$kotlin_version" apply false
     id "org.jetbrains.kotlin.jvm" version "$kotlin_version" apply false
     id "org.jetbrains.kotlin.js" version "$kotlin_version" apply false
     id "org.jetbrains.kotlin.plugin.serialization" version "$kotlin_version" apply false
-
-    id "com.github.node-gradle.node" version "$node_plugin_version" apply false
-    id "com.jfrog.bintray" version "$bintray_plugin_version" apply false
 }
 
 group 'org.jetbrains'
@@ -52,96 +47,8 @@ subprojects {
         }
     }
 
-    ext.configurePublishing = {
-        apply plugin: 'com.github.node-gradle.node'
-        apply plugin: 'com.jfrog.bintray'
-        apply plugin: 'maven-publish'
-
-        artifacts {
-            if (kotlin instanceof org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension) {
-                archives JsSourcesJar
-            } else if (kotlin instanceof org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension) {
-                archives jvmSourcesJar
-                archives jsSourcesJar
-            } else {
-                archives kotlinSourcesJar
-            }
-        }
-
-        def v = Versions.publishVersion(project)
-        bintray {
-            user = System.getenv('BINTRAY_USER')
-            key = System.getenv('BINTRAY_KEY')
-            publish = true
-            pkg {
-                repo = 'kotlin-js-wrappers'
-                name = projectName
-                userOrg = 'kotlin'
-                licenses = ['Apache-2.0']
-                vcsUrl = 'https://github.com/JetBrains/kotlin-wrappers.git'
-                version {
-                    name = v
-                }
-            }
-            if (kotlin instanceof org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension) {
-                publications = ['kotlinMultiplatform', 'metadata', 'js', 'jvm']
-            } else if (!projectName.contains("kotlin-css")) {
-                publications = ['Publication']
-            }
-        }
-
-        // to publish gradle metadata
-        tasks.getByName("bintrayUpload") {
-            doFirst {
-                publishing.publications
-                        .withType(MavenPublication.class)
-                        .forEach { publication ->
-                            def moduleFile = buildDir.toPath().resolve("publications/${publication.name}/module.json").toFile()
-                            if (moduleFile.exists()) {
-                                publication.artifact(new FileBasedMavenArtifact(moduleFile) {
-                                    String getDefaultExtension() {
-                                        return "module"
-                                    }
-                                })
-                            }
-                        }
-            }
-        }
-
-        publishing {
-            publications {
-                if (kotlin instanceof org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension) {
-                    all {
-                        def artifactName
-                        if (name == "kotlinMultiplatform") {
-                            artifactName = ""
-                        } else {
-                            artifactName = "-$name"
-                        }
-                        groupId 'org.jetbrains'
-                        artifactId "$projectName$artifactName"
-                        version v
-                    }
-                } else {
-                    Publication(MavenPublication) {
-                        from components.kotlin
-                        groupId 'org.jetbrains'
-                        artifactId projectName
-                        version v
-
-                        if (kotlin instanceof org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension) {
-                            artifact JsSourcesJar
-                        } else {
-                            artifact kotlinSourcesJar
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     ext.configurePublishingWithNPM = {
-        configurePublishing()
+        apply plugin: "publishing-conventions"
 
         task processPkg(type: Copy) {
             from '.'

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,16 @@
 plugins {
-    kotlin("jvm") version "1.3.71"
+    `kotlin-dsl`
 }
 
 repositories {
-    jcenter()
+    gradlePluginPortal()
+}
+
+kotlinDslPluginOptions {
+    experimentalWarning.set(false)
+}
+
+dependencies {
+    implementation("com.github.node-gradle:gradle-node-plugin:${property("node_plugin_version")}")
+    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:${property("bintray_plugin_version")}")
 }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,4 @@
+# https://github.com/node-gradle/gradle-node-plugin/releases
+node_plugin_version=2.2.3
+# https://github.com/bintray/gradle-bintray-plugin/releases
+bintray_plugin_version=1.8.5

--- a/buildSrc/src/main/kotlin/ArchivesConfigurationAccessors.kt
+++ b/buildSrc/src/main/kotlin/ArchivesConfigurationAccessors.kt
@@ -1,0 +1,7 @@
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.artifacts.dsl.ArtifactHandler
+
+// TODO: check why standard Kotlin DSL extension unresolved
+//  method copied from `kotlin-dsl`
+internal fun ArtifactHandler.archives(artifactNotation: Any): PublishArtifact =
+    add("archives", artifactNotation)

--- a/buildSrc/src/main/kotlin/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/Kotlin.kt
@@ -1,0 +1,7 @@
+import org.gradle.api.Project
+
+internal val Project.isKotlinJsProject:Boolean
+    get() = plugins.hasPlugin("org.jetbrains.kotlin.js")
+
+internal val Project.isKotlinMultiplatformProject:Boolean
+    get() = plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 private fun Project.version(target: String): String =
     property("${target}_version") as String
 
-fun Project.publishVersion(): String {
+internal fun Project.publishVersion(): String {
     val target = name
         .removePrefix("kotlin-")
         .let {

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -1,0 +1,94 @@
+import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
+import org.gradle.kotlin.dsl.*
+
+plugins {
+    id("com.github.node-gradle.node")
+    id("com.jfrog.bintray")
+    `maven-publish`
+}
+
+artifacts {
+    when {
+        isKotlinJsProject ->
+            archives(tasks.named("JsSourcesJar"))
+
+        isKotlinMultiplatformProject -> {
+            archives(tasks.named("jvmSourcesJar"))
+            archives(tasks.named("jsSourcesJar"))
+        }
+
+        else ->
+            archives(tasks.named("kotlinSourcesJar"))
+    }
+}
+
+val publishVersion = publishVersion()
+
+bintray {
+    user = System.getenv("BINTRAY_USER")
+    key = System.getenv("BINTRAY_KEY")
+    publish = true
+    with(pkg) {
+        repo = "kotlin-js-wrappers"
+        name = project.name
+        userOrg = "kotlin"
+        setLicenses("Apache-2.0")
+        vcsUrl = "https://github.com/JetBrains/kotlin-wrappers.git"
+        with(version) {
+            name = publishVersion
+        }
+    }
+    if (isKotlinMultiplatformProject) {
+        setPublications("kotlinMultiplatform", "metadata", "js", "jvm")
+    } else if (!project.name.contains("kotlin-css")) {
+        setPublications("Publication")
+    }
+}
+
+// to publish gradle metadata
+tasks.named("bintrayUpload") {
+    doFirst {
+        publishing.publications
+            .withType<MavenPublication>()
+            .forEach { publication ->
+                val moduleFile = buildDir.resolve("publications/${publication.name}/module.json")
+                if (moduleFile.exists()) {
+                    publication.artifact(MetadataModuleArtifact(moduleFile))
+                }
+            }
+    }
+}
+
+publishing {
+    publications {
+        if (isKotlinMultiplatformProject) {
+            withType<MavenPublication>().all {
+                val artifactName = when (name) {
+                    "kotlinMultiplatform" -> ""
+                    else -> "-$name"
+                }
+
+                groupId = "org.jetbrains"
+                artifactId = "${project.name}$artifactName"
+                version = publishVersion
+            }
+        } else {
+            create<MavenPublication>("Publication") {
+                from(components["kotlin"])
+                groupId = "org.jetbrains"
+                artifactId = project.name
+                version = publishVersion
+
+                if (isKotlinJsProject) {
+                    artifact(tasks.getByName<Zip>("JsSourcesJar"))
+                } else {
+                    artifact(tasks.getByName<Zip>("kotlinSourcesJar"))
+                }
+            }
+        }
+    }
+}
+
+class MetadataModuleArtifact(moduleFile: File) : FileBasedMavenArtifact(moduleFile) {
+    override fun getDefaultExtension() = "module"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,6 @@ kotlinx_html_version=0.7.1-build-1707
 kotlinx_coroutines_version=1.3.5-1.4-M1
 # https://github.com/Kotlin/kotlinx.serialization/releases
 kotlinx_serialization_version=0.20.0-1.4-M1
-# https://github.com/node-gradle/gradle-node-plugin/releases
-node_plugin_version=2.2.3
-# https://github.com/bintray/gradle-bintray-plugin/releases
-bintray_plugin_version=1.8.4
 
 # kotlin-css
 css_version=1.0.0-pre.93

--- a/kotlin-css/build.gradle
+++ b/kotlin-css/build.gradle
@@ -47,7 +47,7 @@ kotlin {
     }
 }
 
-configurePublishing()
+apply plugin: 'publishing-conventions'
 
 project("kotlin-css-js") {
     apply plugin: 'org.jetbrains.kotlin.js'


### PR DESCRIPTION
Part of #161

* Update bintray plugin. `1.8.4` -> `1.8.5`

Additional info:
* [Bintray plugin Kotlin DSL support](https://github.com/bintray/gradle-bintray-plugin/issues/258) 