### PR TITLE
Add hooks API for react-router-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ demonstrates how to add typings for an external library.
 
 5. An [example of using Quill](examples/src/main/kotlin/example/Quill.kt) that shows how to use an external React component.
 
-6. [Building Web Applications with React and Kotlin/JS](https://play.kotlinlang.org/hands-on/Building%20Web%20Applications%20with%20React%20and%20Kotlin%20JS/01_Introduction), a tutorial by JetBrains.
+6. An [example of using react-router-dom](examples/src/main/kotlin/example/ReactRouterDom.kt) that shows how to use react-route-dom with hooks API.
+
+7. [Building Web Applications with React and Kotlin/JS](https://play.kotlinlang.org/hands-on/Building%20Web%20Applications%20with%20React%20and%20Kotlin%20JS/01_Introduction), a tutorial by JetBrains.
  
-7. [A full-stack demo application](https://github.com/mkraynov/kfsad) written in Kotlin for JetBrains Night Moscow 2019.
+8. [A full-stack demo application](https://github.com/mkraynov/kfsad) written in Kotlin for JetBrains Night Moscow 2019.
 
 Follow these examples to learn how to start developing your React apps with Kotlin. Good luck and have fun! 
 You also can clone [my-kotlin-react-sample](https://github.com/ScottHuangZL/my-kotlin-app) to see the result directly.

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,5 +2,6 @@ applyKotlinJS()
 
 dependencies {
     compile project(':kotlin-react-dom')
+    compile project(':kotlin-react-router-dom')
 }
 

--- a/examples/src/main/kotlin/example/ReactRouterDom.kt
+++ b/examples/src/main/kotlin/example/ReactRouterDom.kt
@@ -1,0 +1,69 @@
+package example
+
+import react.RBuilder
+import react.RProps
+import react.child
+import react.dom.*
+import react.functionalComponent
+import react.router.dom.*
+
+val Home = functionalComponent<RProps> { h2 { +"Home" } }
+val About = functionalComponent<RProps> { h2 { +"About" } }
+
+val Topics = functionalComponent<RProps> {
+    val match = useRouteMatch<RProps>() ?: return@functionalComponent
+
+    div {
+        h2 { +"Topics" }
+
+        ul {
+            li {
+                routeLink("${match.url}/components") { +"Components" }
+            }
+            li {
+                routeLink("${match.url}/props-v-state") { +"Props v. State" }
+            }
+        }
+
+        switch {
+            route("${match.path}/:topicId") { child(Topic) }
+            route(match.path) {
+                h3 { +"Please select a topic." }
+            }
+        }
+    }
+}
+
+external interface TopicProps : RProps {
+    val topicId: String
+}
+
+val Topic = functionalComponent<RProps> {
+    val topicId = useParams<TopicProps>()?.topicId ?: return@functionalComponent
+
+    h3 { +"Requested topic ID: $topicId" }
+}
+
+fun RBuilder.appWithRouter() {
+    browserRouter {
+        div {
+            ul {
+                li {
+                    routeLink("/") { +"Home" }
+                }
+                li {
+                    routeLink("/about") { +"About" }
+                }
+                li {
+                    routeLink("/topics") { +"Topics" }
+                }
+            }
+
+            switch {
+                route("/about") { child(About) }
+                route("/topics") { child(Topics) }
+                route("/") { child(Home) }
+            }
+        }
+    }
+}

--- a/kotlin-react-router-dom/package.json
+++ b/kotlin-react-router-dom/package.json
@@ -12,7 +12,7 @@
   "peerDependencies": {
     "@jetbrains/kotlin-react": "^$react_version",
     "kotlin": "^$kotlin_version",
-    "react-router-dom": "^4.3.1"
+    "react-router-dom": "^5.1.2"
   },
   "author": "Andrius Semionovas",
   "license": "Apache-2.0"

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -23,7 +23,7 @@ fun <T: RProps> useRouteMatch(
         this.sensitive = sensitive
     }
 
-    return rawRouteMatch(options)
+    return rawUseRouteMatch(options)
 }
 
 external interface RouteMatchOptions {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -1,0 +1,34 @@
+package react.router.dom
+
+import kotlinext.js.Object
+import kotlinext.js.jsObject
+import react.RProps
+
+fun <T: RProps> useParams(): T? {
+    val rawParams = rawUseParams()
+
+    return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
+}
+
+fun <T: RProps> useRouteMatch(
+        exact: Boolean = false,
+        strict: Boolean = false,
+        sensitive: Boolean = false,
+        vararg path: String
+): RouteResultMatch<T>? {
+    val options: RouteMatchOptions = jsObject {
+        this.path = path
+        this.exact = exact
+        this.strict = strict
+        this.sensitive = sensitive
+    }
+
+    return rawRouteMatch(options)
+}
+
+external interface RouteMatchOptions {
+    var path: Array<out String>
+    var exact: Boolean
+    var strict: Boolean
+    var sensitive: Boolean
+}

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -14,5 +14,5 @@ external fun useLocation(): RouteResultLocation
 external fun rawUseParams(): dynamic
 
 @JsName("useRouteMatch")
-external fun <T: RProps> rawRouteMatch(options: dynamic): RouteResultMatch<T>
+external fun <T: RProps> rawUseRouteMatch(options: dynamic): RouteResultMatch<T>
 

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -1,0 +1,18 @@
+@file:JsModule("react-router-dom")
+
+package react.router.dom
+
+import react.RProps
+
+@JsName("useHistory")
+external fun useHistory(): RouteResultHistory
+
+@JsName("useLocation")
+external fun useLocation(): RouteResultLocation
+
+@JsName("useParams")
+external fun rawUseParams(): dynamic
+
+@JsName("useRouteMatch")
+external fun <T: RProps> rawRouteMatch(options: dynamic): RouteResultMatch<T>
+


### PR DESCRIPTION
fix #146 

Add hooks API for react-router-dom and some wrapper methods

- [`useHistory`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md#usehistory)
- [`useLocation`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md#uselocation)
- [`useParams`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md#useParams)
- [`useRouteMatch`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md#useRouteMatch)

And add sample code of react-router-dom.
- https://github.com/subroh0508/kotlin-wrappers/blob/react-router-dom-hooks-api/examples/src/main/kotlin/example/ReactRouterDom.kt

【Official Document】https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md