### PR TITLE
Remove possibilty to override props

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -23,7 +23,7 @@ external object Children {
 abstract external class Component<P : RProps, S : RState>(
     props: P = definedExternally
 ) {
-    open val props: P
+    val props: P
     var state: S
 
     fun setState(partialState: S, callback: () -> Unit = definedExternally)


### PR DESCRIPTION
`props` instantiated inside React, the problem that `open val` allow to override with `override var`, and setter will be overridden.

But when during native react constructor, react set props, it calls overridden setter, which is not good, I guess