### PR TITLE
Do not inline react.rFunction builder

### DIFF
--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -81,9 +81,9 @@ external interface RReadableRef<out T> : RRef {
 fun <S : RState> Component<*, S>.setState(buildState: S.() -> Unit) =
     setState({ assign(it, buildState) })
 
-inline fun <P : RProps> rFunction(
+fun <P : RProps> rFunction(
     displayName: String,
-    crossinline render: RBuilder.(P) -> Unit
+    render: RBuilder.(P) -> Unit
 ): RClass<P> {
     val fn = { props: P -> buildElements { render(props) } }
     return fn.unsafeCast<RClass<P>>()


### PR DESCRIPTION
By inlining `rFunction`, React Developer Tools Chrome extension shows any hooks deeply nested within some structure. Not inlining removes these extra layers of structure, which make debugging component hooks much easier.

Here's what it looks like before:

![image](https://user-images.githubusercontent.com/1074449/91380053-ab90a100-e7e9-11ea-8596-0c60f595ccc7.png)

Here's what it looks like after:

![image](https://user-images.githubusercontent.com/1074449/91379877-3c1ab180-e7e9-11ea-9416-1c277f5e5f59.png)

This is how `functionalComponent` works (doesn't inline) but that builder doesn't support naming the component which gives a tree of `Anonymous` components which is worse. The other option would be to add `displayName` support to `functionalComponent` if that is the direction this library is moving and the goal is to remove `rFunction`.