### PR TITLE
RBuilder base child methods is strict

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Imports.kt
+++ b/kotlin-react/src/main/kotlin/react/Imports.kt
@@ -7,9 +7,12 @@ import kotlin.js.Promise
 
 // See https://reactjs.org/docs/react-component.html
 
-external fun <P : RProps> createElement(type: Any, props: P, vararg child: Any?): ReactElement
+external fun <P : RProps> createElement(type: String, props: P, vararg child: Any?): ReactElement
+external fun <P : RProps> createElement(type: ComponentType<P>, props: P, vararg child: Any?): ReactElement
+
 external fun <P : RProps> cloneElement(element: ReactElement, props: P, vararg child: Any?): ReactElement
 external fun cloneElement(element: dynamic, props: dynamic, vararg child: Any?): ReactElement
+
 external fun isValidElement(element: Any): Boolean
 
 external object Children {

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -26,14 +26,14 @@ interface RBuilder {
     }
 
     fun <P : RProps> child(
-        type: Any,
+        type: ComponentType<P>,
         props: P,
         children: List<Any>
     ): ReactElement =
         child(createElement(type, props, *children.toTypedArray()))
 
     fun <P : RProps> child(
-        type: Any,
+        type: ComponentType<P>,
         props: P,
         handler: RHandler<P>
     ): ReactElement {
@@ -44,7 +44,7 @@ interface RBuilder {
         return child(type, props, children)
     }
 
-    operator fun <P : RProps> RClass<P>.invoke(
+    operator fun <P : RProps> ComponentType<P>.invoke(
         handler: RHandler<P>
     ): ReactElement =
         child(this, jsObject(), handler)

--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -48,14 +48,14 @@ interface StyledElementBuilder<P : WithClassName> : RElementBuilder<P>, StyledBu
 
     companion object {
         operator fun <P : WithClassName> invoke(
-            type: Any,
+            type: ComponentType<P>,
             attrs: P = jsObject()
         ): StyledElementBuilder<P> = StyledElementBuilderImpl(type, attrs)
     }
 }
 
 class StyledElementBuilderImpl<P : WithClassName>(
-    override val type: Any,
+    override val type: ComponentType<P>,
     attrs: P = jsObject()
 ) : StyledElementBuilder<P>, RElementBuilderImpl<P>(attrs) {
     override val css = CSSBuilder()
@@ -65,7 +65,7 @@ class StyledElementBuilderImpl<P : WithClassName>(
 
 @ReactDsl
 interface StyledDOMBuilder<out T : Tag> : RDOMBuilder<T>, StyledBuilder<DOMProps> {
-    override val type: Any get() = attrs.tagName
+    override val type get() = attrs.tagName
 
     override fun create() = Styled.createElement(type, css, domProps, childList)
 
@@ -81,7 +81,7 @@ class StyledDOMBuilderImpl<out T : Tag>(factory: (TagConsumer<Unit>) -> T) : Sty
 typealias StyledHandler<P> = StyledElementBuilder<P>.() -> Unit
 
 fun <P : WithClassName> styled(type: RClass<P>): RBuilder.(StyledHandler<P>) -> ReactElement = { handler ->
-    child(with(StyledElementBuilder<P>(type)) {
+    child(with(StyledElementBuilder(type)) {
         handler()
         create()
     })
@@ -137,7 +137,7 @@ private external interface GlobalStylesComponentProps : RProps {
 private object GlobalStyles {
     private val component = functionalComponent<GlobalStylesComponentProps> { props ->
         props.globalStyles.forEach {
-            child(it, jsObject {}, emptyList())
+            child(it.unsafeCast<ComponentType<RProps>>(), jsObject {}, emptyList())
         }
     }
 
@@ -151,7 +151,7 @@ private object GlobalStyles {
 
     fun add(globalStyle: Component<RProps, RState>) {
         styles.add(globalStyle)
-        val reactElement = createElement<GlobalStylesComponentProps>(GlobalStyles.component, jsObject {
+        val reactElement = createElement(component, jsObject {
             this.globalStyles = styles
         })
         render(reactElement, root)
@@ -197,13 +197,12 @@ fun injectGlobal(handler: CSSBuilder.() -> Unit) {
 object Styled {
     private val cache = mutableMapOf<dynamic, dynamic>()
 
-    private fun wrap(type: dynamic) =
+    private fun <T> wrap(type: T): T =
         cache.getOrPut(type) {
             devOverrideUseRef { rawStyled(type)({ it.css }) }
         }
 
-    fun createElement(type: Any, css: CSSBuilder, props: WithClassName, children: List<Any>): ReactElement {
-        val wrappedType = wrap(type)
+    private fun <P: WithClassName> buildStyledProps(css: CSSBuilder, props: P): P {
         val styledProps = props.unsafeCast<StyledProps>()
         if (css.rules.isNotEmpty() || css.multiRules.isNotEmpty() || css.declarations.isNotEmpty()) {
             styledProps.css = css.toString()
@@ -214,6 +213,18 @@ object Styled {
         if (css.styleName.isNotEmpty()) {
             styledProps.asDynamic()["data-style"] = css.styleName.joinToString(separator = " ")
         }
+        return styledProps.unsafeCast<P>()
+    }
+
+    fun createElement(type: String, css: CSSBuilder, props: WithClassName, children: List<Any>): ReactElement {
+        val wrappedType = wrap(type)
+        val styledProps = buildStyledProps(css, props)
+        return createElement(wrappedType, styledProps, *children.toTypedArray())
+    }
+
+    fun <P: WithClassName> createElement(type: ComponentType<P>, css: CSSBuilder, props: P, children: List<Any>): ReactElement {
+        val wrappedType = wrap(type)
+        val styledProps = buildStyledProps(css, props)
         return createElement(wrappedType, styledProps, *children.toTypedArray())
     }
 }

--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -131,13 +131,13 @@ private fun injectGlobals(strings: Array<String>) {
 }
 
 private external interface GlobalStylesComponentProps : RProps {
-    var globalStyles: List<Any>
+    var globalStyles: List<ComponentType<RProps>>
 }
 
 private object GlobalStyles {
     private val component = functionalComponent<GlobalStylesComponentProps> { props ->
         props.globalStyles.forEach {
-            child(it.unsafeCast<ComponentType<RProps>>(), jsObject {}, emptyList())
+            child(it, jsObject {}, emptyList())
         }
     }
 
@@ -147,9 +147,9 @@ private object GlobalStyles {
         element
     }
 
-    private val styles = mutableListOf<Component<RProps, RState>>()
+    private val styles = mutableListOf<ComponentType<RProps>>()
 
-    fun add(globalStyle: Component<RProps, RState>) {
+    fun add(globalStyle: ComponentType<RProps>) {
         styles.add(globalStyle)
         val reactElement = createElement(component, jsObject {
             this.globalStyles = styles

--- a/kotlin-styled/src/main/kotlin/styled/styled-components.kt
+++ b/kotlin-styled/src/main/kotlin/styled/styled-components.kt
@@ -4,10 +4,7 @@
 package styled
 
 import kotlinext.js.TemplateTag
-import react.Component
-import react.RClass
-import react.RProps
-import react.RState
+import react.*
 import react.dom.WithClassName
 
 external interface StyledProps : WithClassName {
@@ -53,7 +50,7 @@ external val css: TemplateTag<dynamic, String>
  * isolated from other components. In the case of createGlobalStyle, this limitation is removed
  * and things like CSS resets or base stylesheets can be applied.
  */
-external val createGlobalStyle: TemplateTag<Nothing, Component<RProps, RState>>
+external val createGlobalStyle: TemplateTag<Nothing, ComponentType<RProps>>
 
 /**
  * A utility to help identify styled components.


### PR DESCRIPTION
`RBuilder` base child methods and `createElement` signature are strict.

These changes relates to #358 