### PR TITLE
Add extensions to use useState as delegate

### DIFF
--- a/kotlin-react/src/main/kotlin/react/hooks.kt
+++ b/kotlin-react/src/main/kotlin/react/hooks.kt
@@ -45,11 +45,11 @@ private class ReactStateDelegate<T>(useState: Pair<T, RSetState<T>>) : ReadWrite
 
 @Deprecated("Use useState delegate", ReplaceWith("useState(initValue)"))
 fun <T> state(initValue: T): ReadWriteProperty<Any?, T> =
-    ReactStateDelegate(useState(initValue))
+        ReactStateDelegate(useState(initValue))
 
 @Deprecated("Use useState delegate", ReplaceWith("useState(valueInitializer)"))
 fun <T> state(valueInitializer: () -> T): ReadWriteProperty<Any?, T> =
-    ReactStateDelegate(useState(valueInitializer))
+        ReactStateDelegate(useState(valueInitializer))
 
 typealias RReducer<S, A> = (state: S, action: A) -> S
 typealias RDispatch<A> = (action: A) -> Unit

--- a/kotlin-react/src/main/kotlin/react/hooks.kt
+++ b/kotlin-react/src/main/kotlin/react/hooks.kt
@@ -22,22 +22,32 @@ fun <T> useState(valueInitializer: () -> T): Pair<T, RSetState<T>> {
     return currentValue to setState
 }
 
+operator fun <T> Pair<T, RSetState<T>>.getValue(thisRef: Any?, property: KProperty<*>): T {
+    return first
+}
+
+operator fun <T> Pair<T, RSetState<T>>.setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+    second(value)
+}
+
 private class ReactStateDelegate<T>(useState: Pair<T, RSetState<T>>) : ReadWriteProperty<Any?, T> {
     private val state = useState.first
 
     private val setState = useState.second
 
     override operator fun getValue(thisRef: Any?, property: KProperty<*>): T =
-        state
+            state
 
     override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
         setState(value)
     }
 }
 
+@Deprecated("Use useState delegate", ReplaceWith("useState(initValue)"))
 fun <T> state(initValue: T): ReadWriteProperty<Any?, T> =
     ReactStateDelegate(useState(initValue))
 
+@Deprecated("Use useState delegate", ReplaceWith("useState(valueInitializer)"))
 fun <T> state(valueInitializer: () -> T): ReadWriteProperty<Any?, T> =
     ReactStateDelegate(useState(valueInitializer))
 


### PR DESCRIPTION
Additionally, deprecate state delegate
It leads to consistent usage of react hooks and it respect hooks naming with `use*`