### PR TITLE
Fix ref object contract

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -68,7 +68,7 @@ external val Fragment: RClass<RProps>
 external fun <T> createContext(defaultValue: T = definedExternally): RContext<T>
 
 // Refs (16.3+)
-external fun <T> createRef(): RReadableRef<T>
+external fun <T: Any> createRef(): RReadableRef<T>
 
 @JsName("forwardRef")
 external fun <P : RProps> rawForwardRef(forward: (props: P, ref: RRef) -> Any): RClass<P>
@@ -141,11 +141,11 @@ external fun <T : Function<*>> useCallback(callback: T, dependencies: RDependenc
 external fun <T> useMemo(callback: () -> T, dependencies: RDependenciesArray): T
 
 // Ref Hook (16.8+)
-external interface RMutableRef<T> : RReadableRef<T> {
-    override var current: T
+external interface RMutableRef<T: Any> : RReadableRef<T> {
+    override var current: T?
 }
 
-external fun <T> useRef(initialValue: T): RMutableRef<T>
+external fun <T: Any> useRef(initialValue: T? = definedExternally): RMutableRef<T>
 
 // Imperative Methods Hook (16.8+)
 external fun useImperativeHandle(ref: RRef, createInstance: () -> dynamic, inputs: RDependenciesArray)

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -74,8 +74,8 @@ external interface RContext<T> {
 // Refs (16.3+)
 external interface RRef
 
-external interface RReadableRef<T> : RRef {
-    val current: T
+external interface RReadableRef<out T: Any> : RRef {
+    val current: T?
 }
 
 fun <S : RState> Component<*, S>.setState(buildState: S.() -> Unit) =


### PR DESCRIPTION
### Problems
1. Non-strict contract for `current`. `current` must be nullable
2. Non-strict type parameter for reference types (result of problem 1)

### Example 
[Test project](https://codesandbox.io/s/blissful-beaver-wy7fo)
After second button click one ref is `null` (see console)

### Migration
* `RReadableRef<MyElement?>` -> `RReadableRef<MyElement>`
* `RMutableRef<MyElement?>` -> `RMutableRef<MyElement>`
* `useRef<MyElement?>` -> `useRef<MyElement>`
* `createRef<MyElement?>` -> `createRef<MyElement>`

cc @vlsi