### PR TITLE
redirect-router-dom: Make redirect.from optional

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -89,7 +89,7 @@ external interface RouteResultMatch<T : RProps> {
 }
 
 external interface RedirectProps : RProps {
-    var from: String
+    var from: String?
     var to: String
     var push: Boolean
     var exact: Boolean

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -94,7 +94,7 @@ fun RBuilder.navLink(
 }
 
 fun RBuilder.redirect(
-    from: String,
+    from: String? = null,
     to: String,
     push: Boolean = false,
     exact: Boolean = false,


### PR DESCRIPTION
react-router-dom RedirectComponent can also be used to render an
unconditional redirect. Make the from restriction optional.