### PR TITLE
Support setter of BrowserRouter / HashRouter attributes

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/alias.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/alias.kt
@@ -1,0 +1,3 @@
+package react.router.dom
+
+typealias GetUserConfirmation = (message: String, callback: (Boolean) -> Unit) -> Unit

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -5,12 +5,12 @@ package react.router.dom
 import react.*
 
 @JsName("HashRouter")
-external class HashRouterComponent : Component<RProps, RState> {
+external class HashRouterComponent : Component<HashRouterProps, RState> {
     override fun render(): ReactElement?
 }
 
 @JsName("BrowserRouter")
-external class BrowserRouterComponent : Component<RProps, RState> {
+external class BrowserRouterComponent : Component<BrowserRouterProps, RState> {
     override fun render(): ReactElement?
 }
 
@@ -37,6 +37,24 @@ external class NavLinkComponent<T : RProps> : Component<NavLinkProps<T>, RState>
 @JsName("Redirect")
 external class RedirectComponent : Component<RedirectProps, RState> {
     override fun render(): ReactElement?
+}
+
+external interface BrowserRouterProps : RProps {
+    var basename: String
+    var forceRefresh: Boolean
+    var getUserConfirmation: GetUserConfirmation?
+    var keyLength: Int
+}
+
+@Suppress("EnumEntryName")
+external enum class HashType {
+    slash, noslash, hashbang
+}
+
+external interface HashRouterProps : RProps {
+    var basename: String
+    var getUserConfirmation: GetUserConfirmation?
+    var hashType: String
 }
 
 external interface RouteProps<T : RProps> : RProps {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -3,9 +3,37 @@ package react.router.dom
 import react.*
 import kotlin.reflect.*
 
-fun RBuilder.hashRouter(handler: RHandler<RProps>) = child(HashRouterComponent::class, handler)
+fun RBuilder.hashRouter(
+    basename: String = "",
+    hashType: HashType = HashType.slash,
+    getUserConfirmation: GetUserConfirmation? = null,
+    handler: RHandler<RProps>
+) = child(HashRouterComponent::class) {
+    attrs {
+        this.basename = basename
+        this.hashType = hashType.name
+        this.getUserConfirmation = getUserConfirmation
+    }
 
-fun RBuilder.browserRouter(handler: RHandler<RProps>) = child(BrowserRouterComponent::class, handler)
+    handler.invoke(this)
+}
+
+fun RBuilder.browserRouter(
+    basename: String = "",
+    getUserConfirmation: GetUserConfirmation? = null,
+    forceRefresh: Boolean = false,
+    keyLength: Int = 6,
+    handler: RHandler<RProps>
+) = child(BrowserRouterComponent::class) {
+    attrs {
+        this.basename = basename
+        this.getUserConfirmation = getUserConfirmation
+        this.forceRefresh = forceRefresh
+        this.keyLength = keyLength
+    }
+
+    handler.invoke(this)
+}
 
 fun RBuilder.switch(handler: RHandler<RProps>) = child(SwitchComponent::class, handler)
 


### PR DESCRIPTION
Enabled setting the attribute values of BrowserRouter and HashRouter.

ref. https://reacttraining.com/react-router/web/api/BrowserRouter
ref. https://reacttraining.com/react-router/web/api/HashRouter