### PR TITLE
fix css fontFace - issue #292

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
@@ -43,9 +43,9 @@ interface RuleContainer {
     val rules: MutableList<Rule>
     val multiRules: MutableList<Rule>
 
-    fun rule(selector: String, block: RuleSet) = rule(selector, false, block)
+    fun rule(selector: String, block: RuleSet) = rule(selector, false, block = block)
 
-    fun rule(selector: String, passStaticClassesToParent: Boolean, block: RuleSet, repeatable: Boolean = false) =
+    fun rule(selector: String, passStaticClassesToParent: Boolean, repeatable: Boolean = false, block: RuleSet) =
         Rule(selector, passStaticClassesToParent, block).apply {
             (if (repeatable) multiRules else rules).add(this)
         }
@@ -72,7 +72,7 @@ class CSSBuilder(
     override val multiRules = mutableListOf<Rule>()
 
     operator fun String.invoke(block: RuleSet) =
-        rule(this, false, block)
+        rule(this, false, block = block)
 
     operator fun TagSelector.invoke(block: RuleSet) = tagName(block)
 
@@ -177,7 +177,7 @@ class CSSBuilder(
 
     fun supports(query: String, block: RuleSet) = "@supports $query"(block)
 
-    fun fontFace(block: RuleSet) = rule("@font-face", false, block, true)
+    fun fontFace(block: RuleSet) = rule("@font-face", false, true, block)
 
     fun retina(block: RuleSet) {
         media("(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)") {

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
@@ -26,15 +26,28 @@ interface RuleContainer {
             append(it.value)
             append("}\n")
         }
+
+        multiRules.forEach { (selector, passStaticClassesToParent, block) ->
+            val blockBuilder = CSSBuilder(
+                    "$indent  ",
+                    allowClasses = false,
+                    parent = if (passStaticClassesToParent) this@RuleContainer else null
+            ).block()
+
+            append("$selector {\n")
+            append(blockBuilder)
+            append("}\n")
+        }
     }
 
     val rules: MutableList<Rule>
+    val multiRules: MutableList<Rule>
 
     fun rule(selector: String, block: RuleSet) = rule(selector, false, block)
 
-    fun rule(selector: String, passStaticClassesToParent: Boolean, block: RuleSet) =
+    fun rule(selector: String, passStaticClassesToParent: Boolean, block: RuleSet, repeatable: Boolean = false) =
         Rule(selector, passStaticClassesToParent, block).apply {
-            rules.add(this)
+            (if (repeatable) multiRules else rules).add(this)
         }
 }
 
@@ -56,6 +69,7 @@ class CSSBuilder(
     }
 
     override val rules = mutableListOf<Rule>()
+    override val multiRules = mutableListOf<Rule>()
 
     operator fun String.invoke(block: RuleSet) =
         rule(this, false, block)
@@ -163,7 +177,7 @@ class CSSBuilder(
 
     fun supports(query: String, block: RuleSet) = "@supports $query"(block)
 
-    fun fontFace(query: String, block: RuleSet) = "@font-face $query"(block)
+    fun fontFace(block: RuleSet) = rule("@font-face", false, block, true)
 
     fun retina(block: RuleSet) {
         media("(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)") {

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
@@ -32,7 +32,7 @@ interface RuleContainer {
                     "$indent  ",
                     allowClasses = false,
                     parent = if (passStaticClassesToParent) this@RuleContainer else null
-            ).block()
+            ).apply(block)
 
             append("$selector {\n")
             append(blockBuilder)

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
@@ -9,6 +9,7 @@ class KeyframesBuilder(private val indent: String = "") : RuleContainer {
         }
 
     override val rules = mutableListOf<Rule>()
+    override val multiRules = mutableListOf<Rule>()
 
     fun from(block: RuleSet) = rule("from", block)
     fun to(block: RuleSet) = rule("to", block)

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestFontFace.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestFontFace.kt
@@ -1,0 +1,46 @@
+package kotlinx.css
+
+import kotlin.test.*
+
+class TestFontFace {
+    @Test
+    fun testTwoFontface() {
+        val cssBuilder = CSSBuilder()
+
+        ruleSet {
+            fontFace {
+                fontFamily = "'Roboto'"
+                put("src", "url('Roboto.woff2') format('woff2')")
+                fontWeight = FontWeight.normal
+                fontStyle = FontStyle.normal
+            }
+
+            fontFace {
+                fontFamily = "'Roboto'"
+                put("src", "url('Roboto-Bold.woff2') format('woff2')")
+                fontWeight = FontWeight.bold
+                fontStyle = FontStyle.normal
+            }
+        }.invoke(cssBuilder)
+
+        assertEquals(
+            """
+            @font-face {
+            font-family: 'Roboto';
+            src: url('Roboto.woff2') format('woff2');
+            font-weight: normal;
+            font-style: normal;
+            }
+            @font-face {
+            font-family: 'Roboto';
+            src: url('Roboto-Bold.woff2') format('woff2');
+            font-weight: bold;
+            font-style: normal;
+            }
+    
+            """.trimIndent(),
+            cssBuilder.toString(),
+            "Unexpected generated CSS block"
+        )
+    }
+}

--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -117,7 +117,7 @@ object Styled {
         }
 
     fun createElement(type: Any, css: CSSBuilder, props: WithClassName, children: List<Any>): ReactElement {
-        if (css.rules.isNotEmpty() || css.declarations.isNotEmpty()) {
+        if (css.rules.isNotEmpty() || css.multiRules.isNotEmpty() || css.declarations.isNotEmpty()) {
             val wrappedType = wrap(type)
             val styledProps = props.unsafeCast<StyledProps>()
             styledProps.css = css.toString()


### PR DESCRIPTION
I suggest this fix for https://github.com/JetBrains/kotlin-wrappers/issues/292

Next to `rules: MutableList<Rule>` It introduces another List `multiRules: MutableList<Rule>` that is simply rendered after all the regular rules by `StringBuilder.buildRules`.

This solution does not ensure that all rules are rendered in the same order as they were specified.
I think this should in general not be a problem, except in a scenario like this:
1. the user specifies some rule `r1: Rule` as `multiRules` with a selector `s`
1. the user specifies a rule `r2: Rule` with the same selector `s` in `rules` after these
In regular css, `r1` would possibly be overwritten by `r2`, but here `r1` will instead appear later in the printed css code, and overwrite `r2`.
However, this scenario seems like a clear abuse of that system.