### PR TITLE
Fix 'kotlinx-html' dependency usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ subprojects {
 
         dependencies {
             "implementation"(kotlin("stdlib-js"))
-            "implementation"(kotlinxHtml("js"))
         }
 
         tasks.withType<KotlinJsCompile>().configureEach {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     implementation(project(":kotlin-react-dom"))
     implementation(project(":kotlin-react-router-dom"))
 
+    implementation(kotlinxHtml("js"))
+
     implementation(npm("react-quill", "1.3.5"))
     implementation(npm("axios", "0.19.2"))
 }

--- a/kotlin-react-dom/build.gradle.kts
+++ b/kotlin-react-dom/build.gradle.kts
@@ -7,5 +7,7 @@ dependencies {
     implementation(project(":kotlin-extensions"))
     implementation(project(":kotlin-react"))
 
+    implementation(kotlinxHtml("js"))
+
     implementation(npm("react-dom", npmVersion("react-dom")))
 }

--- a/kotlin-styled/build.gradle.kts
+++ b/kotlin-styled/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":kotlin-react"))
     implementation(project(":kotlin-react-dom"))
 
+    implementation(kotlinxHtml("js"))
+
     implementation(npm("css-in-js-utils", "^3.0.4"))
     implementation(npm("inline-style-prefixer", "^5.1.2"))
     implementation(npm("styled-components", "^5.0.1"))


### PR DESCRIPTION
Before:
* Dependency for all (9) subprojects

After:
* Dependency for `kotlin-react-dom` & `kotlin-styled`