### PR TITLE
`RBuilder.child` returns `Unit`

### DIFF
--- a/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOMTags.kt
+++ b/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOMTags.kt
@@ -7,40 +7,40 @@ import kotlinx.html.attributes.enumEncode
 import react.RBuilder
 import react.ReactElement
 
-inline fun <T : Tag> RBuilder.tag(block: RDOMBuilder<T>.() -> Unit, noinline factory: (TagConsumer<Unit>) -> T): ReactElement =
+inline fun <T : Tag> RBuilder.tag(block: RDOMBuilder<T>.() -> Unit, noinline factory: (TagConsumer<Unit>) -> T) =
     child(RDOMBuilder(factory).apply {
         block()
     }.create())
 
-inline fun RBuilder.a(href: String? = null, target: String? = null, classes: String? = null, block: RDOMBuilder<A>.() -> Unit): ReactElement =
+inline fun RBuilder.a(href: String? = null, target: String? = null, classes: String? = null, block: RDOMBuilder<A>.() -> Unit) =
     tag(block) { A(attributesMapOf("href", href, "target", target, "class", classes), it) }
 
-inline fun RBuilder.abbr(classes: String? = null, block: RDOMBuilder<ABBR>.() -> Unit): ReactElement = tag(block) { ABBR(attributesMapOf("class", classes), it) }
+inline fun RBuilder.abbr(classes: String? = null, block: RDOMBuilder<ABBR>.() -> Unit) = tag(block) { ABBR(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.address(classes: String? = null, block: RDOMBuilder<ADDRESS>.() -> Unit): ReactElement = tag(block) { ADDRESS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.address(classes: String? = null, block: RDOMBuilder<ADDRESS>.() -> Unit) = tag(block) { ADDRESS(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.area(shape: AreaShape? = null, alt: String? = null, classes: String? = null, block: RDOMBuilder<AREA>.() -> Unit): ReactElement =
+inline fun RBuilder.area(shape: AreaShape? = null, alt: String? = null, classes: String? = null, block: RDOMBuilder<AREA>.() -> Unit) =
     tag(block) { AREA(attributesMapOf("Shape", shape?.enumEncode(), "alt", alt, "class", classes), it) }
 
-inline fun RBuilder.article(classes: String? = null, block: RDOMBuilder<ARTICLE>.() -> Unit): ReactElement = tag(block) { ARTICLE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.article(classes: String? = null, block: RDOMBuilder<ARTICLE>.() -> Unit) = tag(block) { ARTICLE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.aside(classes: String? = null, block: RDOMBuilder<ASIDE>.() -> Unit): ReactElement = tag(block) { ASIDE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.aside(classes: String? = null, block: RDOMBuilder<ASIDE>.() -> Unit) = tag(block) { ASIDE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.audio(classes: String? = null, block: RDOMBuilder<AUDIO>.() -> Unit): ReactElement = tag(block) { AUDIO(attributesMapOf("class", classes), it) }
+inline fun RBuilder.audio(classes: String? = null, block: RDOMBuilder<AUDIO>.() -> Unit) = tag(block) { AUDIO(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.b(classes: String? = null, block: RDOMBuilder<B>.() -> Unit): ReactElement = tag(block) { B(attributesMapOf("class", classes), it) }
+inline fun RBuilder.b(classes: String? = null, block: RDOMBuilder<B>.() -> Unit) = tag(block) { B(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.base(classes: String? = null, block: RDOMBuilder<BASE>.() -> Unit): ReactElement = tag(block) { BASE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.base(classes: String? = null, block: RDOMBuilder<BASE>.() -> Unit) = tag(block) { BASE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.bdi(classes: String? = null, block: RDOMBuilder<BDI>.() -> Unit): ReactElement = tag(block) { BDI(attributesMapOf("class", classes), it) }
+inline fun RBuilder.bdi(classes: String? = null, block: RDOMBuilder<BDI>.() -> Unit) = tag(block) { BDI(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.bdo(classes: String? = null, block: RDOMBuilder<BDO>.() -> Unit): ReactElement = tag(block) { BDO(attributesMapOf("class", classes), it) }
+inline fun RBuilder.bdo(classes: String? = null, block: RDOMBuilder<BDO>.() -> Unit) = tag(block) { BDO(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.blockquote(classes: String? = null, block: RDOMBuilder<BLOCKQUOTE>.() -> Unit): ReactElement = tag(block) { BLOCKQUOTE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.blockquote(classes: String? = null, block: RDOMBuilder<BLOCKQUOTE>.() -> Unit) = tag(block) { BLOCKQUOTE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.body(classes: String? = null, block: RDOMBuilder<BODY>.() -> Unit): ReactElement = tag(block) { BODY(attributesMapOf("class", classes), it) }
+inline fun RBuilder.body(classes: String? = null, block: RDOMBuilder<BODY>.() -> Unit) = tag(block) { BODY(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.br(classes: String? = null, block: RDOMBuilder<BR>.() -> Unit): ReactElement = tag(block) { BR(attributesMapOf("class", classes), it) }
+inline fun RBuilder.br(classes: String? = null, block: RDOMBuilder<BR>.() -> Unit) = tag(block) { BR(attributesMapOf("class", classes), it) }
 
 inline fun RBuilder.button(
     formEncType: ButtonFormEncType? = null,
@@ -48,83 +48,83 @@ inline fun RBuilder.button(
     type: ButtonType? = null,
     classes: String? = null,
     block: RDOMBuilder<BUTTON>.() -> Unit,
-): ReactElement = tag(block) { BUTTON(attributesMapOf("formenctype", formEncType?.enumEncode(), "formmethod", formMethod?.enumEncode(), "type", type?.enumEncode(), "class", classes), it) }
+) = tag(block) { BUTTON(attributesMapOf("formenctype", formEncType?.enumEncode(), "formmethod", formMethod?.enumEncode(), "type", type?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.canvas(classes: String? = null, content: String = ""): ReactElement = tag({ +content }) { CANVAS(attributesMapOf("class", classes), it) }
-inline fun RBuilder.canvas(classes: String? = null, block: RDOMBuilder<CANVAS>.() -> Unit): ReactElement = tag(block) { CANVAS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.canvas(classes: String? = null, content: String = "") = tag({ +content }) { CANVAS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.canvas(classes: String? = null, block: RDOMBuilder<CANVAS>.() -> Unit) = tag(block) { CANVAS(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.caption(classes: String? = null, block: RDOMBuilder<CAPTION>.() -> Unit): ReactElement = tag(block) { CAPTION(attributesMapOf("class", classes), it) }
+inline fun RBuilder.caption(classes: String? = null, block: RDOMBuilder<CAPTION>.() -> Unit) = tag(block) { CAPTION(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.cite(classes: String? = null, block: RDOMBuilder<CITE>.() -> Unit): ReactElement = tag(block) { CITE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.cite(classes: String? = null, block: RDOMBuilder<CITE>.() -> Unit) = tag(block) { CITE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.code(classes: String? = null, block: RDOMBuilder<CODE>.() -> Unit): ReactElement = tag(block) { CODE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.code(classes: String? = null, block: RDOMBuilder<CODE>.() -> Unit) = tag(block) { CODE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.col(classes: String? = null, block: RDOMBuilder<COL>.() -> Unit): ReactElement = tag(block) { COL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.col(classes: String? = null, block: RDOMBuilder<COL>.() -> Unit) = tag(block) { COL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.colgroup(classes: String? = null, block: RDOMBuilder<COLGROUP>.() -> Unit): ReactElement = tag(block) { COLGROUP(attributesMapOf("class", classes), it) }
+inline fun RBuilder.colgroup(classes: String? = null, block: RDOMBuilder<COLGROUP>.() -> Unit) = tag(block) { COLGROUP(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.datalist(classes: String? = null, block: RDOMBuilder<DATALIST>.() -> Unit): ReactElement = tag(block) { DATALIST(attributesMapOf("class", classes), it) }
+inline fun RBuilder.datalist(classes: String? = null, block: RDOMBuilder<DATALIST>.() -> Unit) = tag(block) { DATALIST(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.dd(classes: String? = null, block: RDOMBuilder<DD>.() -> Unit): ReactElement = tag(block) { DD(attributesMapOf("class", classes), it) }
+inline fun RBuilder.dd(classes: String? = null, block: RDOMBuilder<DD>.() -> Unit) = tag(block) { DD(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.del(classes: String? = null, block: RDOMBuilder<DEL>.() -> Unit): ReactElement = tag(block) { DEL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.del(classes: String? = null, block: RDOMBuilder<DEL>.() -> Unit) = tag(block) { DEL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.details(classes: String? = null, block: RDOMBuilder<DETAILS>.() -> Unit): ReactElement = tag(block) { DETAILS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.details(classes: String? = null, block: RDOMBuilder<DETAILS>.() -> Unit) = tag(block) { DETAILS(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.dfn(classes: String? = null, block: RDOMBuilder<DFN>.() -> Unit): ReactElement = tag(block) { DFN(attributesMapOf("class", classes), it) }
+inline fun RBuilder.dfn(classes: String? = null, block: RDOMBuilder<DFN>.() -> Unit) = tag(block) { DFN(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.dialog(classes: String? = null, block: RDOMBuilder<DIALOG>.() -> Unit): ReactElement = tag(block) { DIALOG(attributesMapOf("class", classes), it) }
+inline fun RBuilder.dialog(classes: String? = null, block: RDOMBuilder<DIALOG>.() -> Unit) = tag(block) { DIALOG(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.div(classes: String? = null, block: RDOMBuilder<DIV>.() -> Unit): ReactElement = tag(block) { DIV(attributesMapOf("class", classes), it) }
+inline fun RBuilder.div(classes: String? = null, block: RDOMBuilder<DIV>.() -> Unit) = tag(block) { DIV(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.dl(classes: String? = null, block: RDOMBuilder<DL>.() -> Unit): ReactElement = tag(block) { DL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.dl(classes: String? = null, block: RDOMBuilder<DL>.() -> Unit) = tag(block) { DL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.dt(classes: String? = null, block: RDOMBuilder<DT>.() -> Unit): ReactElement = tag(block) { DT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.dt(classes: String? = null, block: RDOMBuilder<DT>.() -> Unit) = tag(block) { DT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.em(classes: String? = null, block: RDOMBuilder<EM>.() -> Unit): ReactElement = tag(block) { EM(attributesMapOf("class", classes), it) }
+inline fun RBuilder.em(classes: String? = null, block: RDOMBuilder<EM>.() -> Unit) = tag(block) { EM(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.embed(classes: String? = null, block: RDOMBuilder<EMBED>.() -> Unit): ReactElement = tag(block) { EMBED(attributesMapOf("class", classes), it) }
+inline fun RBuilder.embed(classes: String? = null, block: RDOMBuilder<EMBED>.() -> Unit) = tag(block) { EMBED(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.fieldset(classes: String? = null, block: RDOMBuilder<FIELDSET>.() -> Unit): ReactElement = tag(block) { FIELDSET(attributesMapOf("class", classes), it) }
+inline fun RBuilder.fieldset(classes: String? = null, block: RDOMBuilder<FIELDSET>.() -> Unit) = tag(block) { FIELDSET(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.figcaption(classes: String? = null, block: RDOMBuilder<FIGCAPTION>.() -> Unit): ReactElement = tag(block) { FIGCAPTION(attributesMapOf("class", classes), it) }
+inline fun RBuilder.figcaption(classes: String? = null, block: RDOMBuilder<FIGCAPTION>.() -> Unit) = tag(block) { FIGCAPTION(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.figure(classes: String? = null, block: RDOMBuilder<FIGURE>.() -> Unit): ReactElement = tag(block) { FIGURE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.figure(classes: String? = null, block: RDOMBuilder<FIGURE>.() -> Unit) = tag(block) { FIGURE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.footer(classes: String? = null, block: RDOMBuilder<FOOTER>.() -> Unit): ReactElement = tag(block) { FOOTER(attributesMapOf("class", classes), it) }
+inline fun RBuilder.footer(classes: String? = null, block: RDOMBuilder<FOOTER>.() -> Unit) = tag(block) { FOOTER(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.form(action: String? = null, encType: FormEncType? = null, method: FormMethod? = null, classes: String? = null, block: RDOMBuilder<FORM>.() -> Unit): ReactElement =
+inline fun RBuilder.form(action: String? = null, encType: FormEncType? = null, method: FormMethod? = null, classes: String? = null, block: RDOMBuilder<FORM>.() -> Unit) =
     tag(block) { FORM(attributesMapOf("action", action, "enctype", encType?.enumEncode(), "method", method?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.h1(classes: String? = null, block: RDOMBuilder<H1>.() -> Unit): ReactElement = tag(block) { H1(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h1(classes: String? = null, block: RDOMBuilder<H1>.() -> Unit) = tag(block) { H1(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.h2(classes: String? = null, block: RDOMBuilder<H2>.() -> Unit): ReactElement = tag(block) { H2(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h2(classes: String? = null, block: RDOMBuilder<H2>.() -> Unit) = tag(block) { H2(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.h3(classes: String? = null, block: RDOMBuilder<H3>.() -> Unit): ReactElement = tag(block) { H3(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h3(classes: String? = null, block: RDOMBuilder<H3>.() -> Unit) = tag(block) { H3(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.h4(classes: String? = null, block: RDOMBuilder<H4>.() -> Unit): ReactElement = tag(block) { H4(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h4(classes: String? = null, block: RDOMBuilder<H4>.() -> Unit) = tag(block) { H4(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.h5(classes: String? = null, block: RDOMBuilder<H5>.() -> Unit): ReactElement = tag(block) { H5(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h5(classes: String? = null, block: RDOMBuilder<H5>.() -> Unit) = tag(block) { H5(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.h6(classes: String? = null, block: RDOMBuilder<H6>.() -> Unit): ReactElement = tag(block) { H6(attributesMapOf("class", classes), it) }
+inline fun RBuilder.h6(classes: String? = null, block: RDOMBuilder<H6>.() -> Unit) = tag(block) { H6(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.head(block: RDOMBuilder<HEAD>.() -> Unit): ReactElement = tag(block) { HEAD(emptyMap, it) }
+inline fun RBuilder.head(block: RDOMBuilder<HEAD>.() -> Unit) = tag(block) { HEAD(emptyMap, it) }
 
-inline fun RBuilder.header(classes: String? = null, block: RDOMBuilder<HEADER>.() -> Unit): ReactElement = tag(block) { HEADER(attributesMapOf("class", classes), it) }
+inline fun RBuilder.header(classes: String? = null, block: RDOMBuilder<HEADER>.() -> Unit) = tag(block) { HEADER(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.hr(classes: String? = null, block: RDOMBuilder<HR>.() -> Unit): ReactElement = tag(block) { HR(attributesMapOf("class", classes), it) }
+inline fun RBuilder.hr(classes: String? = null, block: RDOMBuilder<HR>.() -> Unit) = tag(block) { HR(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.html(block: RDOMBuilder<HTML>.() -> Unit): ReactElement = tag(block) { HTML(emptyMap, it) }
+inline fun RBuilder.html(block: RDOMBuilder<HTML>.() -> Unit) = tag(block) { HTML(emptyMap, it) }
 
-inline fun RBuilder.i(classes: String? = null, block: RDOMBuilder<I>.() -> Unit): ReactElement = tag(block) { I(attributesMapOf("class", classes), it) }
+inline fun RBuilder.i(classes: String? = null, block: RDOMBuilder<I>.() -> Unit) = tag(block) { I(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.iframe(sandbox: IframeSandbox? = null, classes: String? = null, content: String = ""): ReactElement =
+inline fun RBuilder.iframe(sandbox: IframeSandbox? = null, classes: String? = null, content: String = "") =
     tag({ +content }) { IFRAME(attributesMapOf("sandbox", sandbox?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.iframe(sandbox: IframeSandbox? = null, classes: String? = null, block: RDOMBuilder<IFRAME>.() -> Unit): ReactElement =
+inline fun RBuilder.iframe(sandbox: IframeSandbox? = null, classes: String? = null, block: RDOMBuilder<IFRAME>.() -> Unit) =
     tag(block) { IFRAME(attributesMapOf("sandbox", sandbox?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.img(alt: String? = null, src: String? = null, classes: String? = null, block: RDOMBuilder<IMG>.() -> Unit): ReactElement =
+inline fun RBuilder.img(alt: String? = null, src: String? = null, classes: String? = null, block: RDOMBuilder<IMG>.() -> Unit) =
     tag(block) { IMG(attributesMapOf("alt", alt, "src", src, "class", classes), it) }
 
 inline fun RBuilder.input(
@@ -134,122 +134,122 @@ inline fun RBuilder.input(
     name: String? = null,
     classes: String? = null,
     block: RDOMBuilder<INPUT>.() -> Unit,
-): ReactElement =
+) =
     tag(block) { INPUT(attributesMapOf("type", type?.enumEncode(), "formenctype", formEncType?.enumEncode(), "formmethod", formMethod?.enumEncode(), "name", name, "class", classes), it) }
 
-inline fun RBuilder.ins(classes: String? = null, block: RDOMBuilder<INS>.() -> Unit): ReactElement = tag(block) { INS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.ins(classes: String? = null, block: RDOMBuilder<INS>.() -> Unit) = tag(block) { INS(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.kbd(classes: String? = null, block: RDOMBuilder<KBD>.() -> Unit): ReactElement = tag(block) { KBD(attributesMapOf("class", classes), it) }
+inline fun RBuilder.kbd(classes: String? = null, block: RDOMBuilder<KBD>.() -> Unit) = tag(block) { KBD(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.label(classes: String? = null, block: RDOMBuilder<LABEL>.() -> Unit): ReactElement = tag(block) { LABEL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.label(classes: String? = null, block: RDOMBuilder<LABEL>.() -> Unit) = tag(block) { LABEL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.legend(classes: String? = null, block: RDOMBuilder<LEGEND>.() -> Unit): ReactElement = tag(block) { LEGEND(attributesMapOf("class", classes), it) }
+inline fun RBuilder.legend(classes: String? = null, block: RDOMBuilder<LEGEND>.() -> Unit) = tag(block) { LEGEND(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.li(classes: String? = null, block: RDOMBuilder<LI>.() -> Unit): ReactElement = tag(block) { LI(attributesMapOf("class", classes), it) }
+inline fun RBuilder.li(classes: String? = null, block: RDOMBuilder<LI>.() -> Unit) = tag(block) { LI(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.link(href: String? = null, rel: String? = null, type: String? = null, block: RDOMBuilder<LINK>.() -> Unit): ReactElement =
+inline fun RBuilder.link(href: String? = null, rel: String? = null, type: String? = null, block: RDOMBuilder<LINK>.() -> Unit) =
     tag(block) { LINK(attributesMapOf("href", href, "rel", rel, "type", type), it) }
 
-inline fun RBuilder.main(classes: String? = null, block: RDOMBuilder<MAIN>.() -> Unit): ReactElement = tag(block) { MAIN(attributesMapOf("class", classes), it) }
+inline fun RBuilder.main(classes: String? = null, block: RDOMBuilder<MAIN>.() -> Unit) = tag(block) { MAIN(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.map(name: String? = null, classes: String? = null, block: RDOMBuilder<MAP>.() -> Unit): ReactElement = tag(block) { MAP(attributesMapOf("name", name, "class", classes), it) }
+inline fun RBuilder.map(name: String? = null, classes: String? = null, block: RDOMBuilder<MAP>.() -> Unit) = tag(block) { MAP(attributesMapOf("name", name, "class", classes), it) }
 
-inline fun RBuilder.mark(classes: String? = null, block: RDOMBuilder<MARK>.() -> Unit): ReactElement = tag(block) { MARK(attributesMapOf("class", classes), it) }
+inline fun RBuilder.mark(classes: String? = null, block: RDOMBuilder<MARK>.() -> Unit) = tag(block) { MARK(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.math(classes: String? = null, block: RDOMBuilder<MATH>.() -> Unit): ReactElement = tag(block) { MATH(attributesMapOf("class", classes), it) }
+inline fun RBuilder.math(classes: String? = null, block: RDOMBuilder<MATH>.() -> Unit) = tag(block) { MATH(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.meta(name: String? = null, content: String? = null, block: RDOMBuilder<META>.() -> Unit): ReactElement = tag(block) { META(attributesMapOf("name", name, "content", content), it) }
+inline fun RBuilder.meta(name: String? = null, content: String? = null, block: RDOMBuilder<META>.() -> Unit) = tag(block) { META(attributesMapOf("name", name, "content", content), it) }
 
-inline fun RBuilder.meter(classes: String? = null, block: RDOMBuilder<METER>.() -> Unit): ReactElement = tag(block) { METER(attributesMapOf("class", classes), it) }
+inline fun RBuilder.meter(classes: String? = null, block: RDOMBuilder<METER>.() -> Unit) = tag(block) { METER(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.nav(classes: String? = null, block: RDOMBuilder<NAV>.() -> Unit): ReactElement = tag(block) { NAV(attributesMapOf("class", classes), it) }
+inline fun RBuilder.nav(classes: String? = null, block: RDOMBuilder<NAV>.() -> Unit) = tag(block) { NAV(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.noscript(classes: String? = null, block: RDOMBuilder<NOSCRIPT>.() -> Unit): ReactElement = tag(block) { NOSCRIPT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.noscript(classes: String? = null, block: RDOMBuilder<NOSCRIPT>.() -> Unit) = tag(block) { NOSCRIPT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.objectTag(classes: String? = null, block: RDOMBuilder<OBJECT>.() -> Unit): ReactElement = tag(block) { OBJECT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.objectTag(classes: String? = null, block: RDOMBuilder<OBJECT>.() -> Unit) = tag(block) { OBJECT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.ol(classes: String? = null, block: RDOMBuilder<OL>.() -> Unit): ReactElement = tag(block) { OL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.ol(classes: String? = null, block: RDOMBuilder<OL>.() -> Unit) = tag(block) { OL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.optgroup(label: String? = null, classes: String? = null, block: RDOMBuilder<OPTGROUP>.() -> Unit): ReactElement =
+inline fun RBuilder.optgroup(label: String? = null, classes: String? = null, block: RDOMBuilder<OPTGROUP>.() -> Unit) =
     tag(block) { OPTGROUP(attributesMapOf("label", label, "class", classes), it) }
 
-inline fun RBuilder.option(classes: String? = null, content: String = ""): ReactElement = tag({ +content }) { OPTION(attributesMapOf("class", classes), it) }
-inline fun RBuilder.option(classes: String? = null, block: RDOMBuilder<OPTION>.() -> Unit): ReactElement = tag(block) { OPTION(attributesMapOf("class", classes), it) }
+inline fun RBuilder.option(classes: String? = null, content: String = "") = tag({ +content }) { OPTION(attributesMapOf("class", classes), it) }
+inline fun RBuilder.option(classes: String? = null, block: RDOMBuilder<OPTION>.() -> Unit) = tag(block) { OPTION(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.output(classes: String? = null, block: RDOMBuilder<OUTPUT>.() -> Unit): ReactElement = tag(block) { OUTPUT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.output(classes: String? = null, block: RDOMBuilder<OUTPUT>.() -> Unit) = tag(block) { OUTPUT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.p(classes: String? = null, block: RDOMBuilder<P>.() -> Unit): ReactElement = tag(block) { P(attributesMapOf("class", classes), it) }
+inline fun RBuilder.p(classes: String? = null, block: RDOMBuilder<P>.() -> Unit) = tag(block) { P(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.param(name: String? = null, value: String? = null, block: RDOMBuilder<PARAM>.() -> Unit): ReactElement = tag(block) { PARAM(attributesMapOf("name", name, "value", value), it) }
+inline fun RBuilder.param(name: String? = null, value: String? = null, block: RDOMBuilder<PARAM>.() -> Unit) = tag(block) { PARAM(attributesMapOf("name", name, "value", value), it) }
 
-inline fun RBuilder.picture(classes: String? = null, block: RDOMBuilder<PICTURE>.() -> Unit): ReactElement = tag(block) { PICTURE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.picture(classes: String? = null, block: RDOMBuilder<PICTURE>.() -> Unit) = tag(block) { PICTURE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.pre(classes: String? = null, block: RDOMBuilder<PRE>.() -> Unit): ReactElement = tag(block) { PRE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.pre(classes: String? = null, block: RDOMBuilder<PRE>.() -> Unit) = tag(block) { PRE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.progress(classes: String? = null, block: RDOMBuilder<PROGRESS>.() -> Unit): ReactElement = tag(block) { PROGRESS(attributesMapOf("class", classes), it) }
+inline fun RBuilder.progress(classes: String? = null, block: RDOMBuilder<PROGRESS>.() -> Unit) = tag(block) { PROGRESS(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.q(classes: String? = null, block: RDOMBuilder<Q>.() -> Unit): ReactElement = tag(block) { Q(attributesMapOf("class", classes), it) }
+inline fun RBuilder.q(classes: String? = null, block: RDOMBuilder<Q>.() -> Unit) = tag(block) { Q(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.rp(classes: String? = null, block: RDOMBuilder<RP>.() -> Unit): ReactElement = tag(block) { RP(attributesMapOf("class", classes), it) }
+inline fun RBuilder.rp(classes: String? = null, block: RDOMBuilder<RP>.() -> Unit) = tag(block) { RP(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.rt(classes: String? = null, block: RDOMBuilder<RT>.() -> Unit): ReactElement = tag(block) { RT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.rt(classes: String? = null, block: RDOMBuilder<RT>.() -> Unit) = tag(block) { RT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.ruby(classes: String? = null, block: RDOMBuilder<RUBY>.() -> Unit): ReactElement = tag(block) { RUBY(attributesMapOf("class", classes), it) }
+inline fun RBuilder.ruby(classes: String? = null, block: RDOMBuilder<RUBY>.() -> Unit) = tag(block) { RUBY(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.samp(classes: String? = null, block: RDOMBuilder<SAMP>.() -> Unit): ReactElement = tag(block) { SAMP(attributesMapOf("class", classes), it) }
+inline fun RBuilder.samp(classes: String? = null, block: RDOMBuilder<SAMP>.() -> Unit) = tag(block) { SAMP(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.script(type: String? = null, src: String? = null, block: RDOMBuilder<SCRIPT>.() -> Unit): ReactElement = tag(block) { SCRIPT(attributesMapOf("type", type, "src", src), it) }
+inline fun RBuilder.script(type: String? = null, src: String? = null, block: RDOMBuilder<SCRIPT>.() -> Unit) = tag(block) { SCRIPT(attributesMapOf("type", type, "src", src), it) }
 
-inline fun RBuilder.section(classes: String? = null, block: RDOMBuilder<SECTION>.() -> Unit): ReactElement = tag(block) { SECTION(attributesMapOf("class", classes), it) }
+inline fun RBuilder.section(classes: String? = null, block: RDOMBuilder<SECTION>.() -> Unit) = tag(block) { SECTION(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.select(classes: String? = null, block: RDOMBuilder<SELECT>.() -> Unit): ReactElement = tag(block) { SELECT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.select(classes: String? = null, block: RDOMBuilder<SELECT>.() -> Unit) = tag(block) { SELECT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.small(classes: String? = null, block: RDOMBuilder<SMALL>.() -> Unit): ReactElement = tag(block) { SMALL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.small(classes: String? = null, block: RDOMBuilder<SMALL>.() -> Unit) = tag(block) { SMALL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.source(classes: String? = null, block: RDOMBuilder<SOURCE>.() -> Unit): ReactElement = tag(block) { SOURCE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.source(classes: String? = null, block: RDOMBuilder<SOURCE>.() -> Unit) = tag(block) { SOURCE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.span(classes: String? = null, block: RDOMBuilder<SPAN>.() -> Unit): ReactElement = tag(block) { SPAN(attributesMapOf("class", classes), it) }
+inline fun RBuilder.span(classes: String? = null, block: RDOMBuilder<SPAN>.() -> Unit) = tag(block) { SPAN(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.strong(classes: String? = null, block: RDOMBuilder<STRONG>.() -> Unit): ReactElement = tag(block) { STRONG(attributesMapOf("class", classes), it) }
+inline fun RBuilder.strong(classes: String? = null, block: RDOMBuilder<STRONG>.() -> Unit) = tag(block) { STRONG(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.style(type: String? = null, content: String = ""): ReactElement = tag({ +content }) { STYLE(attributesMapOf("type", type), it) }
-inline fun RBuilder.style(type: String? = null, block: RDOMBuilder<STYLE>.() -> Unit): ReactElement = tag(block) { STYLE(attributesMapOf("type", type), it) }
+inline fun RBuilder.style(type: String? = null, content: String = "") = tag({ +content }) { STYLE(attributesMapOf("type", type), it) }
+inline fun RBuilder.style(type: String? = null, block: RDOMBuilder<STYLE>.() -> Unit) = tag(block) { STYLE(attributesMapOf("type", type), it) }
 
-inline fun RBuilder.sub(classes: String? = null, block: RDOMBuilder<SUB>.() -> Unit): ReactElement = tag(block) { SUB(attributesMapOf("class", classes), it) }
+inline fun RBuilder.sub(classes: String? = null, block: RDOMBuilder<SUB>.() -> Unit) = tag(block) { SUB(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.sup(classes: String? = null, block: RDOMBuilder<SUP>.() -> Unit): ReactElement = tag(block) { SUP(attributesMapOf("class", classes), it) }
+inline fun RBuilder.sup(classes: String? = null, block: RDOMBuilder<SUP>.() -> Unit) = tag(block) { SUP(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.svg(classes: String? = null, content: String = ""): ReactElement = tag({ +content }) { SVG(attributesMapOf("class", classes), it) }
-inline fun RBuilder.svg(classes: String? = null, block: RDOMBuilder<SVG>.() -> Unit): ReactElement = tag(block) { SVG(attributesMapOf("class", classes), it) }
+inline fun RBuilder.svg(classes: String? = null, content: String = "") = tag({ +content }) { SVG(attributesMapOf("class", classes), it) }
+inline fun RBuilder.svg(classes: String? = null, block: RDOMBuilder<SVG>.() -> Unit) = tag(block) { SVG(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.table(classes: String? = null, block: RDOMBuilder<TABLE>.() -> Unit): ReactElement = tag(block) { TABLE(attributesMapOf("class", classes), it) }
+inline fun RBuilder.table(classes: String? = null, block: RDOMBuilder<TABLE>.() -> Unit) = tag(block) { TABLE(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.tbody(classes: String? = null, block: RDOMBuilder<TBODY>.() -> Unit): ReactElement = tag(block) { TBODY(attributesMapOf("class", classes), it) }
+inline fun RBuilder.tbody(classes: String? = null, block: RDOMBuilder<TBODY>.() -> Unit) = tag(block) { TBODY(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.td(classes: String? = null, block: RDOMBuilder<TD>.() -> Unit): ReactElement = tag(block) { TD(attributesMapOf("class", classes), it) }
+inline fun RBuilder.td(classes: String? = null, block: RDOMBuilder<TD>.() -> Unit) = tag(block) { TD(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.textarea(rows: String? = null, cols: String? = null, wrap: TextAreaWrap? = null, classes: String? = null, content: String = ""): ReactElement =
+inline fun RBuilder.textarea(rows: String? = null, cols: String? = null, wrap: TextAreaWrap? = null, classes: String? = null, content: String = "") =
     tag({ +content }) { TEXTAREA(attributesMapOf("rows", rows, "cols", cols, "wrap", wrap?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.textarea(rows: String? = null, cols: String? = null, wrap: TextAreaWrap? = null, classes: String? = null, block: RDOMBuilder<TEXTAREA>.() -> Unit): ReactElement =
+inline fun RBuilder.textarea(rows: String? = null, cols: String? = null, wrap: TextAreaWrap? = null, classes: String? = null, block: RDOMBuilder<TEXTAREA>.() -> Unit) =
     tag(block) { TEXTAREA(attributesMapOf("rows", rows, "cols", cols, "wrap", wrap?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.tfoot(classes: String? = null, block: RDOMBuilder<TFOOT>.() -> Unit): ReactElement = tag(block) { TFOOT(attributesMapOf("class", classes), it) }
+inline fun RBuilder.tfoot(classes: String? = null, block: RDOMBuilder<TFOOT>.() -> Unit) = tag(block) { TFOOT(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.th(scope: ThScope? = null, classes: String? = null, block: RDOMBuilder<TH>.() -> Unit): ReactElement =
+inline fun RBuilder.th(scope: ThScope? = null, classes: String? = null, block: RDOMBuilder<TH>.() -> Unit) =
     tag(block) { TH(attributesMapOf("scope", scope?.enumEncode(), "class", classes), it) }
 
-inline fun RBuilder.thead(classes: String? = null, block: RDOMBuilder<THEAD>.() -> Unit): ReactElement = tag(block) { THEAD(attributesMapOf("class", classes), it) }
+inline fun RBuilder.thead(classes: String? = null, block: RDOMBuilder<THEAD>.() -> Unit) = tag(block) { THEAD(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.time(classes: String? = null, block: RDOMBuilder<TIME>.() -> Unit): ReactElement = tag(block) { TIME(attributesMapOf("class", classes), it) }
+inline fun RBuilder.time(classes: String? = null, block: RDOMBuilder<TIME>.() -> Unit) = tag(block) { TIME(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.title(content: String = ""): ReactElement = tag({ +content }) { TITLE(emptyMap, it) }
-inline fun RBuilder.title(block: RDOMBuilder<TITLE>.() -> Unit): ReactElement = tag(block) { TITLE(emptyMap, it) }
+inline fun RBuilder.title(content: String = "") = tag({ +content }) { TITLE(emptyMap, it) }
+inline fun RBuilder.title(block: RDOMBuilder<TITLE>.() -> Unit) = tag(block) { TITLE(emptyMap, it) }
 
-inline fun RBuilder.tr(classes: String? = null, block: RDOMBuilder<TR>.() -> Unit): ReactElement = tag(block) { TR(attributesMapOf("class", classes), it) }
+inline fun RBuilder.tr(classes: String? = null, block: RDOMBuilder<TR>.() -> Unit) = tag(block) { TR(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.ul(classes: String? = null, block: RDOMBuilder<UL>.() -> Unit): ReactElement = tag(block) { UL(attributesMapOf("class", classes), it) }
+inline fun RBuilder.ul(classes: String? = null, block: RDOMBuilder<UL>.() -> Unit) = tag(block) { UL(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.varTag(classes: String? = null, block: RDOMBuilder<VAR>.() -> Unit): ReactElement = tag(block) { VAR(attributesMapOf("class", classes), it) }
+inline fun RBuilder.varTag(classes: String? = null, block: RDOMBuilder<VAR>.() -> Unit) = tag(block) { VAR(attributesMapOf("class", classes), it) }
 
-inline fun RBuilder.video(classes: String? = null, block: RDOMBuilder<VIDEO>.() -> Unit): ReactElement = tag(block) { VIDEO(attributesMapOf("class", classes), it) }
+inline fun RBuilder.video(classes: String? = null, block: RDOMBuilder<VIDEO>.() -> Unit) = tag(block) { VIDEO(attributesMapOf("class", classes), it) }

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Dsl.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Dsl.kt
@@ -7,7 +7,7 @@ fun RBuilder.provider(
     store: Store<*, *, *>,
     context: Context<*>? = null,
     handler: RHandler<ProviderProps>,
-): ReactElement =
+) =
     child<ProviderProps, Provider> {
         attrs.store = store
         if (context != null) attrs.context = context

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -87,14 +87,14 @@ fun RBuilder.route(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
-    render: () -> ReactElement?,
+    render: RRender,
 ) {
     child<RouteProps<RProps>, RouteComponent<RProps>> {
         attrs {
             this.path = path
             this.exact = exact
             this.strict = strict
-            this.render = { render() }
+            this.render = { buildElements(render) }
         }
     }
 }

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -14,9 +14,8 @@ annotation class ReactDsl
 interface RBuilder {
     val childList: MutableList<Any>
 
-    fun <T : Child> child(element: T): T {
+    fun <T : Child> child(element: T) {
         childList.add(element)
-        return element
     }
 
     operator fun Child.unaryPlus() {
@@ -31,35 +30,35 @@ interface RBuilder {
         type: ComponentType<P>,
         props: P,
         children: List<Any>,
-    ): ReactElement =
+    ) =
         child(createElement(type, props, *children.toTypedArray()))
 
     fun <P : RProps> child(
         type: ComponentType<P>,
         props: P,
         handler: RHandler<P>,
-    ): ReactElement {
+    ) {
         val children = with(RElementBuilder(props)) {
             handler()
             childList
         }
-        return child(type, props, children)
+        child(type, props, children)
     }
 
     operator fun <P : RProps> ComponentType<P>.invoke(
         handler: RHandler<P>,
-    ): ReactElement =
+    ) =
         child(this, jsObject(), handler)
 
     operator fun <T> Provider<T>.invoke(
         value: T,
         handler: RHandler<ProviderProps<T>>,
-    ): ReactElement =
+    ) =
         child(this, jsObject { this.value = value }, handler)
 
     operator fun <T> Consumer<T>.invoke(
         handler: RBuilder.(T) -> Unit,
-    ): ReactElement =
+    ) =
         child(this, jsObject<ConsumerProps<T>> {
             this.children = { value ->
                 buildElements { handler(value) }
@@ -73,20 +72,20 @@ interface RBuilder {
     fun <P : RProps> RClass<P>.node(
         props: P,
         children: List<Any> = emptyList(),
-    ): ReactElement =
+    ) =
         child(this, clone(props), children)
 
     fun <P : RProps> child(
         klazz: KClass<out Component<P, *>>,
         handler: RHandler<P>,
-    ): ReactElement =
+    ) =
         klazz.rClass.invoke(handler)
 
     fun <T, P : RProps> childFunction(
         klazz: KClass<out Component<P, *>>,
         handler: RHandler<P>,
         children: RBuilder.(T) -> Unit,
-    ): ReactElement =
+    ) =
         child(
             type = klazz.rClass,
             props = RElementBuilder(jsObject<P>()).apply(handler).attrs,
@@ -101,7 +100,7 @@ interface RBuilder {
         klazz: KClass<out Component<P, *>>,
         props: P,
         children: List<Any> = emptyList(),
-    ): ReactElement =
+    ) =
         child(klazz.rClass, props, children)
 
     fun RProps.children() {
@@ -177,13 +176,13 @@ fun RBuilder(): RBuilder =
 
 inline fun <P : RProps, reified C : Component<P, *>> RBuilder.child(
     noinline handler: RHandler<P>,
-): ReactElement =
+) =
     child(C::class, handler)
 
 inline fun <T, P : RProps, reified C : Component<P, *>> RBuilder.childFunction(
     noinline handler: RHandler<P>,
     noinline children: RBuilder.(T) -> Unit,
-): ReactElement =
+) =
     childFunction(C::class, handler, children)
 
 @Deprecated(
@@ -193,7 +192,7 @@ inline fun <T, P : RProps, reified C : Component<P, *>> RBuilder.childFunction(
 inline fun <P : RProps, reified C : Component<P, *>> RBuilder.node(
     props: P,
     children: List<Any> = emptyList(),
-): ReactElement =
+) =
     child(C::class.rClass, props, children)
 
 open class RBuilderImpl : RBuilder {
@@ -264,14 +263,14 @@ fun <P : RProps> RBuilder.child(
     component: FC<P>,
     props: P = jsObject(),
     handler: RHandler<P> = {},
-): ReactElement =
+) =
     child(component, props, handler)
 
 fun <T, P : RProps> RBuilder.childFunction(
     component: FC<P>,
     handler: RHandler<P> = {},
     children: RBuilder.(T) -> Unit,
-): ReactElement =
+) =
     childFunction(component, jsObject<P>(), handler, children)
 
 fun <T, P : RProps> RBuilder.childFunction(
@@ -279,7 +278,7 @@ fun <T, P : RProps> RBuilder.childFunction(
     props: P,
     handler: RHandler<P> = {},
     children: RBuilder.(T) -> Unit,
-): ReactElement =
+) =
     child(
         type = component,
         props = RElementBuilder(props).apply(handler).attrs,

--- a/kotlin-ring-ui/src/main/kotlin/ringui/Dropdown.ext.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Dropdown.ext.kt
@@ -2,12 +2,11 @@ package ringui
 
 import react.RBuilder
 import react.RHandler
-import react.ReactElement
 
 fun RBuilder.Dropdown(
     anchor: dynamic,
     handler: RHandler<DropdownProps>,
-): ReactElement =
+) =
     Dropdown {
         attrs.anchor = anchor
 

--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -82,7 +82,7 @@ class StyledDOMBuilderImpl<out T : Tag>(factory: (TagConsumer<Unit>) -> T) : Sty
 
 typealias StyledHandler<P> = StyledElementBuilder<P>.() -> Unit
 
-fun <P : WithClassName> styled(type: RClass<P>): RBuilder.(StyledHandler<P>) -> ReactElement = { handler ->
+fun <P : WithClassName> styled(type: RClass<P>): RBuilder.(StyledHandler<P>) -> Unit = { handler ->
     child(with(StyledElementBuilder(type)) {
         handler()
         create()


### PR DESCRIPTION
# !!!WARNING: BREAKING CHANGE!!!
I recommend to increase version to `pre.300` to notify users that these changes are important. 

### Explanation
**React Original implementation:** render is element factory with signature: `(RProps) -> ReactElement`
**Kotlin Wrappers implementation:** render is builder invocation with signature: `RBuilder.(RProps) -> Unit`

`RBuilder.child` had strange signature `RBuilder.(RProps) -> ReactElement`.
 
As result controversial API led to strange side effects (e.g. `RBuilder.route` children were added to parent `RBuilder` and returned `ReactElement` was passed to child `RouteComponent` at the same time).

### Additional change
`RBuilder.route` receives `RRender` instead of `ReactElement` factory