### PR TITLE
#358 Remove `rFunction` (duplicate of `functionalComponent`)

### DIFF
--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -84,15 +84,6 @@ external interface RReadableRef<out T : Any> : RRef {
 fun <S : RState> Component<*, S>.setState(buildState: S.() -> Unit) =
     setState({ assign(it, buildState) })
 
-fun <P : RProps> rFunction(
-    displayName: String,
-    render: RBuilder.(P) -> Unit
-): RClass<P> {
-    val fn = { props: P -> buildElements { render(props) } }
-    return fn.unsafeCast<RClass<P>>()
-        .also { it.displayName = displayName }
-}
-
 abstract class RComponent<P : RProps, S : RState> : Component<P, S> {
     constructor() : super() {
         state = jsObject { init() }


### PR DESCRIPTION
[functionalComponent](https://github.com/JetBrains/kotlin-wrappers/blob/0516221ff85f064f38b87d395ec7da0b0afb961b/kotlin-react/src/main/kotlin/react/RBuilder.kt#L253)