### PR TITLE
Porting react-redux 7.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ react-router-dom.version=5.1.2
 
 # kotlin-redux, kotlin-react-redux
 redux.version=4.0.0
-react-redux.version=5.0.7
+react-redux.version=7.2
 
 # kotlin-styled
 styled.version=5.2.0

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Dsl.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Dsl.kt
@@ -1,10 +1,13 @@
 package react.redux
 
-import react.*
-import redux.*
+import react.RBuilder
+import react.RContext
+import react.RHandler
+import redux.Store
 
-fun RBuilder.provider(store: Store<*, *, *>, handler: RHandler<ProviderProps>) =
+fun RBuilder.provider(store: Store<*, *, *>, context: RContext<*>? = null, handler: RHandler<ProviderProps>) =
     child<ProviderProps, Provider> {
         attrs.store = store
+        if (context != null) attrs.context = context
         handler()
     }

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
@@ -3,8 +3,14 @@
 
 package react.redux
 
-import react.*
-import redux.*
+import react.Component
+import react.FunctionalComponent
+import react.HOC
+import react.RContext
+import react.RProps
+import react.RState
+import react.ReactElement
+import redux.Store
 
 external class Provider : Component<ProviderProps, RState> {
     override fun render(): ReactElement?
@@ -12,6 +18,7 @@ external class Provider : Component<ProviderProps, RState> {
 
 external interface ProviderProps : RProps {
     var store: Store<*, *, *>
+    var context: RContext<*>
 }
 
 external fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> connect(
@@ -25,3 +32,22 @@ external fun <S, A, R, OP : RProps, P : RProps> connectAdvanced(
     selectorFactory: SelectorFactory<S, A, R, OP, P>,
     options: ConnectOptions<P> = definedExternally
 ): HOC<P, OP>
+
+external fun batch(action: () -> Unit)
+
+external fun <S, R> useSelector(selector: (S) -> R) : R
+
+external fun <S, R> useSelector(selector: (S) -> R, equalityFn: (R, R) -> Boolean) : R
+
+external fun <A, R> useDispatch(): ((A) -> R)
+
+external fun <S, A, R> useStore(): Store<S, A, R>
+
+external fun <S, R> createSelectorHook(context: RContext<*>): (selector: (S) -> R, equalityFn: ((R, R) -> Boolean)) -> R
+
+external fun <A, R> createDispatchHook(context: RContext<*>): () -> ((A) -> R)
+
+external fun <S, A, R> createStoreHook(context: RContext<*>): () -> Store<S, A, R>
+
+
+


### PR DESCRIPTION
Hi there! I ported the following (new) API:

- added `context` prop to [`Provider`](https://react-redux.js.org/api/provider#provider)
- [`batch()`](https://react-redux.js.org/api/batch)
- [`useSelector()`](https://react-redux.js.org/api/hooks#useselector)
- [`useStore()`](https://react-redux.js.org/api/hooks#usestore)
- [`useDispatch()`](https://react-redux.js.org/api/hooks#usedispatch)
- [`createSelectorHook`](https://react-redux.js.org/api/hooks#custom-context)
- [`createStoreHook`](https://react-redux.js.org/api/hooks#custom-context)
- [`createDispatchHook`](https://react-redux.js.org/api/hooks#custom-context)

Comments are welcome.

(closes #357)