### PR TITLE
Standard names for `state` classes

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -107,15 +107,15 @@ external interface ProfilerProps : RProps {
 external val Profiler: RClass<ProfilerProps>
 
 // State Hook (16.8+)
-external fun <T : Any> useState(): RStateDelegate<T?>
+external fun <T : Any> useState(): StateInstance<T?>
 
 external fun <T> useState(
     initValue: T,
-): RStateDelegate<T>
+): StateInstance<T>
 
 external fun <T> useState(
     valueInitializer: () -> T,
-): RStateDelegate<T>
+): StateInstance<T>
 
 // Reducer Hook (16.8+)
 @JsName("useReducer")

--- a/kotlin-react/src/main/kotlin/react/StateInstance.kt
+++ b/kotlin-react/src/main/kotlin/react/StateInstance.kt
@@ -5,7 +5,7 @@ package react
 import kotlin.reflect.KProperty
 
 // TODO: make external in IR
-class RSetState<T>
+class StateSetter<T>
 private constructor() {
     inline operator fun invoke(value: T) {
         asDynamic()(value)
@@ -16,15 +16,21 @@ private constructor() {
     }
 }
 
+@Deprecated(
+    message = "Legacy name for `StateSetter`",
+    replaceWith = ReplaceWith("StateSetter<T>"),
+)
+typealias RSetState<T> = StateSetter<T>
+
 /**
  * Only works inside [functionalComponent]
  * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
  */
 // TODO: make external in IR
-class RStateDelegate<T>
+class StateInstance<T>
 private constructor() {
     inline operator fun component1(): T = asDynamic()[0]
-    inline operator fun component2(): RSetState<T> = asDynamic()[1]
+    inline operator fun component2(): StateSetter<T> = asDynamic()[1]
 
     inline operator fun getValue(
         thisRef: Nothing?,
@@ -40,3 +46,9 @@ private constructor() {
         asDynamic()[1](value)
     }
 }
+
+@Deprecated(
+    message = "Legacy name for `StateInstance`",
+    replaceWith = ReplaceWith("StateInstance<T>"),
+)
+typealias RStateDelegate<T> = StateInstance<T>


### PR DESCRIPTION
`StateInstance` - like [`TableInstance`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0db3b0f8fc437d00900166cffa8a884142f1247d/types/react-table/index.d.ts#L163)
`StateSetter` - like [`PropGetter`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0db3b0f8fc437d00900166cffa8a884142f1247d/types/react-table/index.d.ts#L181)

Smooth migration provided by IDEA via formatting

cc @sgrishchenko 