### PR TITLE
Add support method for Function as Child Component Pattern

### DIFF
--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -70,6 +70,11 @@ open class RBuilder {
     fun RProps.children() {
         childList.addAll(Children.toArray(children))
     }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> RProps.children(value: T) {
+        childList.add((children as (T) -> Any).invoke(value))
+    }
 }
 
 open class RBuilderMultiple : RBuilder()

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -57,6 +57,17 @@ open class RBuilder {
     inline fun <P : RProps, reified C : Component<P, *>> child(noinline handler: RHandler<P>) =
         child(C::class, handler)
 
+    fun <T, P : RProps, C : Component<P, *>> childFunction(
+            klazz: KClass<C>,
+            handler: RHandler<P>,
+            children: RBuilder.(T) -> Unit
+    ) = child(klazz.rClass, RElementBuilder(jsObject<P>()).apply(handler).attrs, listOf { value: T -> buildElement { children(value) } })
+
+    inline fun <T, P : RProps, reified C : Component<P, *>> childFunction(
+            noinline handler: RHandler<P>,
+            noinline children: RBuilder.(T) -> Unit
+    ) = childFunction(C::class, handler, children)
+
     fun <P : RProps, C : Component<P, *>> node(
         klazz: KClass<C>,
         props: P,

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -153,3 +153,20 @@ fun <P : RProps> RBuilder.child(
 ): ReactElement {
     return child(functionalComponent, props, handler)
 }
+
+fun <T, P: RProps> RBuilder.childFunction(
+    functionalComponent: FunctionalComponent<P>,
+    handler: RHandler<P> = {},
+    children: RBuilder.(T) -> Unit
+): ReactElement {
+    return childFunction(functionalComponent, jsObject<P>(), handler, children)
+}
+
+fun <T, P: RProps> RBuilder.childFunction(
+    functionalComponent: FunctionalComponent<P>,
+    props: P,
+    handler: RHandler<P> = {},
+    children: RBuilder.(T) -> Unit
+): ReactElement {
+    return child(functionalComponent, RElementBuilder(props).apply(handler).attrs, listOf { value: T -> buildElement { children(value) } })
+}

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -108,6 +108,10 @@ abstract class RComponent<P : RProps, S : RState> : Component<P, S> {
         props.children()
     }
 
+    fun <T> RBuilder.children(value: T) {
+        props.children(value)
+    }
+
     abstract fun RBuilder.render()
 
     override fun render() = buildElements { render() }
@@ -129,6 +133,10 @@ abstract class RPureComponent<P : RProps, S : RState> : PureComponent<P, S> {
 
     fun RBuilder.children() {
         props.children()
+    }
+
+    fun <T> RBuilder.children(value: T) {
+        props.children(value)
     }
 
     abstract fun RBuilder.render()


### PR DESCRIPTION
relates #130 

Several functions have been added to support the Function as Child Component Pattern.

For example, by JSX

```jsx
const ParentComponent = (props) => {
  return (
    <div>
      { props.parentText }
      { props.children("Child") }
    </div>
  )
}

const ChildComponent = (props) => {
  return (
    <div>
      { props.childText }
    </div>
  )
}

const App = () => (
  <ParentComponent parentText="Parent">
    { (text) => (<ChildComponent childText={ text }>) }
  </ParentComponent>
)

/* [Result]
 * <div>
 *   Parent
 *   <div>Child</div>
 *  </div>
 */
```

On this Pull Request, for example

```kotlin
external interface ParentProps : RProps {
    var parentText: String
}

external interface ChildProps : RProps {
    var childText: String
}

// Functional Component
val FunctionalParentComponent = functionalComponent<ParentProps> { props ->
    div {
        +props.parentText
        props.children("Child")
    }
}

val FunctionalChildComponent = functionalComponent<ChildProps> { props ->
    div {
        +props.childText
    }
}

fun RBuilder.app() = childFunction(FunctionalParentComponent, {
    attrs.parentText = "Parent"
}, { text: String ->
    child(FunctionalChildComponent) { attrs.childText = text }
})

// Class Component
class ParentComponent : RComponent<ParentProps, RState>() {
    override fun RBuilder.render() {
        div {
            +props.parentText
            props.children("Child")
        }
    }
}

class ChildComponent : RComponent<ChildProps, RState>() {
    override fun RBuilder.render() {
        div {
            +props.childText
        }
    }
}


fun RBuilder.app() = childFunction(ParentComponent::class, {
    attrs.parentText = "Parent"
}, { text: String ->
    child(ChildComponent::class) { attrs.childText = text }
})
```