### PR TITLE
Sync `licences` section with `kotlin` project

### DIFF
--- a/buildSrc/src/main/kotlin/maven-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publishing-conventions.gradle.kts
@@ -63,8 +63,8 @@ fun MavenPublication.metadata() {
 
         licenses {
             license {
-                name.set("Apache License, Version 2.0")
-                url.set("https://github.com/JetBrains/kotlin-wrappers/blob/master/LICENSE")
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
             }
         }
 


### PR DESCRIPTION
Subtask of #431

Licences section
https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib/1.5.0