### PR TITLE
useState. Avoid additional imports (getValue, setValue)

### DIFF
--- a/kotlin-react/src/main/kotlin/react/hooks.kt
+++ b/kotlin-react/src/main/kotlin/react/hooks.kt
@@ -28,14 +28,14 @@ class RStateDelegate<T>
 internal constructor(
     private val state: T,
     private val setState: RSetState<T>
-) : ReadWriteProperty<Any, T> {
+) : ReadWriteProperty<Any?, T> {
     operator fun component1(): T = state
     operator fun component2(): RSetState<T> = setState
 
-    override operator fun getValue(thisRef: Any, property: KProperty<*>): T =
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T =
         state
 
-    override operator fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+    override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
         setState(value)
     }
 }


### PR DESCRIPTION
```Kotlin
import react.getValue // redundant
import react.setValue // redundant
import react.useState

val (n, setN) = useState("n") // works

var k by useState("k") // works
```