### PR TITLE
Add interface for CSSBuilder injecting directly in styled components.

### DIFF
--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -160,6 +160,10 @@ private object GlobalStyles {
     }
 }
 
+fun injectGlobal(css: CSSBuilder) {
+    injectGlobal(css.toString())
+}
+
 /**
  * @deprecated Use [createGlobalStyle] instead
  */


### PR DESCRIPTION
Add interface for CSSBuilder injecting directly in styled components. It is needed because CSSBuilder contains already parsed rules, with which we can work directly in CSSOM later