### PR TITLE
Old memoization hooks are deprecated

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -151,10 +151,18 @@ external fun rawUseLayoutEffect(
 external fun <T> useContext(context: RContext<T>): T
 
 // Callback Hook (16.8+)
-external fun <T : Function<*>> useCallback(callback: T, dependencies: RDependenciesArray): T
+@JsName("useCallback")
+external fun <T : Function<*>> rawUseCallback(
+    callback: T,
+    dependencies: RDependenciesArray
+): T
 
 // Memo Hook (16.8+)
-external fun <T> useMemo(callback: () -> T, dependencies: RDependenciesArray): T
+@JsName("useMemo")
+external fun <T> rawUseMemo(
+    callback: () -> T,
+    dependencies: RDependenciesArray
+): T
 
 // Ref Hook (16.8+)
 external interface RMutableRef<T : Any> : RReadableRef<T> {
@@ -175,4 +183,4 @@ external fun <T : Any> useDebugValue(
 // Transitions (18.0+)
 external fun startTransition(callback: () -> Unit)
 
-external fun useTransition(options: TransitionOptions = definedExternally) : TransitionInstance
+external fun useTransition(options: TransitionOptions = definedExternally): TransitionInstance

--- a/kotlin-react/src/main/kotlin/react/useCallback.kt
+++ b/kotlin-react/src/main/kotlin/react/useCallback.kt
@@ -10,4 +10,17 @@ inline fun <T : Function<*>> useCallback(
     vararg dependencies: dynamic,
     callback: T,
 ): T =
-    useCallback(callback, dependencies)
+    rawUseCallback(callback, dependencies)
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
+inline fun <T : Function<*>> useCallback(
+    callback: T,
+    dependencies: RDependenciesArray
+): T =
+    rawUseCallback(callback, dependencies)

--- a/kotlin-react/src/main/kotlin/react/useMemo.kt
+++ b/kotlin-react/src/main/kotlin/react/useMemo.kt
@@ -10,4 +10,18 @@ inline fun <T> useMemo(
     vararg dependencies: dynamic,
     noinline callback: () -> T,
 ): T =
-    useMemo(callback, dependencies)
+    rawUseMemo(callback, dependencies)
+
+/**
+ * Only works inside [functionalComponent]
+ * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
+ */
+@Deprecated(
+    message = "Inconsistent hooks API",
+)
+inline fun <T> useMemo(
+    noinline callback: () -> T,
+    dependencies: RDependenciesArray
+): T =
+    rawUseMemo(callback, dependencies)
+


### PR DESCRIPTION
`useMemo` and `useCallback` hooks with array dependencies are deprecated, only hooks with vararg dependencies are recommended for usage.

cc @turansky
