### PR TITLE
Consistency of hook dependencies v2

### DIFF
--- a/kotlin-react/src/main/kotlin/react/EffectBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/EffectBuilder.kt
@@ -14,12 +14,11 @@ private constructor() {
 
 internal fun createEffectCallback(
     effect: EffectBuilder.() -> Unit,
-): () -> RCleanup? =
-    {
-        val cleanups = arrayOf<RCleanup>()
-        effect(cleanups.unsafeCast<EffectBuilder>())
-        buildCleanup(cleanups)
-    }
+): () -> RCleanup? = {
+    val cleanups = arrayOf<RCleanup>()
+    effect(cleanups.unsafeCast<EffectBuilder>())
+    buildCleanup(cleanups)
+}
 
 private fun buildCleanup(
     cleanups: Array<out RCleanup>,

--- a/kotlin-react/src/main/kotlin/react/EffectBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/EffectBuilder.kt
@@ -12,10 +12,10 @@ private constructor() {
     }
 }
 
-internal fun useEffectCallback(
+internal fun createEffectCallback(
     effect: EffectBuilder.() -> Unit,
 ): () -> RCleanup? =
-    useCallback(effect) {
+    {
         val cleanups = arrayOf<RCleanup>()
         effect(cleanups.unsafeCast<EffectBuilder>())
         buildCleanup(cleanups)

--- a/kotlin-react/src/main/kotlin/react/useEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useEffect.kt
@@ -12,8 +12,8 @@ typealias RCleanup = () -> Unit
 fun useEffect(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseEffect(effectCallback)
+    val callback = useEffectCallback(effect)
+    rawUseEffect(callback)
 }
 
 /**
@@ -24,8 +24,8 @@ fun useEffect(
     vararg dependencies: dynamic,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseEffect(effectCallback, dependencies)
+    val callback = useEffectCallback(effect)
+    rawUseEffect(callback, dependencies)
 }
 
 /**
@@ -35,8 +35,8 @@ fun useEffect(
 fun useEffectOnce(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseEffect(effectCallback, emptyArray())
+    val callback = useEffectCallback(effect)
+    rawUseEffect(callback, emptyArray())
 }
 
 /**
@@ -68,10 +68,10 @@ fun useEffect(
     dependencies: RDependenciesList? = null,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
+    val callback = useEffectCallback(effect)
     if (dependencies != null) {
-        rawUseEffect(effectCallback, dependencies.toTypedArray())
+        rawUseEffect(callback, dependencies.toTypedArray())
     } else {
-        rawUseEffect(effectCallback)
+        rawUseEffect(callback)
     }
 }

--- a/kotlin-react/src/main/kotlin/react/useEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useEffect.kt
@@ -9,6 +9,43 @@ typealias RCleanup = () -> Unit
  * Only works inside [functionalComponent]
  * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
  */
+fun useEffect(
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseEffect(effectCallback)
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+fun useEffect(
+    vararg dependencies: dynamic,
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseEffect(effectCallback, dependencies)
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+fun useEffectOnce(
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseEffect(effectCallback, emptyArray())
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
 fun useEffectWithCleanup(
     dependencies: RDependenciesList? = null,
     effect: () -> RCleanup,
@@ -24,17 +61,17 @@ fun useEffectWithCleanup(
  * Only works inside [functionalComponent]
  * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
  */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
 fun useEffect(
     dependencies: RDependenciesList? = null,
-    effect: () -> Unit,
+    effect: EffectBuilder.() -> Unit,
 ) {
-    val rawEffect = {
-        effect()
-        undefined
-    }
+    val effectCallback = useEffectCallback(effect)
     if (dependencies != null) {
-        rawUseEffect(rawEffect, dependencies.toTypedArray())
+        rawUseEffect(effectCallback, dependencies.toTypedArray())
     } else {
-        rawUseEffect(rawEffect)
+        rawUseEffect(effectCallback)
     }
 }

--- a/kotlin-react/src/main/kotlin/react/useEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useEffect.kt
@@ -12,7 +12,7 @@ typealias RCleanup = () -> Unit
 fun useEffect(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseEffect(callback)
 }
 
@@ -24,7 +24,7 @@ fun useEffect(
     vararg dependencies: dynamic,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseEffect(callback, dependencies)
 }
 
@@ -35,7 +35,7 @@ fun useEffect(
 fun useEffectOnce(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseEffect(callback, emptyArray())
 }
 
@@ -68,7 +68,7 @@ fun useEffect(
     dependencies: RDependenciesList? = null,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     if (dependencies != null) {
         rawUseEffect(callback, dependencies.toTypedArray())
     } else {

--- a/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
@@ -7,8 +7,8 @@ package react
 fun useLayoutEffect(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseLayoutEffect(effectCallback)
+    val callback = useEffectCallback(effect)
+    rawUseLayoutEffect(callback)
 }
 
 /**
@@ -19,8 +19,8 @@ fun useLayoutEffect(
     vararg dependencies: dynamic,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseLayoutEffect(effectCallback, dependencies)
+    val callback = useEffectCallback(effect)
+    rawUseLayoutEffect(callback, dependencies)
 }
 
 /**
@@ -30,8 +30,8 @@ fun useLayoutEffect(
 fun useLayoutEffectOnce(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
-    rawUseLayoutEffect(effectCallback, emptyArray())
+    val callback = useEffectCallback(effect)
+    rawUseLayoutEffect(callback, emptyArray())
 }
 
 /**
@@ -63,10 +63,10 @@ fun useLayoutEffect(
     dependencies: RDependenciesList? = null,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val effectCallback = useEffectCallback(effect)
+    val callback = useEffectCallback(effect)
     if (dependencies != null) {
-        rawUseLayoutEffect(effectCallback, dependencies.toTypedArray())
+        rawUseLayoutEffect(callback, dependencies.toTypedArray())
     } else {
-        rawUseLayoutEffect(effectCallback)
+        rawUseLayoutEffect(callback)
     }
 }

--- a/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
@@ -4,6 +4,43 @@ package react
  * Only works inside [functionalComponent]
  * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
  */
+fun useLayoutEffect(
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseLayoutEffect(effectCallback)
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+fun useLayoutEffect(
+    vararg dependencies: dynamic,
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseLayoutEffect(effectCallback, dependencies)
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+fun useLayoutEffectOnce(
+    effect: EffectBuilder.() -> Unit,
+) {
+    val effectCallback = useEffectCallback(effect)
+    rawUseLayoutEffect(effectCallback, emptyArray())
+}
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
 fun useLayoutEffectWithCleanup(
     dependencies: RDependenciesList? = null,
     effect: () -> RCleanup,
@@ -19,17 +56,17 @@ fun useLayoutEffectWithCleanup(
  * Only works inside [functionalComponent]
  * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
  */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
 fun useLayoutEffect(
     dependencies: RDependenciesList? = null,
-    effect: () -> Unit,
+    effect: EffectBuilder.() -> Unit,
 ) {
-    val rawEffect = {
-        effect()
-        undefined
-    }
+    val effectCallback = useEffectCallback(effect)
     if (dependencies != null) {
-        rawUseLayoutEffect(rawEffect, dependencies.toTypedArray())
+        rawUseLayoutEffect(effectCallback, dependencies.toTypedArray())
     } else {
-        rawUseLayoutEffect(rawEffect)
+        rawUseLayoutEffect(effectCallback)
     }
 }

--- a/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useLayoutEffect.kt
@@ -7,7 +7,7 @@ package react
 fun useLayoutEffect(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseLayoutEffect(callback)
 }
 
@@ -19,7 +19,7 @@ fun useLayoutEffect(
     vararg dependencies: dynamic,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseLayoutEffect(callback, dependencies)
 }
 
@@ -30,7 +30,7 @@ fun useLayoutEffect(
 fun useLayoutEffectOnce(
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     rawUseLayoutEffect(callback, emptyArray())
 }
 
@@ -63,7 +63,7 @@ fun useLayoutEffect(
     dependencies: RDependenciesList? = null,
     effect: EffectBuilder.() -> Unit,
 ) {
-    val callback = useEffectCallback(effect)
+    val callback = createEffectCallback(effect)
     if (dependencies != null) {
         rawUseLayoutEffect(callback, dependencies.toTypedArray())
     } else {


### PR DESCRIPTION
Fix #463
New implementation of hooks with vararg dependencies is added, old implementation is deprecated.
Cc @turansky 