### PR TITLE
Add hex function for Color with unit test

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
@@ -533,6 +533,8 @@ class Color(override val value: String) : CssValue(value) {
     }
 }
 
+private fun String.withZeros() = this + "0".repeat(max(0, 3 - this.length))
+fun hex(value: Int) = Color("#${value.toString(16).withZeros()}")
 fun rgb(red: Int, green: Int, blue: Int) = Color("rgb($red, $green, $blue)")
 fun rgba(red: Int, green: Int, blue: Int, alpha: Double) = Color("rgba($red, $green, $blue, ${formatAlpha(alpha)})")
 fun hsl(hue: Int, saturation: Int, lightness: Int) = Color("hsl($hue, $saturation%, $lightness%)")

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestColor.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestColor.kt
@@ -204,6 +204,17 @@ class TestColor {
     }
 
     @Test
+    fun testHex() {
+        val black = hex(0x000)
+        val white = hex(0xfff)
+        val color = hex(0x812dd3)
+
+        assertEquals("#000", black.toString())
+        assertEquals("#fff", white.toString())
+        assertEquals("#812dd3", color.toString())
+    }
+
+    @Test
     fun testBlend() {
         val source = whiteAlpha(0.1)
         val mix = source.blend(Color("#1a3b66"))


### PR DESCRIPTION
I added a `hex` color function like `rgb` and `hsl` for Kotlin styled.
As parameter it takes an integer.
It is meant to be used like `hex(0xdeadbe)`.
I think it's a useful function as I use a lot of hex codes and using a function is more idiomatic than `Color("#deadbe")`.