### PR TITLE
jsStyle not written into string attributes

### DIFF
--- a/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOMAttributes.kt
+++ b/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOMAttributes.kt
@@ -2,6 +2,7 @@ package react.dom
 
 import kotlinext.js.*
 import kotlinx.html.*
+import kotlinx.html.attributes.booleanEncode
 import kotlin.reflect.*
 
 private val events = listOf(
@@ -228,13 +229,16 @@ var TEXTAREA.value by StringAttr
 
 var Tag.jsStyle: dynamic
     get() {
-        val value = attributes["style"] ?: js {}
+        val value = asDynamic()[jsStyleMarker] ?: js {}
         jsStyle = value
         return value
     }
     set(value) {
-        attributes["style"] = value
+        asDynamic()[jsStyleMarker] = value
+        attributes[jsStyleMarker] = value.hashCode().toString()
     }
+
+const val jsStyleMarker = "${"$"}style${"$"}"
 
 inline fun Tag.jsStyle(handler: dynamic.() -> Unit) =
     handler(jsStyle)


### PR DESCRIPTION
`kotlinx.html` has `attributes` map `String` -> `String`
So, it is't allowed to pit dynamic here.
In legacy backend, there is no check in this place (but it is incorrect action in Kotlin type system)
But in IR there is type check, and it breaks on runtime