### PR TITLE
Add changeAlpha function

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
@@ -364,6 +364,12 @@ class Color(override val value: String) : CssValue(value) {
             else -> with(toRGBA()) { rgba(red, green, blue, normalizeAlpha(alpha) * this.alpha) }
         }
 
+    fun changeAlpha(alpha: Double) =
+        when {
+            value.startsWith("hsl", true) -> with(fromHSLANotation()) { hsla(hue, saturation, lightness, normalizeAlpha(alpha)) }
+            else -> with(toRGBA()) { rgba(red, green, blue, normalizeAlpha(alpha)) }
+        }
+
     // https://stackoverflow.com/questions/2049230/convert-rgba-color-to-rgb
     fun blend(backgroundColor: Color): Color {
         val source = this.toRGBA()

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestColor.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestColor.kt
@@ -204,6 +204,21 @@ class TestColor {
     }
 
     @Test
+    fun testChangeAlpha() {
+        val rgb = rgb(0, 0, 0).changeAlpha(0.1)
+        val rgba = rgba(0, 0, 0, 0.5).changeAlpha(0.1)
+        val hex = Color("#000").changeAlpha(0.1)
+        val hexa = Color("#00000000").changeAlpha(0.1)
+        val hexa2 = Color("#00000022").changeAlpha(0.1)
+
+        assertEquals("rgba(0, 0, 0, 0.1)", rgb.toString(), "Alpha conversion is incorrect")
+        assertEquals("rgba(0, 0, 0, 0.1)", rgba.toString(), "Alpha conversion is incorrect")
+        assertEquals("rgba(0, 0, 0, 0.1)", hex.toString(), "Alpha conversion is incorrect")
+        assertEquals("rgba(0, 0, 0, 0.1)", hexa.toString(), "Alpha conversion is incorrect")
+        assertEquals("rgba(0, 0, 0, 0.1)", hexa2.toString(), "Alpha conversion is incorrect")
+    }
+
+    @Test
     fun testHex() {
         val black = hex(0x000)
         val white = hex(0xfff)


### PR DESCRIPTION
Adds `changeAlpha` function.

Unlike `withAlpha`, that **multiplies** color's current alpha value on the given number, `changeAlpha` completely replaces color's alpha with a given one.