### PR TITLE
Fix rawUseRouteMatch when path is empty

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -11,11 +11,15 @@ fun <T : RProps> useParams(): T? {
 }
 
 fun <T : RProps> useRouteMatch(
+    vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
-    sensitive: Boolean = false,
-    vararg path: String
+    sensitive: Boolean = false
 ): RouteResultMatch<T>? {
+    if (path.isEmpty()) {
+        return rawUseRouteMatch(null)
+    }
+
     val options: RouteMatchOptions = jsObject {
         this.path = path
         this.exact = exact


### PR DESCRIPTION
Fix #216 

The bug was caused by executing a function with an option value when the argument `path` was empty🥺

The following is a Javascript implementation of useRouteMatch.
https://github.com/ReactTraining/react-router/blob/c0b8ce42d3c6b85e3a53d1c56ae12c88205d00d8/packages/react-router/modules/hooks.js#L43-L55