### PR TITLE
Support CDN delivery of kotlin-react-router-dom

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -3,16 +3,8 @@ package react.router.dom
 import react.*
 import kotlin.reflect.KClass
 
-fun <P : RProps> withRouter(
-        module: ReactRouterDom,
-        klazz: KClass<out Component<P, *>>
-): RClass<P> = module.withRouter(klazz.rClass)
+fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): RClass<P> =
+    ReactRouterDomModule.withRouter(klazz.rClass)
 
-fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDomModule, klazz)
-
-fun <P : RProps> withRouter(
-        module: ReactRouterDom,
-        component: FunctionalComponent<P>
-): RClass<P> = module.withRouter(component)
-
-fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDomModule, component)
+fun <P : RProps> withRouter(component: FunctionalComponent<P>): RClass<P> =
+    ReactRouterDomModule.withRouter(component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -8,11 +8,11 @@ fun <P : RProps> withRouter(
         klazz: KClass<out Component<P, *>>
 ): RClass<P> = module.withRouter(klazz.rClass)
 
-fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDom, klazz)
+fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDomModule, klazz)
 
 fun <P : RProps> withRouter(
         module: ReactRouterDom,
         component: FunctionalComponent<P>
 ): RClass<P> = module.withRouter(component)
 
-fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDom, component)
+fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDomModule, component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -6,15 +6,13 @@ import kotlin.reflect.KClass
 fun <P : RProps> withRouter(
         module: ReactRouterDom,
         klazz: KClass<out Component<P, *>>
-): RClass<P> = module.rawWithRouter(klazz.rClass)
+): RClass<P> = module.withRouter(klazz.rClass)
 
-fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): RClass<P> =
-    withRouter(ReactRouterDomModule, klazz)
+fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDomModule, klazz)
 
 fun <P : RProps> withRouter(
         module: ReactRouterDom,
         component: FunctionalComponent<P>
-): RClass<P> = module.rawWithRouter(component)
+): RClass<P> = module.withRouter(component)
 
-fun <P : RProps> withRouter(component: FunctionalComponent<P>): RClass<P> =
-    withRouter(ReactRouterDomModule, component)
+fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDomModule, component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -3,8 +3,18 @@ package react.router.dom
 import react.*
 import kotlin.reflect.KClass
 
+fun <P : RProps> withRouter(
+        module: ReactRouterDom,
+        klazz: KClass<out Component<P, *>>
+): RClass<P> = module.rawWithRouter(klazz.rClass)
+
 fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): RClass<P> =
-    ReactRouterDomModule.rawWithRouter(klazz.rClass)
+    withRouter(ReactRouterDomModule, klazz)
+
+fun <P : RProps> withRouter(
+        module: ReactRouterDom,
+        component: FunctionalComponent<P>
+): RClass<P> = module.rawWithRouter(component)
 
 fun <P : RProps> withRouter(component: FunctionalComponent<P>): RClass<P> =
-    ReactRouterDomModule.rawWithRouter(component)
+    withRouter(ReactRouterDomModule, component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -4,7 +4,7 @@ import react.*
 import kotlin.reflect.KClass
 
 fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): RClass<P> =
-    rawWithRouter(klazz.rClass)
+    ReactRouterDomModule.rawWithRouter(klazz.rClass)
 
 fun <P : RProps> withRouter(component: FunctionalComponent<P>): RClass<P> =
-    rawWithRouter(component)
+    ReactRouterDomModule.rawWithRouter(component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -8,11 +8,11 @@ fun <P : RProps> withRouter(
         klazz: KClass<out Component<P, *>>
 ): RClass<P> = module.withRouter(klazz.rClass)
 
-fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDomModule, klazz)
+fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>) = withRouter(ReactRouterDom, klazz)
 
 fun <P : RProps> withRouter(
         module: ReactRouterDom,
         component: FunctionalComponent<P>
 ): RClass<P> = module.withRouter(component)
 
-fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDomModule, component)
+fun <P : RProps> withRouter(component: FunctionalComponent<P>) = withRouter(ReactRouterDom, component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -8,23 +8,20 @@ fun useHistory() = ReactRouterDomModule.useHistory()
 
 fun useLocation() = ReactRouterDomModule.useLocation()
 
-fun <T : RProps> useParams(module: ReactRouterDom): T? {
-    val rawParams = module.useParams()
+fun <T : RProps> useParams(): T? {
+    val rawParams = ReactRouterDomModule.useParams()
 
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
 
-fun <T : RProps> useParams() = useParams<T>(ReactRouterDomModule)
-
 fun <T : RProps> useRouteMatch(
-    module: ReactRouterDom,
     path: Array<out String>,
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false
 ): RouteResultMatch<T>? {
     if (path.isEmpty()) {
-        return module.useRouteMatch(null)
+        return ReactRouterDomModule.useRouteMatch(null)
     }
 
     val options: RouteMatchOptions = jsObject {
@@ -34,15 +31,8 @@ fun <T : RProps> useRouteMatch(
         this.sensitive = sensitive
     }
 
-    return module.useRouteMatch(options)
+    return ReactRouterDomModule.useRouteMatch(options)
 }
-
-fun <T : RProps> useRouteMatch(
-    vararg path: String,
-    exact: Boolean = false,
-    strict: Boolean = false,
-    sensitive: Boolean = false
-) = useRouteMatch<T>(ReactRouterDomModule, path, exact, strict, sensitive)
 
 external interface RouteMatchOptions {
     var path: Array<out String>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -4,9 +4,9 @@ import kotlinext.js.Object
 import kotlinext.js.jsObject
 import react.RProps
 
-fun useHistory() = ReactRouterDom.useHistory()
+fun useHistory() = ReactRouterDomModule.useHistory()
 
-fun useLocation() = ReactRouterDom.useLocation()
+fun useLocation() = ReactRouterDomModule.useLocation()
 
 fun <T : RProps> useParams(module: ReactRouterDom): T? {
     val rawParams = module.useParams()
@@ -14,7 +14,7 @@ fun <T : RProps> useParams(module: ReactRouterDom): T? {
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
 
-fun <T : RProps> useParams() = useParams<T>(ReactRouterDom)
+fun <T : RProps> useParams() = useParams<T>(ReactRouterDomModule)
 
 fun <T : RProps> useRouteMatch(
     module: ReactRouterDom,
@@ -42,7 +42,7 @@ fun <T : RProps> useRouteMatch(
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false
-) = useRouteMatch<T>(ReactRouterDom, path = path, exact = exact, strict = strict, sensitive  = sensitive)
+) = useRouteMatch<T>(ReactRouterDomModule, path, exact, strict, sensitive)
 
 external interface RouteMatchOptions {
     var path: Array<out String>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -4,8 +4,12 @@ import kotlinext.js.Object
 import kotlinext.js.jsObject
 import react.RProps
 
+fun useHistory() = ReactRouterDomModule.rawUseHistory()
+
+fun useLocation() = ReactRouterDomModule.rawUseLocation()
+
 fun <T : RProps> useParams(): T? {
-    val rawParams = rawUseParams()
+    val rawParams = ReactRouterDomModule.rawUseParams()
 
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
@@ -17,7 +21,7 @@ fun <T : RProps> useRouteMatch(
     sensitive: Boolean = false
 ): RouteResultMatch<T>? {
     if (path.isEmpty()) {
-        return rawUseRouteMatch(null)
+        return ReactRouterDomModule.rawUseRouteMatch(null)
     }
 
     val options: RouteMatchOptions = jsObject {
@@ -27,7 +31,7 @@ fun <T : RProps> useRouteMatch(
         this.sensitive = sensitive
     }
 
-    return rawUseRouteMatch(options)
+    return ReactRouterDomModule.rawUseRouteMatch(options)
 }
 
 external interface RouteMatchOptions {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -4,9 +4,9 @@ import kotlinext.js.Object
 import kotlinext.js.jsObject
 import react.RProps
 
-fun useHistory() = ReactRouterDomModule.useHistory()
+fun useHistory() = ReactRouterDom.useHistory()
 
-fun useLocation() = ReactRouterDomModule.useLocation()
+fun useLocation() = ReactRouterDom.useLocation()
 
 fun <T : RProps> useParams(module: ReactRouterDom): T? {
     val rawParams = module.useParams()
@@ -14,7 +14,7 @@ fun <T : RProps> useParams(module: ReactRouterDom): T? {
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
 
-fun <T : RProps> useParams() = useParams<T>(ReactRouterDomModule)
+fun <T : RProps> useParams() = useParams<T>(ReactRouterDom)
 
 fun <T : RProps> useRouteMatch(
     module: ReactRouterDom,
@@ -42,7 +42,7 @@ fun <T : RProps> useRouteMatch(
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false
-) = useRouteMatch<T>(ReactRouterDomModule, path, exact, strict, sensitive)
+) = useRouteMatch<T>(ReactRouterDom, path = path, exact = exact, strict = strict, sensitive  = sensitive)
 
 external interface RouteMatchOptions {
     var path: Array<out String>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -4,17 +4,17 @@ import kotlinext.js.Object
 import kotlinext.js.jsObject
 import react.RProps
 
-fun useHistory() = ReactRouterDomModule.rawUseHistory()
+fun useHistory() = ReactRouterDomModule.useHistory()
 
-fun useLocation() = ReactRouterDomModule.rawUseLocation()
+fun useLocation() = ReactRouterDomModule.useLocation()
 
 fun <T : RProps> useParams(module: ReactRouterDom): T? {
-    val rawParams = module.rawUseParams()
+    val rawParams = module.useParams()
 
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
 
-fun <T : RProps> useParams(): T? = useParams<T>(ReactRouterDomModule)
+fun <T : RProps> useParams() = useParams<T>(ReactRouterDomModule)
 
 fun <T : RProps> useRouteMatch(
     module: ReactRouterDom,
@@ -24,7 +24,7 @@ fun <T : RProps> useRouteMatch(
     sensitive: Boolean = false
 ): RouteResultMatch<T>? {
     if (path.isEmpty()) {
-        return module.rawUseRouteMatch(null)
+        return module.useRouteMatch(null)
     }
 
     val options: RouteMatchOptions = jsObject {
@@ -34,7 +34,7 @@ fun <T : RProps> useRouteMatch(
         this.sensitive = sensitive
     }
 
-    return module.rawUseRouteMatch(options)
+    return module.useRouteMatch(options)
 }
 
 fun <T : RProps> useRouteMatch(

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -8,20 +8,23 @@ fun useHistory() = ReactRouterDomModule.rawUseHistory()
 
 fun useLocation() = ReactRouterDomModule.rawUseLocation()
 
-fun <T : RProps> useParams(): T? {
-    val rawParams = ReactRouterDomModule.rawUseParams()
+fun <T : RProps> useParams(module: ReactRouterDom): T? {
+    val rawParams = module.rawUseParams()
 
     return if (Object.keys(rawParams as Any).isEmpty()) null else rawParams as T
 }
 
+fun <T : RProps> useParams(): T? = useParams<T>(ReactRouterDomModule)
+
 fun <T : RProps> useRouteMatch(
-    vararg path: String,
+    module: ReactRouterDom,
+    path: Array<out String>,
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false
 ): RouteResultMatch<T>? {
     if (path.isEmpty()) {
-        return ReactRouterDomModule.rawUseRouteMatch(null)
+        return module.rawUseRouteMatch(null)
     }
 
     val options: RouteMatchOptions = jsObject {
@@ -31,8 +34,23 @@ fun <T : RProps> useRouteMatch(
         this.sensitive = sensitive
     }
 
-    return ReactRouterDomModule.rawUseRouteMatch(options)
+    return module.rawUseRouteMatch(options)
 }
+
+fun <T : RProps> useRouteMatch(
+    module: ReactRouterDom,
+    vararg path: String,
+    exact: Boolean = false,
+    strict: Boolean = false,
+    sensitive: Boolean = false
+) = useRouteMatch<T>(module, path, exact, strict, sensitive)
+
+fun <T : RProps> useRouteMatch(
+    vararg path: String,
+    exact: Boolean = false,
+    strict: Boolean = false,
+    sensitive: Boolean = false
+) = useRouteMatch<T>(ReactRouterDomModule, path, exact, strict, sensitive)
 
 external interface RouteMatchOptions {
     var path: Array<out String>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -38,14 +38,6 @@ fun <T : RProps> useRouteMatch(
 }
 
 fun <T : RProps> useRouteMatch(
-    module: ReactRouterDom,
-    vararg path: String,
-    exact: Boolean = false,
-    strict: Boolean = false,
-    sensitive: Boolean = false
-) = useRouteMatch<T>(module, path, exact, strict, sensitive)
-
-fun <T : RProps> useRouteMatch(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -1,19 +1,34 @@
-@file:JsModule("react-router-dom")
-
 package react.router.dom
 
 import react.RClass
 import react.RProps
 
-external fun useHistory(): RouteResultHistory
+external interface ReactRouterDom {
+    @JsName("useHistory")
+    fun rawUseHistory(): RouteResultHistory
+    @JsName("useLocation")
+    fun rawUseLocation(): RouteResultLocation
+    @JsName("useParams")
+    fun rawUseParams(): dynamic
+    @JsName("useRouteMatch")
+    fun <T : RProps> rawUseRouteMatch(options: dynamic): RouteResultMatch<T>
+    @JsName("withRouter")
+    fun <T : RProps> rawWithRouter(component: dynamic): RClass<T>
+    @Suppress("PropertyName")
+    val HashRouter: RClass<RProps>
+    @Suppress("PropertyName")
+    val BrowserRouter: RClass<RProps>
+    @Suppress("PropertyName")
+    val Switch: RClass<RProps>
+    @Suppress("PropertyName")
+    val Route: RClass<dynamic>
+    @Suppress("PropertyName")
+    val Link: RClass<LinkProps>
+    @Suppress("PropertyName")
+    val NavLink: RClass<dynamic>
+    @Suppress("PropertyName")
+    val Redirect : RClass<RedirectProps>
+}
 
-external fun useLocation(): RouteResultLocation
-
-@JsName("useParams")
-external fun rawUseParams(): dynamic
-
-@JsName("useRouteMatch")
-external fun <T : RProps> rawUseRouteMatch(options: dynamic): RouteResultMatch<T>
-
-@JsName("withRouter")
-external fun <T : RProps> rawWithRouter(component: dynamic): RClass<T>
+@JsModule("react-router-dom")
+external val ReactRouterDomModule: ReactRouterDom

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -5,8 +5,7 @@ package react.router.dom
 import react.RClass
 import react.RProps
 
-@JsModule("react-router-dom")
-external object ReactRouterDom {
+external interface ReactRouterDom {
     fun useHistory(): RouteResultHistory
     fun useLocation(): RouteResultLocation
     fun useParams(): dynamic
@@ -20,3 +19,6 @@ external object ReactRouterDom {
     val NavLink: RClass<dynamic>
     val Redirect : RClass<RedirectProps>
 }
+
+@JsModule("react-router-dom")
+external val ReactRouterDomModule: ReactRouterDom

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -1,32 +1,22 @@
+@file:Suppress("PropertyName")
+
 package react.router.dom
 
 import react.RClass
 import react.RProps
 
 external interface ReactRouterDom {
-    @JsName("useHistory")
-    fun rawUseHistory(): RouteResultHistory
-    @JsName("useLocation")
-    fun rawUseLocation(): RouteResultLocation
-    @JsName("useParams")
-    fun rawUseParams(): dynamic
-    @JsName("useRouteMatch")
-    fun <T : RProps> rawUseRouteMatch(options: dynamic): RouteResultMatch<T>
-    @JsName("withRouter")
-    fun <T : RProps> rawWithRouter(component: dynamic): RClass<T>
-    @Suppress("PropertyName")
+    fun useHistory(): RouteResultHistory
+    fun useLocation(): RouteResultLocation
+    fun useParams(): dynamic
+    fun <T : RProps> useRouteMatch(options: dynamic): RouteResultMatch<T>
+    fun <T : RProps> withRouter(component: dynamic): RClass<T>
     val HashRouter: RClass<RProps>
-    @Suppress("PropertyName")
     val BrowserRouter: RClass<RProps>
-    @Suppress("PropertyName")
     val Switch: RClass<RProps>
-    @Suppress("PropertyName")
     val Route: RClass<dynamic>
-    @Suppress("PropertyName")
     val Link: RClass<LinkProps>
-    @Suppress("PropertyName")
     val NavLink: RClass<dynamic>
-    @Suppress("PropertyName")
     val Redirect : RClass<RedirectProps>
 }
 

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -5,7 +5,8 @@ package react.router.dom
 import react.RClass
 import react.RProps
 
-external interface ReactRouterDom {
+@JsModule("react-router-dom")
+external object ReactRouterDom {
     fun useHistory(): RouteResultHistory
     fun useLocation(): RouteResultLocation
     fun useParams(): dynamic
@@ -19,6 +20,3 @@ external interface ReactRouterDom {
     val NavLink: RClass<dynamic>
     val Redirect : RClass<RedirectProps>
 }
-
-@JsModule("react-router-dom")
-external val ReactRouterDomModule: ReactRouterDom

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -1,43 +1,6 @@
-@file:JsModule("react-router-dom")
-
 package react.router.dom
 
 import react.*
-
-@JsName("HashRouter")
-external class HashRouterComponent : Component<RProps, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("BrowserRouter")
-external class BrowserRouterComponent : Component<RProps, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("Switch")
-external class SwitchComponent : Component<RProps, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("Route")
-external class RouteComponent<T : RProps> : Component<RouteProps<T>, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("Link")
-external class LinkComponent : Component<LinkProps, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("NavLink")
-external class NavLinkComponent<T : RProps> : Component<NavLinkProps<T>, RState> {
-    override fun render(): ReactElement?
-}
-
-@JsName("Redirect")
-external class RedirectComponent : Component<RedirectProps, RState> {
-    override fun render(): ReactElement?
-}
 
 external interface RouteProps<T : RProps> : RProps {
     var path: String

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -5,11 +5,11 @@ package react.router.dom
 import react.*
 import kotlin.reflect.*
 
-fun RBuilder.hashRouter(handler: RHandler<RProps>) = ReactRouterDom.HashRouter(handler)
+fun RBuilder.hashRouter(handler: RHandler<RProps>) = ReactRouterDomModule.HashRouter(handler)
 
-fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDom.BrowserRouter(handler)
+fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDomModule.BrowserRouter(handler)
 
-fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDom.Switch(handler)
+fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDomModule.Switch(handler)
 
 fun RBuilder.route(
     routeComponent: RClass<RouteProps<RProps>>,
@@ -67,21 +67,21 @@ fun RBuilder.route(
     component: KClass<out Component<RProps, *>>,
     exact: Boolean = false,
     strict: Boolean = false
-) = route(ReactRouterDom.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
 
 fun <T : RProps> RBuilder.route(
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: (props: RouteResultProps<T>) -> ReactElement?
-) = route(ReactRouterDom.Route as RClass<RouteProps<T>>, path, exact, strict, render)
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<T>>, path, exact, strict, render)
 
 fun RBuilder.route(
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: () -> ReactElement?
-) = route(ReactRouterDom.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
 
 fun RBuilder.routeLink(
     routeLinkComponent: RClass<LinkProps>,
@@ -103,7 +103,7 @@ fun RBuilder.routeLink(
     replace: Boolean = false,
     className: String? = null,
     handler: RHandler<RProps>?
-) = routeLink(ReactRouterDom.Link, to, replace, className, handler)
+) = routeLink(ReactRouterDomModule.Link, to, replace, className, handler)
 
 fun <T : RProps> RBuilder.navLink(
     navLinkComponent: RClass<NavLinkProps<T>>,
@@ -137,7 +137,7 @@ fun <T : RProps> RBuilder.navLink(
     strict: Boolean = false,
     isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
     handler: RHandler<NavLinkProps<T>>?
-) = navLink(ReactRouterDom.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
+) = navLink(ReactRouterDomModule.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
 
 fun RBuilder.redirect(
     redirectComponent: RClass<RedirectProps>,
@@ -162,4 +162,4 @@ fun RBuilder.redirect(
     push: Boolean = false,
     exact: Boolean = false,
     strict: Boolean = false
-) = redirect(ReactRouterDom.Redirect, from, to, push, exact, strict)
+) = redirect(ReactRouterDomModule.Redirect, from, to, push, exact, strict)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -1,21 +1,24 @@
+@file:Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+
 package react.router.dom
 
 import react.*
 import kotlin.reflect.*
 
-fun RBuilder.hashRouter(handler: RHandler<RProps>) = child(HashRouterComponent::class, handler)
+fun RBuilder.hashRouter(handler: RHandler<RProps>) = ReactRouterDomModule.HashRouter(handler)
 
-fun RBuilder.browserRouter(handler: RHandler<RProps>) = child(BrowserRouterComponent::class, handler)
+fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDomModule.BrowserRouter(handler)
 
-fun RBuilder.switch(handler: RHandler<RProps>) = child(SwitchComponent::class, handler)
+fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDomModule.Switch(handler)
 
 fun RBuilder.route(
+    routeComponent: RClass<RouteProps<RProps>>,
     path: String,
     component: KClass<out Component<RProps, *>>,
     exact: Boolean = false,
     strict: Boolean = false
 ): ReactElement {
-    return child<RouteProps<RProps>, RouteComponent<RProps>> {
+    return routeComponent {
         attrs {
             this.path = path
             this.exact = exact
@@ -26,12 +29,13 @@ fun RBuilder.route(
 }
 
 fun <T : RProps> RBuilder.route(
+    routeComponent: RClass<RouteProps<T>>,
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: (props: RouteResultProps<T>) -> ReactElement?
 ): ReactElement {
-    return child<RouteProps<T>, RouteComponent<T>> {
+    return routeComponent {
         attrs {
             this.path = path
             this.exact = exact
@@ -42,12 +46,13 @@ fun <T : RProps> RBuilder.route(
 }
 
 fun RBuilder.route(
+    routeComponent: RClass<RouteProps<RProps>>,
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: () -> ReactElement?
 ): ReactElement {
-    return child<RouteProps<RProps>, RouteComponent<RProps>> {
+    return routeComponent {
         attrs {
             this.path = path
             this.exact = exact
@@ -57,16 +62,68 @@ fun RBuilder.route(
     }
 }
 
+fun RBuilder.route(
+    path: String,
+    component: KClass<out Component<RProps, *>>,
+    exact: Boolean = false,
+    strict: Boolean = false
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
+
+fun <T : RProps> RBuilder.route(
+    path: String,
+    exact: Boolean = false,
+    strict: Boolean = false,
+    render: (props: RouteResultProps<T>) -> ReactElement?
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<T>>, path, exact, strict, render)
+
+fun RBuilder.route(
+    path: String,
+    exact: Boolean = false,
+    strict: Boolean = false,
+    render: () -> ReactElement?
+) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
+
+fun RBuilder.routeLink(
+    routeLinkComponent: RClass<LinkProps>,
+    to: String,
+    replace: Boolean = false,
+    className: String? = null,
+    handler: RHandler<RProps>?
+) = routeLinkComponent {
+    attrs {
+        this.to = to
+        this.replace = replace
+        this.className = className
+    }
+    handler?.invoke(this)
+}
+
 fun RBuilder.routeLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
     handler: RHandler<RProps>?
-) = child(LinkComponent::class) {
+) = routeLink(ReactRouterDomModule.Link, to, replace, className, handler)
+
+fun <T : RProps> RBuilder.navLink(
+    navLinkComponent: RClass<NavLinkProps<T>>,
+    to: String,
+    replace: Boolean = false,
+    className: String? = null,
+    activeClassName: String = "active",
+    exact: Boolean = false,
+    strict: Boolean = false,
+    isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
+    handler: RHandler<NavLinkProps<T>>?
+) = navLinkComponent {
     attrs {
         this.to = to
         this.replace = replace
         this.className = className
+        this.activeClassName = activeClassName
+        this.exact = exact
+        this.strict = strict
+        this.isActive = isActive
     }
     handler?.invoke(this)
 }
@@ -80,26 +137,16 @@ fun <T : RProps> RBuilder.navLink(
     strict: Boolean = false,
     isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
     handler: RHandler<NavLinkProps<T>>?
-) = child<NavLinkProps<T>, NavLinkComponent<T>> {
-    attrs {
-        this.to = to
-        this.replace = replace
-        this.className = className
-        this.activeClassName = activeClassName
-        this.exact = exact
-        this.strict = strict
-        this.isActive = isActive
-    }
-    handler?.invoke(this)
-}
+) = navLink(ReactRouterDomModule.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
 
 fun RBuilder.redirect(
+    redirectComponent: RClass<RedirectProps>,
     from: String? = null,
     to: String,
     push: Boolean = false,
     exact: Boolean = false,
     strict: Boolean = false
-) = child(RedirectComponent::class) {
+) = redirectComponent {
     attrs {
         this.from = from
         this.to = to
@@ -108,3 +155,11 @@ fun RBuilder.redirect(
         this.strict = strict
     }
 }
+
+fun RBuilder.redirect(
+    from: String? = null,
+    to: String,
+    push: Boolean = false,
+    exact: Boolean = false,
+    strict: Boolean = false
+) = redirect(ReactRouterDomModule.Redirect, from, to, push, exact, strict)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -5,11 +5,11 @@ package react.router.dom
 import react.*
 import kotlin.reflect.*
 
-fun RBuilder.hashRouter(handler: RHandler<RProps>) = ReactRouterDomModule.HashRouter(handler)
+fun RBuilder.hashRouter(handler: RHandler<RProps>) = ReactRouterDom.HashRouter(handler)
 
-fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDomModule.BrowserRouter(handler)
+fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDom.BrowserRouter(handler)
 
-fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDomModule.Switch(handler)
+fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDom.Switch(handler)
 
 fun RBuilder.route(
     routeComponent: RClass<RouteProps<RProps>>,
@@ -67,21 +67,21 @@ fun RBuilder.route(
     component: KClass<out Component<RProps, *>>,
     exact: Boolean = false,
     strict: Boolean = false
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
+) = route(ReactRouterDom.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
 
 fun <T : RProps> RBuilder.route(
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: (props: RouteResultProps<T>) -> ReactElement?
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<T>>, path, exact, strict, render)
+) = route(ReactRouterDom.Route as RClass<RouteProps<T>>, path, exact, strict, render)
 
 fun RBuilder.route(
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: () -> ReactElement?
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
+) = route(ReactRouterDom.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
 
 fun RBuilder.routeLink(
     routeLinkComponent: RClass<LinkProps>,
@@ -103,7 +103,7 @@ fun RBuilder.routeLink(
     replace: Boolean = false,
     className: String? = null,
     handler: RHandler<RProps>?
-) = routeLink(ReactRouterDomModule.Link, to, replace, className, handler)
+) = routeLink(ReactRouterDom.Link, to, replace, className, handler)
 
 fun <T : RProps> RBuilder.navLink(
     navLinkComponent: RClass<NavLinkProps<T>>,
@@ -137,7 +137,7 @@ fun <T : RProps> RBuilder.navLink(
     strict: Boolean = false,
     isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
     handler: RHandler<NavLinkProps<T>>?
-) = navLink(ReactRouterDomModule.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
+) = navLink(ReactRouterDom.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
 
 fun RBuilder.redirect(
     redirectComponent: RClass<RedirectProps>,
@@ -162,4 +162,4 @@ fun RBuilder.redirect(
     push: Boolean = false,
     exact: Boolean = false,
     strict: Boolean = false
-) = redirect(ReactRouterDomModule.Redirect, from, to, push, exact, strict)
+) = redirect(ReactRouterDom.Redirect, from, to, push, exact, strict)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -12,13 +12,12 @@ fun RBuilder.browserRouter(handler: RHandler<RProps>) = ReactRouterDomModule.Bro
 fun RBuilder.switch(handler: RHandler<RProps>) = ReactRouterDomModule.Switch(handler)
 
 fun RBuilder.route(
-    routeComponent: RClass<RouteProps<RProps>>,
     path: String,
     component: KClass<out Component<RProps, *>>,
     exact: Boolean = false,
     strict: Boolean = false
 ): ReactElement {
-    return routeComponent {
+    return (ReactRouterDomModule.Route as RClass<RouteProps<RProps>>) {
         attrs {
             this.path = path
             this.exact = exact
@@ -29,13 +28,12 @@ fun RBuilder.route(
 }
 
 fun <T : RProps> RBuilder.route(
-    routeComponent: RClass<RouteProps<T>>,
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: (props: RouteResultProps<T>) -> ReactElement?
 ): ReactElement {
-    return routeComponent {
+    return (ReactRouterDomModule.Route as RClass<RouteProps<T>>) {
         attrs {
             this.path = path
             this.exact = exact
@@ -46,13 +44,12 @@ fun <T : RProps> RBuilder.route(
 }
 
 fun RBuilder.route(
-    routeComponent: RClass<RouteProps<RProps>>,
     path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     render: () -> ReactElement?
 ): ReactElement {
-    return routeComponent {
+    return (ReactRouterDomModule.Route as RClass<RouteProps<RProps>>) {
         attrs {
             this.path = path
             this.exact = exact
@@ -62,34 +59,12 @@ fun RBuilder.route(
     }
 }
 
-fun RBuilder.route(
-    path: String,
-    component: KClass<out Component<RProps, *>>,
-    exact: Boolean = false,
-    strict: Boolean = false
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, component, exact, strict)
-
-fun <T : RProps> RBuilder.route(
-    path: String,
-    exact: Boolean = false,
-    strict: Boolean = false,
-    render: (props: RouteResultProps<T>) -> ReactElement?
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<T>>, path, exact, strict, render)
-
-fun RBuilder.route(
-    path: String,
-    exact: Boolean = false,
-    strict: Boolean = false,
-    render: () -> ReactElement?
-) = route(ReactRouterDomModule.Route as RClass<RouteProps<RProps>>, path, exact, strict, render)
-
 fun RBuilder.routeLink(
-    routeLinkComponent: RClass<LinkProps>,
     to: String,
     replace: Boolean = false,
     className: String? = null,
     handler: RHandler<RProps>?
-) = routeLinkComponent {
+) = ReactRouterDomModule.Link {
     attrs {
         this.to = to
         this.replace = replace
@@ -98,15 +73,7 @@ fun RBuilder.routeLink(
     handler?.invoke(this)
 }
 
-fun RBuilder.routeLink(
-    to: String,
-    replace: Boolean = false,
-    className: String? = null,
-    handler: RHandler<RProps>?
-) = routeLink(ReactRouterDomModule.Link, to, replace, className, handler)
-
 fun <T : RProps> RBuilder.navLink(
-    navLinkComponent: RClass<NavLinkProps<T>>,
     to: String,
     replace: Boolean = false,
     className: String? = null,
@@ -115,7 +82,7 @@ fun <T : RProps> RBuilder.navLink(
     strict: Boolean = false,
     isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
     handler: RHandler<NavLinkProps<T>>?
-) = navLinkComponent {
+) = (ReactRouterDomModule.NavLink as RClass<NavLinkProps<T>>) {
     attrs {
         this.to = to
         this.replace = replace
@@ -128,25 +95,13 @@ fun <T : RProps> RBuilder.navLink(
     handler?.invoke(this)
 }
 
-fun <T : RProps> RBuilder.navLink(
-    to: String,
-    replace: Boolean = false,
-    className: String? = null,
-    activeClassName: String = "active",
-    exact: Boolean = false,
-    strict: Boolean = false,
-    isActive: ((match: RouteResultMatch<T>?, location: RouteResultLocation) -> Boolean)? = null,
-    handler: RHandler<NavLinkProps<T>>?
-) = navLink(ReactRouterDomModule.NavLink as RClass<NavLinkProps<T>>, to, replace, className, activeClassName, exact, strict, isActive, handler)
-
 fun RBuilder.redirect(
-    redirectComponent: RClass<RedirectProps>,
     from: String? = null,
     to: String,
     push: Boolean = false,
     exact: Boolean = false,
     strict: Boolean = false
-) = redirectComponent {
+) = ReactRouterDomModule.Redirect {
     attrs {
         this.from = from
         this.to = to
@@ -155,11 +110,3 @@ fun RBuilder.redirect(
         this.strict = strict
     }
 }
-
-fun RBuilder.redirect(
-    from: String? = null,
-    to: String,
-    push: Boolean = false,
-    exact: Boolean = false,
-    strict: Boolean = false
-) = redirect(ReactRouterDomModule.Redirect, from, to, push, exact, strict)


### PR DESCRIPTION
fix #306 

【example repository】
additonal methods/classes: https://github.com/subroh0508/colormaster/blob/externalize-react-router-dom/web/app/src/main/kotlin/utilities/imports_react_router_dom.kt

usage: https://github.com/subroh0508/colormaster/blob/85de3b97e1bad1ad01b12a1e7d1d3a9d0dc2c356/web/app/src/main/kotlin/containers/AppFrameContainer.kt#L27