### PR TITLE
Add ios target and workaround native plugin late evaluation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,10 +37,12 @@ subprojects {
             }
         }
     }
+    afterEvaluate {
+        tasks.withType<KotlinCompile<*>>().configureEach {
+            if (!name.endsWith("JsIr")) {
+                kotlinOptions.allWarningsAsErrors = true
+            }
 
-    tasks.withType<KotlinCompile<*>>().configureEach {
-        if (!name.endsWith("JsIr")) {
-            kotlinOptions.allWarningsAsErrors = true
         }
     }
 }

--- a/kotlin-css/build.gradle.kts
+++ b/kotlin-css/build.gradle.kts
@@ -9,6 +9,9 @@ kotlin {
         moduleName = project.name
         browser()
     }
+    iosArm32("iosArm32")
+    iosX64("iosX64")
+    iosArm64("iosArm64")
 
     sourceSets {
         val commonTest by getting {


### PR DESCRIPTION
This 3 explicit targets are required for now so that kotlin-css can be consumed by Kotlin/Native ios targets. Can be extended later for all native targets, if needed. 