### PR TITLE
Add withRouter

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -1,0 +1,7 @@
+package react.router.dom
+
+import react.*
+import kotlin.reflect.KClass
+
+fun <P : RProps, S, T : Component<P, S>> withRouter(klazz: KClass<T>) = rawWithRouter<P>(klazz.js.unsafeCast<RClass<P>>())
+fun <P : RProps> withRouter(functionalComponent: FunctionalComponent<P>) = rawWithRouter<P>(functionalComponent)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -2,6 +2,7 @@
 
 package react.router.dom
 
+import react.RClass
 import react.RProps
 
 @JsName("useHistory")
@@ -16,3 +17,5 @@ external fun rawUseParams(): dynamic
 @JsName("useRouteMatch")
 external fun <T: RProps> rawUseRouteMatch(options: dynamic): RouteResultMatch<T>
 
+@JsName("withRouter")
+external fun <T: RProps> rawWithRouter(component: dynamic): RClass<T>


### PR DESCRIPTION
fix #128 

Add wrapper method of withRouter.

```
class TestComponent : RComponent<RProps, RState>() { ... }

val Component: RClass<RProps> = withRouter(TestComponent::class)
```

or

```
val TestComponent = functionalComponent<RProps> { ... }

val Component: RClass<RProps> = withRouter(TestComponent)
```

【Official Document】https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/withRouter.md

ref. #172 