### PR TITLE
`ComponentType` interface is introduced

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -6,5 +6,5 @@ import kotlin.reflect.KClass
 fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): RClass<P> =
     rawWithRouter(klazz.rClass)
 
-fun <P : RProps> withRouter(component: FunctionalComponent<P>): RClass<P> =
+fun <P : RProps> withRouter(component: FC<P>): RClass<P> =
     rawWithRouter(component)

--- a/kotlin-react-table/src/main/kotlin/react/table/GroupBy.kt
+++ b/kotlin-react-table/src/main/kotlin/react/table/GroupBy.kt
@@ -6,7 +6,7 @@
 package react.table
 
 import kotlinext.js.Record
-import react.FunctionalComponent
+import react.FC
 
 external val useGroupBy: PluginHook<Any>
 
@@ -48,7 +48,7 @@ external interface UseGroupByState<D: Any> {
 
 external interface UseGroupByColumnOptions<D: Any> {
     val aggregate: Aggregator
-    val Aggregated: FunctionalComponent<CellProps<D, *>>
+    val Aggregated: FC<CellProps<D, *>>
     val disableGroupBy: Boolean
     val defaultCanGroupBy: Boolean
 }

--- a/kotlin-react-table/src/main/kotlin/react/table/Table.kt
+++ b/kotlin-react-table/src/main/kotlin/react/table/Table.kt
@@ -203,7 +203,7 @@ external interface HeaderProps<D: Any, V> : TableInstance<D> {
     val column: ColumnInstance<D, *>
 }
 
-external interface CellProps<D: Any, V> : TableInstance<D> {
+external interface CellProps<D: Any, V> : TableInstance<D>, RProps {
     val column: ColumnInstance<D, V>
     val row: Row<D>
     val cell: Cell<D, V>

--- a/kotlin-react/src/main/kotlin/react/ComponentType.kt
+++ b/kotlin-react/src/main/kotlin/react/ComponentType.kt
@@ -1,0 +1,10 @@
+package react
+
+external interface ComponentType<in P : RProps>
+
+external interface ComponentClass<in P : RProps> :
+    ComponentType<P>,
+    RComponentClassStatics<P, RState, RContext<*>?>
+
+external interface FunctionComponent<in P : RProps> :
+    ComponentType<P>

--- a/kotlin-react/src/main/kotlin/react/ComponentType.kt
+++ b/kotlin-react/src/main/kotlin/react/ComponentType.kt
@@ -2,9 +2,10 @@ package react
 
 external interface ComponentType<in P : RProps>
 
+// TODO: Should extend RComponentClassStatics, but has problems with generic params
 external interface ComponentClass<in P : RProps> :
     ComponentType<P>,
-    RComponentClassStatics<P, RState, RContext<*>?>
+    RComponentClassStatics<RProps, RState, RContext<*>?>
 
 external interface FunctionComponent<in P : RProps> :
     ComponentType<P>

--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -77,9 +77,9 @@ external fun <P : RProps> rawForwardRef(forward: (props: P, ref: RRef) -> Any): 
 external val StrictMode: RClass<RProps>
 
 // Memo (16.6+)
-external fun <P : RProps> memo(fc: FunctionalComponent<P>): FunctionalComponent<P>
+external fun <P : RProps> memo(fc: FC<P>): FC<P>
 
-external fun <P : RProps> memo(fc: FunctionalComponent<P>, areEqual: (P, P) -> Boolean): FunctionalComponent<P>
+external fun <P : RProps> memo(fc: FC<P>, areEqual: (P, P) -> Boolean): FC<P>
 
 // Lazy (16.6+)
 external fun <P : RProps> lazy(

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -247,6 +247,10 @@ fun <P : RProps> forwardRef(handler: RBuilder.(P, RRef) -> Unit): RClass<P> =
         buildElements { handler(props, ref) }
     }
 
+@Deprecated(
+    message = "Legacy type alias",
+    ReplaceWith("FunctionComponent", "react.FunctionComponent")
+)
 typealias FunctionalComponent<P> = FunctionComponent<P>
 
 typealias FC<P> = FunctionComponent<P>
@@ -257,7 +261,7 @@ typealias FC<P> = FunctionComponent<P>
 fun <P : RProps> functionalComponent(
     displayName: String? = null,
     func: RBuilder.(props: P) -> Unit
-): FunctionalComponent<P> {
+): FC<P> {
     val fc: dynamic = { props: P ->
         buildElements {
             func(props)
@@ -274,21 +278,21 @@ fun <P : RProps> functionalComponent(
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 fun <P : RProps> RBuilder.child(
-    component: FunctionalComponent<P>,
+    component: FC<P>,
     props: P = jsObject(),
     handler: RHandler<P> = {}
 ): ReactElement =
     child(component, props, handler)
 
 fun <T, P : RProps> RBuilder.childFunction(
-    component: FunctionalComponent<P>,
+    component: FC<P>,
     handler: RHandler<P> = {},
     children: RBuilder.(T) -> Unit
 ): ReactElement =
     childFunction(component, jsObject<P>(), handler, children)
 
 fun <T, P : RProps> RBuilder.childFunction(
-    component: FunctionalComponent<P>,
+    component: FC<P>,
     props: P,
     handler: RHandler<P> = {},
     children: RBuilder.(T) -> Unit

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -247,9 +247,9 @@ fun <P : RProps> forwardRef(handler: RBuilder.(P, RRef) -> Unit): RClass<P> =
         buildElements { handler(props, ref) }
     }
 
-typealias FunctionalComponent<P> = (props: P) -> dynamic
+typealias FunctionalComponent<P> = FunctionComponent<P>
 
-typealias FC<P> = FunctionalComponent<P>
+typealias FC<P> = FunctionComponent<P>
 
 /**
  * Get functional component from [func]
@@ -258,15 +258,15 @@ fun <P : RProps> functionalComponent(
     displayName: String? = null,
     func: RBuilder.(props: P) -> Unit
 ): FunctionalComponent<P> {
-    val fc = { props: P ->
+    val fc: dynamic = { props: P ->
         buildElements {
             func(props)
         }
     }
     if (displayName != null) {
-        fc.asDynamic().displayName = displayName
+        fc.displayName = displayName
     }
-    return fc
+    return fc.unsafeCast<FunctionComponent<P>>()
 }
 
 /**

--- a/kotlin-react/src/main/kotlin/react/React.kt
+++ b/kotlin-react/src/main/kotlin/react/React.kt
@@ -55,6 +55,6 @@ fun SuspenseProps.fallback(handler: RRender) {
  *
  * in your class components
  */
-open class RStatics<P : RProps, S : RState, C : Component<P, S>, CTX : RContext<Any>?>(
+open class RStatics<P : RProps, S : RState, C : Component<P, S>, CTX : RContext<*>?>(
     klazz: KClass<C>
 ) : RComponentClassStatics<P, S, CTX> by klazz.js.unsafeCast<RComponentClassStatics<P, S, CTX>>()

--- a/kotlin-react/src/main/kotlin/react/React.kt
+++ b/kotlin-react/src/main/kotlin/react/React.kt
@@ -55,6 +55,6 @@ fun SuspenseProps.fallback(handler: RRender) {
  *
  * in your class components
  */
-open class RStatics<P : RProps, S : RState, C : Component<P, S>, CTX : RContext<*>?>(
+open class RStatics<P : RProps, S : RState, C : Component<P, S>, CTX : RContext<Any>?>(
     klazz: KClass<C>
 ) : RComponentClassStatics<P, S, CTX> by klazz.js.unsafeCast<RComponentClassStatics<P, S, CTX>>()

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -37,14 +37,13 @@ external interface RErrorInfo
 val RErrorInfo.componentStack: Any
     get() = asDynamic().componentStack
 
-// TODO: Should extend RComponentClassStatics, but has problems with generic params
-external interface RClass<in P : RProps> : RComponentClassStatics<RProps, RState, RContext<Any>?>
+typealias RClass<P> = ComponentClass<P>
 
 external interface RClassModule<in P : RProps> {
     val default: RClass<P>
 }
 
-external interface RComponentClassStatics<P : RProps, S : RState, C : RContext<Any>?> {
+external interface RComponentClassStatics<P : RProps, S : RState, C : RContext<*>?> {
     var displayName: String?
 
     var defaultProps: P?

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -37,23 +37,21 @@ external interface RErrorInfo
 val RErrorInfo.componentStack: Any
     get() = asDynamic().componentStack
 
-external interface RClass<in P : RProps> : RComponentClassStatics<P, RState, RContext<*>?>
+// TODO: Should extend RComponentClassStatics, but has problems with generic params
+external interface RClass<in P : RProps> : RComponentClassStatics<RProps, RState, RContext<Any>?>
 
 external interface RClassModule<in P : RProps> {
     val default: RClass<P>
 }
 
-external interface RComponentClassStatics<in P : RProps, S : RState, C : RContext<*>?> {
+external interface RComponentClassStatics<P : RProps, S : RState, C : RContext<Any>?> {
     var displayName: String?
 
-    var defaultProps: @UnsafeVariance P?
-        @Deprecated(message = "Write-only property", level = DeprecationLevel.HIDDEN)
-        get() = definedExternally
-        set(value) = definedExternally
+    var defaultProps: P?
 
     var contextType: C
 
-    var getDerivedStateFromProps: ((@UnsafeVariance P, S) -> S?)?
+    var getDerivedStateFromProps: ((P, S) -> S?)?
 
     var getDerivedStateFromError: ((Throwable) -> S?)?
 }

--- a/kotlin-react/src/main/kotlin/react/ReactComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactComponent.kt
@@ -37,21 +37,23 @@ external interface RErrorInfo
 val RErrorInfo.componentStack: Any
     get() = asDynamic().componentStack
 
-// TODO: Should extend RComponentClassStatics, but has problems with generic params
-external interface RClass<in P : RProps> : RComponentClassStatics<RProps, RState, RContext<Any>?>
+external interface RClass<in P : RProps> : RComponentClassStatics<P, RState, RContext<*>?>
 
 external interface RClassModule<in P : RProps> {
     val default: RClass<P>
 }
 
-external interface RComponentClassStatics<P : RProps, S : RState, C : RContext<Any>?> {
+external interface RComponentClassStatics<in P : RProps, S : RState, C : RContext<*>?> {
     var displayName: String?
 
-    var defaultProps: P?
+    var defaultProps: @UnsafeVariance P?
+        @Deprecated(message = "Write-only property", level = DeprecationLevel.HIDDEN)
+        get() = definedExternally
+        set(value) = definedExternally
 
     var contextType: C
 
-    var getDerivedStateFromProps: ((P, S) -> S?)?
+    var getDerivedStateFromProps: ((@UnsafeVariance P, S) -> S?)?
 
     var getDerivedStateFromError: ((Throwable) -> S?)?
 }


### PR DESCRIPTION
1) `ComponentType` interface is introduced
1) Asterisk is used for Context generic parameter bound
1) `FunctionalComponent` is deprecated (POTENTIALLY BREAKING CHANGE!!!)
