### PR TITLE
Fix typo in GridAutoRows and GridAutoColumns

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
@@ -754,9 +754,9 @@ class GridAutoColumns(override val value: String) : CssValue(value) {
         val maxContent = GridAutoColumns("max-content")
         val minContent = GridAutoColumns("min-content")
 
-        fun fitContent(argument: GridAutoColumns) = GridAutoColumns("min-max(auto, max(auto, $argument))")
-        fun minMax(min: LinearDimension, max: LinearDimension) = GridAutoColumns("min-max($min, $max)")
-        fun minMax(min: GridAutoColumns, max: GridAutoColumns) = GridAutoColumns("min-max($min, $max)")
+        fun fitContent(argument: GridAutoColumns) = GridAutoColumns("minmax(auto, max(auto, $argument))")
+        fun minMax(min: LinearDimension, max: LinearDimension) = GridAutoColumns("minmax($min, $max)")
+        fun minMax(min: GridAutoColumns, max: GridAutoColumns) = GridAutoColumns("minmax($min, $max)")
     }
 }
 
@@ -784,9 +784,9 @@ class GridAutoRows(override val value: String) : CssValue(value) {
         val maxContent = GridAutoRows("max-content")
         val minContent = GridAutoRows("min-content")
 
-        fun fitContent(argument: GridAutoRows) = GridAutoRows("min-max(auto, max(auto, $argument))")
-        fun minMax(min: LinearDimension, max: LinearDimension) = GridAutoRows("min-max($min, $max)")
-        fun minMax(min: GridAutoRows, max: GridAutoRows) = GridAutoRows("min-max($min, $max)")
+        fun fitContent(argument: GridAutoRows) = GridAutoRows("minmax(auto, max(auto, $argument))")
+        fun minMax(min: LinearDimension, max: LinearDimension) = GridAutoRows("minmax($min, $max)")
+        fun minMax(min: GridAutoRows, max: GridAutoRows) = GridAutoRows("minmax($min, $max)")
     }
 }
 
@@ -850,8 +850,8 @@ class GridTemplateColumns(override val value: String) : CssValue(value) {
         val none = GridTemplateColumns("none")
 
         fun fitContent(dim: LinearDimension) = GridTemplateColumns("min(max-content, max(auto, $dim))")
-        fun minMax(min: LinearDimension, max: LinearDimension) = GridTemplateColumns("min-max($min, $max)")
-        fun minMax(min: GridTemplateColumns, max: GridTemplateColumns) = GridTemplateColumns("min-max($min, $max)")
+        fun minMax(min: LinearDimension, max: LinearDimension) = GridTemplateColumns("minmax($min, $max)")
+        fun minMax(min: GridTemplateColumns, max: GridTemplateColumns) = GridTemplateColumns("minmax($min, $max)")
         fun repeat(argument: String) = GridTemplateColumns("repeat($argument)")
     }
 }
@@ -868,8 +868,8 @@ class GridTemplateRows(override val value: String) : CssValue(value) {
         val none = GridTemplateRows("none")
 
         fun fitContent(dim: LinearDimension) = GridTemplateRows("min(max-content, max(auto, $dim))")
-        fun minMax(min: LinearDimension, max: LinearDimension) = GridTemplateRows("min-max($min, $max)")
-        fun minMax(min: GridTemplateRows, max: GridTemplateRows) = GridTemplateRows("min-max($min, $max)")
+        fun minMax(min: LinearDimension, max: LinearDimension) = GridTemplateRows("minmax($min, $max)")
+        fun minMax(min: GridTemplateRows, max: GridTemplateRows) = GridTemplateRows("minmax($min, $max)")
         fun repeat(argument: String) = GridTemplateRows("repeat($argument)")
     }
 }

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestGrid.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestGrid.kt
@@ -67,7 +67,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-columns: min-max(auto, max(auto, min-max(10px, 20px)));
+                grid-auto-columns: minmax(auto, max(auto, minmax(10px, 20px)));
     
             """.trimIndent(),
             cssBuilder.toString(),
@@ -121,7 +121,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-columns: min-max(10fr, 20fr);
+                grid-auto-columns: minmax(10fr, 20fr);
     
             """.trimIndent(),
             cssBuilder.toString(),
@@ -139,7 +139,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-columns: min-max(auto, 10fr);
+                grid-auto-columns: minmax(auto, 10fr);
     
             """.trimIndent(),
             cssBuilder.toString(),
@@ -355,7 +355,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-rows: min-max(auto, max(auto, min-max(10px, 20px)));
+                grid-auto-rows: minmax(auto, max(auto, minmax(10px, 20px)));
     
             """.trimIndent(),
             cssBuilder.toString(),
@@ -409,7 +409,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-rows: min-max(10fr, 20fr);
+                grid-auto-rows: minmax(10fr, 20fr);
     
             """.trimIndent(),
             cssBuilder.toString(),
@@ -427,7 +427,7 @@ class TestGrid {
 
         assertEquals(
             """
-                grid-auto-rows: min-max(auto, 10fr);
+                grid-auto-rows: minmax(auto, 10fr);
     
             """.trimIndent(),
             cssBuilder.toString(),


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows#syntax
https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns#syntax