### PR TITLE
Update to styled components v5

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
@@ -169,7 +169,7 @@ class CSSBuilder(
     }
 
     fun prefix(selector: String, block: RuleSet) {
-        "$selector &"(block)
+        "$selector &&"(block)
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CSSBuilder.kt
@@ -169,6 +169,7 @@ class CSSBuilder(
     }
 
     fun prefix(selector: String, block: RuleSet) {
+        // Temporarily using && here because of a bug introduced in version 5.2: https://github.com/styled-components/styled-components/issues/3244#issuecomment-687676703
         "$selector &&"(block)
     }
 

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -174,13 +174,19 @@ typealias FunctionalComponent<P> = (props: P) -> dynamic
  * Get functional component from [func]
  */
 fun <P : RProps> functionalComponent(
+    displayName: String? = null,
     func: RBuilder.(props: P) -> Unit
-): FunctionalComponent<P> =
-    { props: P ->
+): FunctionalComponent<P> {
+    val fc = { props: P ->
         buildElements {
             func(props)
         }
     }
+    if (displayName != null) {
+        fc.asDynamic().displayName = displayName
+    }
+    return fc
+}
 
 /**
  * Append functional component [component] as child of current builder

--- a/kotlin-styled/build.gradle.kts
+++ b/kotlin-styled/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 
     api(npm("css-in-js-utils", "^3.1.0"))
     api(npm("inline-style-prefixer", "^6.0.0"))
-    api(npm("styled-components", "^4.4.1"))
+    api(npm("styled-components", "^5.2.0"))
 }

--- a/kotlin-styled/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyleSheet.kt
@@ -2,6 +2,7 @@ package styled
 
 import kotlinext.js.*
 import kotlinx.css.*
+import react.*
 import kotlin.reflect.*
 
 open class StyleSheet(var name: String, val isStatic: Boolean = false) {
@@ -38,6 +39,14 @@ open class StyleSheet(var name: String, val isStatic: Boolean = false) {
             }
 
             injectGlobal(builder.toString())
+        } else {
+            // for styled-components v5
+            // inject global uses useRef() to check if it's created dynamically,
+            // but using hooks should be without any condition in render flow
+            // so it should be placed in else too
+            try {
+                useRef(undefined)
+            } catch (e: Throwable) {}
         }
     }
 }

--- a/kotlin-styled/src/main/kotlin/styled/styled-components.kt
+++ b/kotlin-styled/src/main/kotlin/styled/styled-components.kt
@@ -31,6 +31,7 @@ external interface Styler : TemplateTag<(StyledProps) -> String, dynamic> {
 }
 
 external interface Keyframes {
+    val rules: Array<out dynamic>
     fun getName(): String
 }
 


### PR DESCRIPTION
There were two problems:
1) Animation keyframes internal rules generation changed
2) `createGlobalStyle` has internal check of using in render by hook `useRef` and it was called conditionally against hooks rules.

And just added ability to name functionalComponent