### PR TITLE
Externalize redux actions

### DIFF
--- a/kotlin-redux/src/main/kotlin/redux/Helpers.kt
+++ b/kotlin-redux/src/main/kotlin/redux/Helpers.kt
@@ -42,9 +42,9 @@ fun <S> rEnhancer(): Enhancer<S, Action, Action, RAction, WrapperAction> = { nex
     }
 }
 
-interface WrapperAction : Action {
+external interface WrapperAction : Action {
     override val type: String
     val action: RAction
 }
 
-interface RAction
+external interface RAction


### PR DESCRIPTION
In fact `WrapperAction` and `RAction` are externals
In https://github.com/JetBrains/kotlin-wrappers/blob/1550ab7e35e6d16afa3f76ebf67c911357486ce7/kotlin-redux/src/main/kotlin/redux/Helpers.kt#L34 we get `action` with dynamic, so we need to get it by name.
Non externals don't get such guarantees (and in IR it doesn't, access will be by property accessors - getter and setter), but externals do (by semantic)