### PR TITLE
Merge duplicate Component.rClass properties

### DIFF
--- a/kotlin-react/src/main/kotlin/react/React.kt
+++ b/kotlin-react/src/main/kotlin/react/React.kt
@@ -38,7 +38,7 @@ inline fun <P : RProps> cloneElement(
 fun clone(element: dynamic, props: dynamic, child: Any? = null): ReactElement =
     cloneElement(element, props, *Children.toArray(child))
 
-val <P : RProps, T : RComponent<P, *>> KClass<T>.rClass
+val <P : RProps, T : Component<P, *>> KClass<T>.rClass
     get() =
         js.unsafeCast<RClass<P>>()
 

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -39,9 +39,6 @@ val RErrorInfo.componentStack: Any get() = asDynamic().componentStack
 // TODO: Should extend RComponentClassStatics, but has problems with generic params
 external interface RClass<in P : RProps> : RComponentClassStatics<RProps, RState, RContext<Any>?>
 
-internal inline val <P : RProps, C : Component<P, *>> KClass<C>.rClass: RClass<P>
-    get() = js.unsafeCast<RClass<P>>()
-
 external interface RComponentClassStatics<P : RProps, S : RState, C : RContext<Any>?> {
     var displayName: String?
 


### PR DESCRIPTION
There has been a KComponent.rClass property getter in React.kt for a while.
Recently a Component.rClass has been added (that thus also works for PureComponent), however it is not publicly available.
I don't see a reason why these should not be merged.

This change widenes the receiver parameters of the public rClass property, and removes the internal one.