### PR TITLE
Adding control over comparison for memo

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -79,6 +79,8 @@ external val StrictMode: RClass<RProps>
 // Memo (16.6+)
 external fun <P : RProps> memo(fc: FunctionalComponent<P>): FunctionalComponent<P>
 
+external fun <P : RProps> memo(fc: FunctionalComponent<P>, areEqual: (P, P) -> Boolean): FunctionalComponent<P>
+
 // Lazy (16.6+)
 external fun <P : RProps> lazy(loadComponent: () -> Promise<RClass<P>>): RClass<P>
 


### PR DESCRIPTION
As explained in the React documentation (https://reactjs.org/docs/react-api.html#reactmemo) we should be able to provide a custom comparison function to React.memo for some performance optimizations. Therefore, I added the external declaration to provide this feature. 