### PR TITLE
Update README.md sample for React Component

### DIFF
--- a/kotlin-react/README.md
+++ b/kotlin-react/README.md
@@ -114,7 +114,8 @@ fun RBuilder.welcome(handler: WelcomeProps.() -> Unit) = child(welcome) {
 
 #### Creating a React class component with Kotlin
 
-Here's an example of a component defined using a class with a `name` property of type `String`:
+Here's an example of a component defined using a class with a `name` property of type `String` and 
+a matching component state to hold the `name` property:
 
 ```kotlin
 import react.*
@@ -124,10 +125,20 @@ external interface WelcomeProps : RProps {
     var name: String
 }
 
-class Welcome: RComponent<WelcomeProps, RState>() {
-     override fun RBuilder.render() {
+external interface WelcomeState: RState {
+    var name: String
+}
+
+@JsExport
+class Welcome(props: WelcomeProps): RComponent<WelcomeProps, WelcomeState>(props) {
+
+    override fun WelcomeState.init(props: WelcomeProps) {
+        name = props.name
+    }
+
+    override fun RBuilder.render() {
         div {
-            +"Hello, ${props.name}"
+            +"Hello, ${state.name}"
         }
     }
 }


### PR DESCRIPTION
Updating the sample for the React Custom Component to better reflect the approach to creating an Initial State for a component from the props that are injected. 

Covers:
- IR Compatibility
- State instantiation 
- @JsExport for class components. 
- Override State `init` function.

This has come about after a conversation with @SebastianAigner regarding state initialisation in `Kotlin-React` components that are built with the new IR compiler. 