### PR TITLE
Implement styled-components in kotlin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,7 @@ ring-ui.version=4.0.21
 # kotlin-styled
 styled.version=5.3.0
 
+# kotlin-styled-next
+styled-next.version=0.1
+
 wrappers-bom.version=0.0.1

--- a/kotlin-styled-next/README.md
+++ b/kotlin-styled-next/README.md
@@ -1,0 +1,183 @@
+[![Bintray](https://img.shields.io/bintray/v/kotlin/kotlin-js-wrappers/kotlin-styled)](https://bintray.com/kotlin/kotlin-js-wrappers/kotlin-styled)
+
+## kotlin-styled
+
+Kotlin wrappers for [styled-components](https://www.styled-components.com/) and [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer). 
+
+Major version number of this wrapper matches that of styled-components itself.
+
+### Installation
+
+1. `npm i @jetbrains/kotlin-css @jetbrains/kotlin-styled inline-style-prefixer styled-components`
+
+2. `npm run gen-idea-libs`
+
+See the [Bintray page](https://bintray.com/kotlin/kotlin-js-wrappers/kotlin-styled) for Maven and Gradle installation 
+instructions.
+
+### Getting Started
+
+`kotlin-styled` is a great fit for applications built using `kotlin-react`. It gives you not only a type-safe way of 
+authoring stylesheets, but it also takes care of adding vendor prefixes for your CSS rules, assembling stylesheets, 
+and injecting them into the DOM.
+
+If you are not familiar with [styled-components](https://www.styled-components.com/) or CSS-in-JS in general, now would 
+be a good time to [inform yourself about the concept](https://blog.codecarrot.net/all-you-need-to-know-about-css-in-js/), 
+because `kotlin-styled` implements this exact idea... in Kotlin.
+
+When using just `kotlin-react` you would create a regular CSS file and then you would reference CSS classes from Kotlin 
+like this:
+
+```kotlin
+fun RBuilder.div() {
+    div("some-class") {
+        +"Hello world!"
+    }
+}
+```
+
+With `kotlin-styled` you never have to leave Kotlin:
+
+```kotlin
+fun RBuilder.div() {
+    styledDiv {
+        css {
+            padding(vertical = 16.px)
+	        
+            backgroundColor = Color.green
+        }
+
+        +"Hello world!"
+    }
+}
+```
+
+While you can mix markup and styles in one-off scenarios like the example above, most times you would probably want to 
+have them separated to enable code reuse:
+
+```kotlin
+object ComponentStyles : StyleSheet("ComponentStyles", isStatic = true) {
+    val wrapper by css {
+        padding(vertical = 16.px)
+        
+        backgroundColor = Color.green
+    }
+}
+
+fun RBuilder.div() {
+    styledDiv {
+        css {
+            +ComponentStyles.wrapper
+        }
+
+        +"Hello world!"
+    }
+}
+```
+
+The latter is much easier to debug in the browser as well: when inspecting the element you'll see readable class names, 
+e.g. `class="ComponentStyles-wrapper"` rather than generated ones.
+
+### CSS Properties
+
+The DSL supports most common CSS properties and values, including animations, transforms, shadows, flexbox, and grids. 
+**SVG properties are not supported yet, contributions are welcome**. 
+However, you can use `put("property", "value")` syntax for any unsupported property:
+
+```kotlin
+fun RBuilder.div() {
+    styledDiv {
+        css {
+            put("will-change", "transform")
+        }
+    }
+}
+```
+
+### CSS Selectors
+
+The DSL allows you to use most CSS selectors. See 
+[CSSBuilder](https://github.com/JetBrains/kotlin-wrappers/blob/master/kotlin-css/src/main/kotlin/kotlinx/css/CSSBuilder.kt#L35)
+for more details. **Contributions are welcome**.
+
+After creating a `StyleSheet` just go ahead and start using it in a component, it will be injected automatically.
+
+```kotlin
+object ComponentStyles : StyleSheet("ComponentStyles") {
+    // Example of an ".element:hover" selector
+    val element by css {        
+        backgroundColor = Color.green
+        
+        hover {
+            backgroundColor = Color.red
+        }
+    }
+    
+    // Example of a ".wrapper > *" selector
+    val wrapper by css {
+        children {
+            // CSS properties
+        }
+    }
+    
+    // Example of a ".wrapper > div" selector
+    val wrapper by css {
+        children("div") {
+            // CSS properties
+        }
+    }
+    
+    // Example of a ".wrapper:hover .inner" selector 
+    val wrapper by css {
+        // CSS properties
+    }
+    
+    val inner by css {
+        backgroundColor = Color.green
+        
+        // Use reflection to refer to other elements, it's longer but safer than using hard-coded class names
+        ancestorHover("${ComponentStyles.name}-${ComponentStyles::wrapper.name}") {
+            backgroundColor = Color.red
+        }
+    }        
+}
+
+fun RBuilder.div() {
+    styledDiv {
+        css {
+            +ComponentStyles.element
+        }
+
+        +"An element"
+    }
+
+    styledDiv {
+        css {
+            +ComponentStyles.wrapper
+        }
+
+        styledDiv {
+            css {
+                +ComponentStyles.inner
+            }
+
+            +"Inner element"
+        }
+    }
+}
+```
+
+### Global Styles
+
+To create a global stylesheet use the `CSSBuilder` class and the `StyledComponents.injectGlobal()` function:
+
+```kotlin
+val styles = CSSBuilder().apply {
+    body {
+        margin(0.px)
+        padding(0.px)
+    }
+}
+
+StyledComponents.injectGlobal(styles)
+```

--- a/kotlin-styled-next/build.gradle.kts
+++ b/kotlin-styled-next/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("js")
+}
+
+dependencies {
+    api(project(":kotlin-extensions"))
+    api(project(":kotlin-css"))
+    api(project(":kotlin-react"))
+    api(project(":kotlin-react-dom"))
+
+    api(kotlinxHtml("js"))
+
+    api(npm("inline-style-prefixer", "^6.0.0"))
+}

--- a/kotlin-styled-next/gradle.properties
+++ b/kotlin-styled-next/gradle.properties
@@ -1,0 +1,2 @@
+description=Kotlin implementation of styled-components
+author=Konstantin Tretiakov

--- a/kotlin-styled-next/src/main/kotlin/styled/CSSBuilder.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/CSSBuilder.kt
@@ -1,0 +1,29 @@
+package styled
+
+import kotlinx.css.CSSBuilder
+import kotlinx.css.properties.*
+
+fun CSSBuilder.animation(
+    duration: Time = 0.s,
+    timing: Timing = Timing.ease,
+    delay: Time = 0.s,
+    iterationCount: IterationCount = 1.times,
+    direction: AnimationDirection = AnimationDirection.normal,
+    fillMode: FillMode = FillMode.none,
+    playState: PlayState = PlayState.running,
+    builder: KeyframesBuilder.() -> Unit
+) {
+    val name = GlobalStyles.scheduleToInject(builder)
+    put(
+        "animation", Animation(
+            duration,
+            timing,
+            delay,
+            iterationCount,
+            direction,
+            fillMode,
+            playState,
+            name
+        ).toString()
+    )
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
@@ -1,0 +1,112 @@
+package styled
+
+import kotlinx.browser.window
+import kotlinx.css.CSSBuilder
+import kotlinx.css.properties.KeyframesBuilder
+import org.w3c.dom.HTMLStyleElement
+import org.w3c.dom.css.CSSStyleSheet
+import kotlin.collections.*
+
+/**
+ * Inject css code, defined in [css], to the DOM
+ */
+fun injectGlobal(css: CSSBuilder) {
+    GlobalStyles.scheduleToInject(css.toStyledCss().getCssRules(null))
+    GlobalStyles.injectScheduled()
+}
+
+object GlobalStyles {
+    private val sheet by lazy {
+        val style = window.document.head!!.appendChild(window.document.createElement("style")) as HTMLStyleElement
+        style.setAttribute("id", "ksc-global-styles")
+        style.sheet as CSSStyleSheet
+    }
+
+    private var incrementedClassName: Int = 0
+        get() {
+            field++
+            return field
+        }
+
+    private val styledClasses = LinkedHashMap<StyledCss, ClassName>()
+    private val scheduledRules = mutableListOf<String>()
+    private val injectedStyleSheetRules = mutableSetOf<Selector>()
+
+    private fun getInjectedClassName(css: StyledCss): ClassName {
+        val className = styledClasses[css]
+        return className ?: scheduleToInjectClassName(css)
+    }
+
+    private fun scheduleToInjectClassName(css: StyledCss): ClassName {
+        val className = "ksc-$incrementedClassName"
+        styledClasses[css] = className
+        val selector = ".$className"
+        scheduledRules.addAll(css.getCssRules(selector))
+        return className
+    }
+
+    /**
+     * Inject all the scheduled rules to a DOM and clear the [scheduledRules]
+     * If the rule cannot be parsed by the browser, it gets thrown away.
+     */
+    fun injectScheduled() {
+        var maxIdx = sheet.cssRules.length
+        for (rule in scheduledRules.filter { it.isNotEmpty() }) {
+            try {
+                sheet.insertRule(rule, maxIdx)
+                maxIdx++
+            } catch (e: Throwable) {
+                /* Browser does not support the rule */
+            }
+        }
+        scheduledRules.clear()
+    }
+
+    /**
+     * Schedule [rules] for inject to DOM.
+     * They will be injected when the [injectScheduled] function will be called next time
+     */
+    fun scheduleToInject(rules: List<String>) {
+        scheduledRules.addAll(rules)
+    }
+
+    /**
+     * Schedule css from [builder] for inject to DOM with the corresponding [selector].
+     * They will be injected when the [injectScheduled] function will be called next time
+     */
+    fun scheduleToInject(selector: Selector, builder: CSSBuilder) {
+        if (!injectedStyleSheetRules.contains(selector)) {
+            val styled = builder.toStyledCss()
+            scheduleToInject(styled.getCssRules(selector))
+            injectedStyleSheetRules.add(selector)
+        }
+    }
+
+    private val injectedKeyframes = mutableMapOf<StyledKeyframes, ClassName>()
+
+    /**
+     * Schedule keyframes css in [builder] for inject to DOM.
+     * They will be injected when the [injectScheduled] function will be called next time
+     */
+    fun scheduleToInject(builder: KeyframesBuilder.() -> Unit): ClassName {
+        val keyframes = KeyframesBuilder().apply(builder).toStyledKeyframes()
+        return injectedKeyframes[keyframes] ?: "ksc-keyframe-$incrementedClassName".also { keyframeName ->
+            val css = keyframes.toString()
+            injectedKeyframes[keyframes] = keyframeName
+            val prefixes = listOf("@-webkit-keyframes", "@keyframes")
+            scheduleToInject(prefixes.map { prefix -> "$prefix $keyframeName { $css }" })
+        }
+    }
+
+    /**
+     * @return list of classnames for the css, declared in [css].
+     * If the CSS code for the [css] was not injected to DOM previously, it is injected after function call
+     */
+
+    fun getInjectedClassNames(css: CSSBuilder): List<ClassName> {
+        val styledCss = css.toStyledCss()
+        val selfClassName = getInjectedClassName(styledCss)
+        val externalClassNames = styledCss.classes
+        return listOf(selfClassName) + externalClassNames
+    }
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/InlineStylePrefixer.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/InlineStylePrefixer.kt
@@ -1,0 +1,20 @@
+@file:JsModule("inline-style-prefixer")
+@file:JsNonModule
+
+package styled
+
+/**
+ * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/prefix.md)
+ *
+ * @param data an object containing a valid prefixMap and a plugins list
+ * @return custom prefix function
+ */
+external fun createPrefixer(data: dynamic): dynamic
+
+/**
+ * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/createPrefixer.md)
+ *
+ * @param style an object containing valid style declarations
+ * @return an object containing all style declarations with vendor prefixes
+ */
+external fun prefix(style: dynamic): dynamic

--- a/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
@@ -1,0 +1,51 @@
+package styled
+
+import kotlinext.js.Object
+import kotlinext.js.js
+import kotlinx.css.StyledElement
+import react.dom.RDOMBuilder
+import react.dom.setProp
+
+// Inserts vendor prefixes (using inline-style-prefixer) and sets the style attribute
+fun RDOMBuilder<*>.inlineStyles(prefix: Boolean = true, builder: StyledElement.() -> Unit) {
+    val styles = StyledElement()
+    builder(styles)
+    setProp("style", styles.toStyle(prefix))
+}
+
+@JsName("Array")
+private external class JsArray
+
+fun StyledElement.toStyle(prefix: Boolean = true): Any {
+    val res = js { }
+    declarations.forEach { (key, value) ->
+        res[key] = when (value) {
+            is String, is Number -> value
+            else -> value.toString()
+        }
+    }
+
+    if (!prefix) {
+        return res
+    }
+
+    val prefixed = prefix(res) as Object
+
+    // https://inline-style-prefixer.js.org/docs/guides/ResolvingArrays.html
+    Object.keys(prefixed).forEach {
+        if (prefixed.hasOwnProperty(it)) {
+            @Suppress("UNUSED_VARIABLE")
+            val value = prefixed.asDynamic()[it]
+
+            @Suppress("UnsafeCastFromDynamic")
+            if (value is JsArray) {
+                // Find the unprefixed value in the array and use it: multiple values don't work for some reason
+                val displayValue = value.find(js("function(element) { return !element.startsWith('-') }"))
+
+                prefixed.asDynamic()[it] = displayValue
+            }
+        }
+    }
+
+    return prefixed
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
@@ -1,0 +1,91 @@
+package styled
+
+import kotlinx.css.CSSBuilder
+import kotlinx.css.RuleSet
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.KProperty0
+
+open class StyleSheet(var name: String, val isStatic: Boolean = false) {
+    private val holders: MutableList<CssHolder> = mutableListOf()
+
+    constructor(name: String, parent: StyleSheet, isStatic: Boolean = false) : this(parent.name + "-" + name, isStatic)
+
+    fun css(vararg parents: RuleSet, builder: RuleSet) =
+        CssHolder(this, *parents, builder)
+            .also { addCssHolder(it) }
+
+    internal fun addCssHolder(holder: CssHolder) {
+        holders.add(holder)
+    }
+
+    fun inject() {
+        scheduleToInject()
+        GlobalStyles.injectScheduled()
+    }
+
+    fun scheduleToInject() {
+        holders.forEach {
+            it.scheduleToInject()
+        }
+    }
+}
+
+class CssHolder(private val sheet: StyleSheet, internal vararg val ruleSets: RuleSet) {
+    private val classNamesToInject = mutableMapOf<ClassName, Boolean>()
+
+    val css by lazy {
+        CSSBuilder(allowClasses = false).apply {
+            this@CssHolder.ruleSets.map { it() }
+        }
+    }
+
+    private fun scheduleToInject(className: String) {
+        if (classNamesToInject[className] == true) {
+            classNamesToInject[className] = false
+            GlobalStyles.scheduleToInject(".$className", css)
+        }
+    }
+
+    fun scheduleToInject() {
+        classNamesToInject.keys.forEach { className ->
+            scheduleToInject(className)
+        }
+    }
+
+    operator fun provideDelegate(thisRef: Any?, providingProperty: KProperty<*>): ReadOnlyProperty<Any?, RuleSet> {
+        val className = sheet.getClassName(providingProperty)
+        classNamesToInject[className] = true
+        return ReadOnlyProperty { _, property ->
+            {
+                if (sheet.isStatic) {
+                    scheduleToInject(className)
+                    classes.add(className)
+                }
+                if (!sheet.isStatic || !allowClasses) {
+                    styleName.add(sheet.getClassName(property))
+                    ruleSets.forEach { it() }
+                }
+            }
+        }
+    }
+}
+
+fun <T : StyleSheet> T.getClassName(getClass: (T) -> KProperty0<RuleSet>): String {
+    return getClassName(getClass(this))
+}
+
+private fun StyleSheet.getClassName(property: KProperty<*>): String {
+    return "$name-${property.name}"
+}
+
+fun <T : StyleSheet> T.getClassSelector(getClass: (T) -> KProperty0<RuleSet>): String {
+    return ".${getClassName(getClass)}"
+}
+
+/**
+ * Use this function to assign a CSS class without any properties to an element
+ */
+fun StyleSheet.cssMarker() =
+    CssHolder(this, {})
+        .also { addCssHolder(it) }

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
@@ -1,0 +1,142 @@
+package styled
+
+import kotlinext.js.clone
+import kotlinext.js.jsObject
+import kotlinx.css.CSSBuilder
+import kotlinx.css.RuleSet
+import kotlinx.html.*
+import react.*
+import react.dom.DOMProps
+import react.dom.RDOMBuilder
+import react.dom.RDOMBuilderImpl
+import react.dom.WithClassName
+
+typealias AnyTagStyledBuilder = StyledDOMBuilder<CommonAttributeGroupFacade>
+typealias AnyBuilder = AnyTagStyledBuilder.() -> Unit
+
+typealias HTMLTagBuilder = StyledDOMBuilder<HTMLTag>.() -> Unit
+
+typealias ABuilder = StyledDOMBuilder<A>.() -> Unit
+typealias DIVBuilder = StyledDOMBuilder<DIV>.() -> Unit
+typealias SPANBuilder = StyledDOMBuilder<SPAN>.() -> Unit
+typealias INPUTBuilder = StyledDOMBuilder<INPUT>.() -> Unit
+
+external interface CustomStyledProps : RProps {
+    var css: ArrayList<RuleSet>?
+}
+
+inline fun CustomStyledProps.forwardCss(builder: CSSBuilder) {
+    css?.forEach { it(builder) }
+}
+
+inline fun CustomStyledProps.forwardCss(props: CustomStyledProps) {
+    css?.forEach { c ->
+        if (props.css == null) {
+            props.css = ArrayList()
+        }
+        props.css!!.add(c)
+    }
+}
+
+interface StyledBuilder<P : WithClassName> {
+    val css: CSSBuilder
+    val type: Any
+}
+
+inline fun StyledBuilder<*>.css(handler: RuleSet) = css.handler()
+
+interface StyledElementBuilder<P : WithClassName> : RElementBuilder<P>, StyledBuilder<P> {
+    fun create(): ReactElement
+
+    companion object {
+        operator fun <P : WithClassName> invoke(
+            type: ComponentType<P>,
+            attrs: P = jsObject(),
+        ): StyledElementBuilder<P> = StyledElementBuilderImpl(type, attrs)
+    }
+}
+
+class StyledElementBuilderImpl<P : WithClassName>(
+    override val type: ComponentType<P>,
+    attrs: P = jsObject(),
+) : StyledElementBuilder<P>, RElementBuilderImpl<P>(attrs) {
+    override val css = CSSBuilder()
+
+    override fun create() = Styled.createElement(type, css, attrs, childList)
+}
+
+@ReactDsl
+interface StyledDOMBuilder<out T : Tag> : RDOMBuilder<T>, StyledBuilder<DOMProps> {
+    override val type get() = attrs.tagName
+
+    override fun create() = Styled.createElement(type, css, domProps, childList)
+
+    companion object {
+        operator fun <T : Tag> invoke(factory: (TagConsumer<Unit>) -> T): StyledDOMBuilder<T> =
+            StyledDOMBuilderImpl(factory)
+    }
+}
+
+class StyledDOMBuilderImpl<out T : Tag>(factory: (TagConsumer<Unit>) -> T) : StyledDOMBuilder<T>,
+    RDOMBuilderImpl<T>(factory) {
+    override val css = CSSBuilder()
+}
+
+typealias StyledHandler<P> = StyledElementBuilder<P>.() -> Unit
+
+fun <P : WithClassName> styled(type: RClass<P>): RBuilder.(StyledHandler<P>) -> Unit = { handler ->
+    child(with(StyledElementBuilder(type)) {
+        handler()
+        create()
+    })
+}
+
+inline fun CustomStyledProps.css(noinline handler: RuleSet) {
+    if (css == null) {
+        css = ArrayList()
+    }
+    css!!.add(handler)
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <P : CustomStyledProps> RElementBuilder<P>.css(noinline handler: RuleSet) = attrs.css(handler)
+
+
+external interface StyledProps : WithClassName {
+    var css: CSSBuilder
+}
+
+fun customStyled(type: String): ComponentType<StyledProps> {
+    val fc = forwardRef<StyledProps> { props, rRef ->
+        val css = props.css
+        val classNames = useMemo(css) {
+            GlobalStyles.getInjectedClassNames(css).joinToString(" ").also {
+                GlobalStyles.injectScheduled()
+            }
+        }
+
+        val newProps = clone(props)
+        newProps.className = (if (props.className != undefined) props.className else "") + classNames
+        newProps.ref = rRef
+        newProps.asDynamic().css = undefined
+        child(createElement(type, newProps))
+    }
+    fc.asDynamic().displayName = "styled${type.replaceFirstChar { it.titlecase() }}"
+    return fc
+}
+
+object Styled {
+    private val cache = mutableMapOf<dynamic, dynamic>()
+
+    private fun wrap(type: dynamic) =
+        cache.getOrPut<dynamic, ComponentType<StyledProps>>(type) {
+            customStyled(type)
+        }
+
+    fun createElement(type: Any, css: CSSBuilder, props: WithClassName, children: List<Any>): ReactElement {
+        val wrappedType = wrap(type)
+        val styledProps = props.unsafeCast<StyledProps>()
+        styledProps.css = css
+        return createElement(wrappedType, styledProps, *children.toTypedArray())
+    }
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -1,0 +1,175 @@
+package styled
+
+import kotlinx.css.*
+import kotlinx.css.properties.*
+
+internal typealias ClassName = String
+internal typealias Selector = String
+
+internal data class StyledRule(val selector: String, val passStaticClassesToParent: Boolean = false, val css: StyledCss) {
+    private var memoizedHashCode: Int? = null
+
+    override fun hashCode(): Int {
+        return memoizedHashCode ?: (selector.hashCode() + css.hashCode()).also { hash -> memoizedHashCode = hash }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as StyledRule
+
+        return hashCode() == other.hashCode()
+                && selector == other.selector
+                && css == other.css
+    }
+}
+
+/**
+ * StyledCss is used to efficiently build css rules from the DSL representation.
+ */
+internal open class StyledCss(
+    declarations: LinkedHashMap<String, Any>?,
+    private val rules: List<StyledRule>,
+    val classes: List<String>,
+) {
+    private val declarations = buildString {
+        declarations?.forEach { outer ->
+            append("${outer.key.hyphenize()}: ${outer.value};\n")
+        }
+    }
+
+    private fun buildRules(indent: String = ""): List<String> {
+        return rules.filter { (selector) -> !withAmpersand(selector) && !withMedia(selector) }.flatMap { (selector, _, css) ->
+            css.getCssRules(selector, "  $indent")
+        }
+    }
+
+    private var memoizedHashCode: Int? = null
+    override fun hashCode(): Int {
+        return memoizedHashCode ?: (rules.sumOf { it.hashCode() } + declarations.hashCode())
+            .also { hashCode -> memoizedHashCode = hashCode }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as StyledCss
+
+        return hashCode() == other.hashCode()
+                && rules == other.rules
+                && declarations == other.declarations
+    }
+
+    /**
+     * @param outerSelector is the selector
+     * @param indent is indentation for the pretty resulting CSS string representation
+     * @return the list of built rules in string representation.
+     * Each resulting rule can be injected to a CSS Object Model or plain stylesheet.
+     */
+    fun getCssRules(outerSelector: String?, indent: String = ""): List<String> {
+        val result = mutableListOf<String>()
+        val (ampersandRules, rules) = rules.partition { withAmpersand(it.selector) }
+        if (rules.isNotEmpty() || declarations.isNotEmpty()) {
+            if (outerSelector != null) {
+                result.add(
+                    buildString {
+                        append("$indent$outerSelector {\n")
+                        append(declarations)
+                        append("$indent}\n")
+                        buildRules(indent).forEach { result.add("$outerSelector $it\n") }
+                    }
+                )
+            } else {
+                result.addAll(buildRules(indent))
+            }
+        }
+
+        rules.filter { withMedia(it.selector) }.forEach { (selector, _, css) ->
+            result.add(
+                buildString {
+                    append("$indent$selector {\n")
+                    css.getCssRules(outerSelector, "  $indent").forEach { appendLine(it); }
+                    append("$indent}\n")
+                }
+            )
+        }
+
+        ampersandRules.forEach {
+            result.add(
+                buildString {
+                    val selector = resolveRelativeSelector(it.selector, outerSelector!!)
+                    result.addAll(it.css.getCssRules(selector, indent))
+                }
+            )
+        }
+        return result
+    }
+
+    private fun withAmpersand(selector: String): Boolean {
+        return selector.contains("&")
+    }
+
+    private fun withMedia(selector: String): Boolean {
+        return selector.trim().startsWith("@media")
+    }
+
+    private fun resolveRelativeSelector(selector: Selector, selfClassName: ClassName): String {
+        return selector.replace("&", selfClassName)
+    }
+}
+
+private fun Rule.toStyledRule(parent: RuleContainer, block: RuleSet = this.block): StyledRule {
+    return StyledRule(
+        selector,
+        passStaticClassesToParent,
+        CSSBuilder(allowClasses = false, parent = if (passStaticClassesToParent) parent else null).apply { block() }.toStyledCss()
+    )
+}
+
+/**
+ * @return all [multiRules], but only first occurrence of a regular rule from [rules]
+ */
+private fun resolveRules(rules: List<Rule>, multiRules: List<Rule>, parent: RuleContainer): List<StyledRule> {
+    val resolvedRules = LinkedHashMap<String, Rule>()
+    val newRules = mutableListOf<StyledRule>()
+    rules.forEach {
+        if (!resolvedRules.containsKey(it.selector)) {
+            resolvedRules[it.selector] = it
+        }
+        newRules.add(resolvedRules[it.selector]!!.toStyledRule(parent, it.block))
+    }
+    newRules.addAll(multiRules.map { it.toStyledRule(parent) })
+    return newRules
+}
+
+internal fun CSSBuilder.toStyledCss(): StyledCss {
+    val resolvedRules = resolveRules(rules = rules, multiRules = multiRules, parent = this)
+    return StyledCss(declarations, rules = resolvedRules, classes = classes)
+}
+
+internal class StyledKeyframes(private val rules: List<StyledRule>) {
+    override fun hashCode(): Int {
+        return rules.sumOf { it.hashCode() }
+    }
+
+    override fun toString(): String {
+        return buildString {
+            rules.forEach { (selector, _, css) ->
+                append(css.getCssRules(selector).joinToString("\n"))
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as StyledKeyframes
+        return rules == other.rules
+    }
+}
+
+internal fun KeyframesBuilder.toStyledKeyframes(): StyledKeyframes {
+    val resolvedRules = resolveRules(rules = rules, multiRules = multiRules, parent = this)
+    return StyledKeyframes(rules = resolvedRules)
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledTags.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledTags.kt
@@ -1,0 +1,391 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package styled
+
+import kotlinx.html.*
+import kotlinx.html.attributes.enumEncode
+import react.RBuilder
+
+/* HTML elements according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element */
+
+inline fun <T : Tag> RBuilder.styledTag(
+    block: StyledDOMBuilder<T>.() -> Unit,
+    noinline factory: (TagConsumer<Unit>) -> T
+) = child(StyledDOMBuilder(factory).apply(block).create())
+
+/* Main root */
+
+inline fun RBuilder.styledHtml(block: StyledDOMBuilder<HTML>.() -> Unit) = styledTag(block) { HTML(emptyMap, it) }
+
+/* Document metadata */
+
+inline fun RBuilder.styledBase(block: StyledDOMBuilder<BASE>.() -> Unit) = styledTag(block) { BASE(emptyMap, it) }
+
+inline fun RBuilder.styledHead(block: StyledDOMBuilder<HEAD>.() -> Unit) = styledTag(block) { HEAD(emptyMap, it) }
+
+inline fun RBuilder.styledLink(
+    href: String? = null,
+    rel: String? = null,
+    type: String? = null,
+    block: StyledDOMBuilder<LINK>.() -> Unit
+) = styledTag(block) { LINK(attributesMapOf("href", href, "rel", rel, "type", type), it) }
+
+inline fun RBuilder.styledMeta(
+    name: String? = null,
+    content: String? = null,
+    block: StyledDOMBuilder<META>.() -> Unit
+) = styledTag(block) { META(attributesMapOf("name", name, "content", content), it) }
+
+inline fun RBuilder.styledStyle(type: String? = null, content: String = "") =
+    styledTag({ +content }) { STYLE(attributesMapOf("type", type), it) }
+
+inline fun RBuilder.styledStyle(type: String? = null, block: StyledDOMBuilder<STYLE>.() -> Unit) =
+    styledTag(block) { STYLE(attributesMapOf("type", type), it) }
+
+inline fun RBuilder.styledTitle(content: String = "") = styledTag({ +content }) { TITLE(emptyMap, it) }
+inline fun RBuilder.styledTitle(block: StyledDOMBuilder<TITLE>.() -> Unit) = styledTag(block) { TITLE(emptyMap, it) }
+
+/* Sectioning root */
+
+inline fun RBuilder.styledBody(block: StyledDOMBuilder<BODY>.() -> Unit) = styledTag(block) { BODY(emptyMap, it) }
+
+/* Content sectioning */
+
+inline fun RBuilder.styledAddress(block: StyledDOMBuilder<ADDRESS>.() -> Unit) =
+    styledTag(block) { ADDRESS(emptyMap, it) }
+
+inline fun RBuilder.styledArticle(block: StyledDOMBuilder<ARTICLE>.() -> Unit) =
+    styledTag(block) { ARTICLE(emptyMap, it) }
+
+inline fun RBuilder.styledAside(block: StyledDOMBuilder<ASIDE>.() -> Unit) = styledTag(block) { ASIDE(emptyMap, it) }
+
+inline fun RBuilder.styledFooter(block: StyledDOMBuilder<FOOTER>.() -> Unit) = styledTag(block) { FOOTER(emptyMap, it) }
+
+inline fun RBuilder.styledHeader(block: StyledDOMBuilder<HEADER>.() -> Unit) = styledTag(block) { HEADER(emptyMap, it) }
+
+inline fun RBuilder.styledH1(block: StyledDOMBuilder<H1>.() -> Unit) = styledTag(block) { H1(emptyMap, it) }
+
+inline fun RBuilder.styledH2(block: StyledDOMBuilder<H2>.() -> Unit) = styledTag(block) { H2(emptyMap, it) }
+
+inline fun RBuilder.styledH3(block: StyledDOMBuilder<H3>.() -> Unit) = styledTag(block) { H3(emptyMap, it) }
+
+inline fun RBuilder.styledH4(block: StyledDOMBuilder<H4>.() -> Unit) = styledTag(block) { H4(emptyMap, it) }
+
+inline fun RBuilder.styledH5(block: StyledDOMBuilder<H5>.() -> Unit) = styledTag(block) { H5(emptyMap, it) }
+
+inline fun RBuilder.styledH6(block: StyledDOMBuilder<H6>.() -> Unit) = styledTag(block) { H6(emptyMap, it) }
+
+inline fun RBuilder.styledMain(block: StyledDOMBuilder<MAIN>.() -> Unit) = styledTag(block) { MAIN(emptyMap, it) }
+
+inline fun RBuilder.styledNav(block: StyledDOMBuilder<NAV>.() -> Unit) = styledTag(block) { NAV(emptyMap, it) }
+
+inline fun RBuilder.styledSection(block: StyledDOMBuilder<SECTION>.() -> Unit) =
+    styledTag(block) { SECTION(emptyMap, it) }
+
+/* Text content */
+
+inline fun RBuilder.styledBlockquote(block: StyledDOMBuilder<BLOCKQUOTE>.() -> Unit) =
+    styledTag(block) { BLOCKQUOTE(emptyMap, it) }
+
+inline fun RBuilder.styledDd(block: StyledDOMBuilder<DD>.() -> Unit) = styledTag(block) { DD(emptyMap, it) }
+
+inline fun RBuilder.styledDiv(block: StyledDOMBuilder<DIV>.() -> Unit) = styledTag(block) { DIV(emptyMap, it) }
+
+inline fun RBuilder.styledDl(block: StyledDOMBuilder<DL>.() -> Unit) = styledTag(block) { DL(emptyMap, it) }
+
+inline fun RBuilder.styledDt(block: StyledDOMBuilder<DT>.() -> Unit) = styledTag(block) { DT(emptyMap, it) }
+
+inline fun RBuilder.styledFigcaption(block: StyledDOMBuilder<FIGCAPTION>.() -> Unit) =
+    styledTag(block) { FIGCAPTION(emptyMap, it) }
+
+inline fun RBuilder.styledFigure(block: StyledDOMBuilder<FIGURE>.() -> Unit) = styledTag(block) { FIGURE(emptyMap, it) }
+
+inline fun RBuilder.styledHr(block: StyledDOMBuilder<HR>.() -> Unit) = styledTag(block) { HR(emptyMap, it) }
+
+inline fun RBuilder.styledLi(block: StyledDOMBuilder<LI>.() -> Unit) = styledTag(block) { LI(emptyMap, it) }
+
+inline fun RBuilder.styledOl(block: StyledDOMBuilder<OL>.() -> Unit) = styledTag(block) { OL(emptyMap, it) }
+
+inline fun RBuilder.styledP(block: StyledDOMBuilder<P>.() -> Unit) = styledTag(block) { P(emptyMap, it) }
+
+inline fun RBuilder.styledPre(block: StyledDOMBuilder<PRE>.() -> Unit) = styledTag(block) { PRE(emptyMap, it) }
+
+inline fun RBuilder.styledUl(block: StyledDOMBuilder<UL>.() -> Unit) = styledTag(block) { UL(emptyMap, it) }
+
+/* Inline text semantics */
+
+inline fun RBuilder.styledA(href: String? = null, target: String? = null, block: StyledDOMBuilder<A>.() -> Unit) =
+    styledTag(block) { A(attributesMapOf("href", href, "target", target), it) }
+
+inline fun RBuilder.styledAbbr(block: StyledDOMBuilder<ABBR>.() -> Unit) = styledTag(block) { ABBR(emptyMap, it) }
+
+inline fun RBuilder.styledB(block: StyledDOMBuilder<B>.() -> Unit) = styledTag(block) { B(emptyMap, it) }
+
+inline fun RBuilder.styledBdi(block: StyledDOMBuilder<BDI>.() -> Unit) = styledTag(block) { BDI(emptyMap, it) }
+
+inline fun RBuilder.styledBdo(block: StyledDOMBuilder<BDO>.() -> Unit) = styledTag(block) { BDO(emptyMap, it) }
+
+inline fun RBuilder.styledBr(block: StyledDOMBuilder<BR>.() -> Unit) = styledTag(block) { BR(emptyMap, it) }
+
+inline fun RBuilder.styledCite(block: StyledDOMBuilder<CITE>.() -> Unit) = styledTag(block) { CITE(emptyMap, it) }
+
+inline fun RBuilder.styledCode(block: StyledDOMBuilder<CODE>.() -> Unit) = styledTag(block) { CODE(emptyMap, it) }
+
+// TODO DATA isn't defined in kotlinx.html
+
+inline fun RBuilder.styledDfn(block: StyledDOMBuilder<DFN>.() -> Unit) = styledTag(block) { DFN(emptyMap, it) }
+
+inline fun RBuilder.styledEm(block: StyledDOMBuilder<EM>.() -> Unit) = styledTag(block) { EM(emptyMap, it) }
+
+inline fun RBuilder.styledI(block: StyledDOMBuilder<I>.() -> Unit) = styledTag(block) { I(emptyMap, it) }
+
+inline fun RBuilder.styledKbd(block: StyledDOMBuilder<KBD>.() -> Unit) = styledTag(block) { KBD(emptyMap, it) }
+
+inline fun RBuilder.styledMark(block: StyledDOMBuilder<MARK>.() -> Unit) = styledTag(block) { MARK(emptyMap, it) }
+
+inline fun RBuilder.styledQ(block: StyledDOMBuilder<Q>.() -> Unit) = styledTag(block) { Q(emptyMap, it) }
+
+// TODO RB isn't defined in kotlinx.html
+
+inline fun RBuilder.styledRp(block: StyledDOMBuilder<RP>.() -> Unit) = styledTag(block) { RP(emptyMap, it) }
+
+inline fun RBuilder.styledRt(block: StyledDOMBuilder<RT>.() -> Unit) = styledTag(block) { RT(emptyMap, it) }
+
+// TODO RTC isn't defined in kotlinx.html
+
+inline fun RBuilder.styledRuby(block: StyledDOMBuilder<RUBY>.() -> Unit) = styledTag(block) { RUBY(emptyMap, it) }
+
+// TODO S isn't defined in kotlinx.html
+
+inline fun RBuilder.styledSamp(block: StyledDOMBuilder<SAMP>.() -> Unit) = styledTag(block) { SAMP(emptyMap, it) }
+
+inline fun RBuilder.styledSmall(block: StyledDOMBuilder<SMALL>.() -> Unit) = styledTag(block) { SMALL(emptyMap, it) }
+
+inline fun RBuilder.styledSpan(block: StyledDOMBuilder<SPAN>.() -> Unit) = styledTag(block) { SPAN(emptyMap, it) }
+
+inline fun RBuilder.styledStrong(block: StyledDOMBuilder<STRONG>.() -> Unit) = styledTag(block) { STRONG(emptyMap, it) }
+
+inline fun RBuilder.styledSub(block: StyledDOMBuilder<SUB>.() -> Unit) = styledTag(block) { SUB(emptyMap, it) }
+
+inline fun RBuilder.styledSup(block: StyledDOMBuilder<SUP>.() -> Unit) = styledTag(block) { SUP(emptyMap, it) }
+
+inline fun RBuilder.styledTime(block: StyledDOMBuilder<TIME>.() -> Unit) = styledTag(block) { TIME(emptyMap, it) }
+
+// TODO U isn't defined in kotlinx.html
+
+inline fun RBuilder.styledVar(block: StyledDOMBuilder<VAR>.() -> Unit) = styledTag(block) { VAR(emptyMap, it) }
+
+// TODO WBR isn't defined in kotlinx.html
+
+/* Image and multimedia */
+
+inline fun RBuilder.styledArea(
+    shape: AreaShape? = null,
+    alt: String? = null,
+    block: StyledDOMBuilder<AREA>.() -> Unit
+) = styledTag(block) { AREA(attributesMapOf("Shape", shape?.enumEncode(), "alt", alt), it) }
+
+inline fun RBuilder.styledAudio(block: StyledDOMBuilder<AUDIO>.() -> Unit) = styledTag(block) { AUDIO(emptyMap, it) }
+
+inline fun RBuilder.styledImg(alt: String? = null, src: String? = null, block: StyledDOMBuilder<IMG>.() -> Unit) =
+    styledTag(block) { IMG(attributesMapOf("alt", alt, "src", src), it) }
+
+inline fun RBuilder.styledMap(name: String? = null, block: StyledDOMBuilder<MAP>.() -> Unit) =
+    styledTag(block) { MAP(attributesMapOf("name", name), it) }
+
+// TODO TRACK isn't defined in kotlinx.html
+
+inline fun RBuilder.styledVideo(block: StyledDOMBuilder<VIDEO>.() -> Unit) = styledTag(block) { VIDEO(emptyMap, it) }
+
+/* Embedded content */
+
+inline fun RBuilder.styledEmbed(block: StyledDOMBuilder<EMBED>.() -> Unit) = styledTag(block) { EMBED(emptyMap, it) }
+
+inline fun RBuilder.styledIframe(sandbox: IframeSandbox? = null, content: String = "") =
+    styledTag({ +content }) { IFRAME(attributesMapOf("sandbox", sandbox?.enumEncode()), it) }
+
+inline fun RBuilder.styledIframe(sandbox: IframeSandbox? = null, block: StyledDOMBuilder<IFRAME>.() -> Unit) =
+    styledTag(block) { IFRAME(attributesMapOf("sandbox", sandbox?.enumEncode()), it) }
+
+inline fun RBuilder.styledObject(block: StyledDOMBuilder<OBJECT>.() -> Unit) = styledTag(block) { OBJECT(emptyMap, it) }
+
+inline fun RBuilder.styledParam(
+    name: String? = null,
+    value: String? = null,
+    block: StyledDOMBuilder<PARAM>.() -> Unit
+) = styledTag(block) { PARAM(attributesMapOf("name", name, "value", value), it) }
+
+inline fun RBuilder.styledPicture(block: StyledDOMBuilder<PICTURE>.() -> Unit) =
+    styledTag(block) { PICTURE(emptyMap, it) }
+
+// TODO PORTAL isn't defined in kotlinx.html
+
+inline fun RBuilder.styledSource(block: StyledDOMBuilder<SOURCE>.() -> Unit) = styledTag(block) { SOURCE(emptyMap, it) }
+
+/* SVG and MathML */
+
+inline fun RBuilder.styledSvg(content: String = "") = styledTag({ +content }) { SVG(emptyMap, it) }
+inline fun RBuilder.styledSvg(block: StyledDOMBuilder<SVG>.() -> Unit) = styledTag(block) { SVG(emptyMap, it) }
+
+inline fun RBuilder.styledMath(block: StyledDOMBuilder<MATH>.() -> Unit) = styledTag(block) { MATH(emptyMap, it) }
+
+/* Scripting */
+
+inline fun RBuilder.styledCanvas(content: String = "") = styledTag({ +content }) { CANVAS(emptyMap, it) }
+inline fun RBuilder.styledCanvas(block: StyledDOMBuilder<CANVAS>.() -> Unit) = styledTag(block) { CANVAS(emptyMap, it) }
+
+inline fun RBuilder.styledNoscript(block: StyledDOMBuilder<NOSCRIPT>.() -> Unit) =
+    styledTag(block) { NOSCRIPT(emptyMap, it) }
+
+inline fun RBuilder.styledScript(
+    type: String? = null,
+    src: String? = null,
+    block: StyledDOMBuilder<SCRIPT>.() -> Unit
+) = styledTag(block) { SCRIPT(attributesMapOf("type", type, "src", src), it) }
+
+/* Demarcating edits */
+
+inline fun RBuilder.styledDel(block: StyledDOMBuilder<DEL>.() -> Unit) = styledTag(block) { DEL(emptyMap, it) }
+
+inline fun RBuilder.styledIns(block: StyledDOMBuilder<INS>.() -> Unit) = styledTag(block) { INS(emptyMap, it) }
+
+/* Table content */
+
+inline fun RBuilder.styledCaption(block: StyledDOMBuilder<CAPTION>.() -> Unit) =
+    styledTag(block) { CAPTION(emptyMap, it) }
+
+inline fun RBuilder.styledCol(block: StyledDOMBuilder<COL>.() -> Unit) = styledTag(block) { COL(emptyMap, it) }
+
+inline fun RBuilder.styledColgroup(block: StyledDOMBuilder<COLGROUP>.() -> Unit) =
+    styledTag(block) { COLGROUP(emptyMap, it) }
+
+inline fun RBuilder.styledTable(block: StyledDOMBuilder<TABLE>.() -> Unit) = styledTag(block) { TABLE(emptyMap, it) }
+
+inline fun RBuilder.styledTbody(block: StyledDOMBuilder<TBODY>.() -> Unit) = styledTag(block) { TBODY(emptyMap, it) }
+
+inline fun RBuilder.styledTd(block: StyledDOMBuilder<TD>.() -> Unit) = styledTag(block) { TD(emptyMap, it) }
+
+inline fun RBuilder.styledTfoot(block: StyledDOMBuilder<TFOOT>.() -> Unit) = styledTag(block) { TFOOT(emptyMap, it) }
+
+inline fun RBuilder.styledTh(scope: ThScope? = null, block: StyledDOMBuilder<TH>.() -> Unit) =
+    styledTag(block) { TH(attributesMapOf("scope", scope?.enumEncode()), it) }
+
+inline fun RBuilder.styledThead(block: StyledDOMBuilder<THEAD>.() -> Unit) = styledTag(block) { THEAD(emptyMap, it) }
+
+inline fun RBuilder.styledTr(block: StyledDOMBuilder<TR>.() -> Unit) = styledTag(block) { TR(emptyMap, it) }
+
+/* Forms */
+
+inline fun RBuilder.styledButton(
+    formEncType: ButtonFormEncType? = null,
+    formMethod: ButtonFormMethod? = null,
+    type: ButtonType? = null,
+    block: StyledDOMBuilder<BUTTON>.() -> Unit
+) = styledTag(block) {
+    BUTTON(
+        attributesMapOf(
+            "formenctype",
+            formEncType?.enumEncode(),
+            "formmethod",
+            formMethod?.enumEncode(),
+            "type",
+            type?.enumEncode()
+        ), it
+    )
+}
+
+inline fun RBuilder.styledDatalist(block: StyledDOMBuilder<DATALIST>.() -> Unit) =
+    styledTag(block) { DATALIST(emptyMap, it) }
+
+inline fun RBuilder.styledFieldset(block: StyledDOMBuilder<FIELDSET>.() -> Unit) =
+    styledTag(block) { FIELDSET(emptyMap, it) }
+
+inline fun RBuilder.styledForm(
+    action: String? = null,
+    encType: FormEncType? = null,
+    method: FormMethod? = null,
+    block: StyledDOMBuilder<FORM>.() -> Unit
+) = styledTag(block) {
+    FORM(
+        attributesMapOf(
+            "action",
+            action,
+            "enctype",
+            encType?.enumEncode(),
+            "method",
+            method?.enumEncode()
+        ), it
+    )
+}
+
+inline fun RBuilder.styledInput(
+    type: InputType? = null,
+    formEncType: InputFormEncType? = null,
+    formMethod: InputFormMethod? = null,
+    name: String? = null,
+    block: StyledDOMBuilder<INPUT>.() -> Unit
+) = styledTag(block) {
+    INPUT(
+        attributesMapOf(
+            "type",
+            type?.enumEncode(),
+            "formenctype",
+            formEncType?.enumEncode(),
+            "formmethod",
+            formMethod?.enumEncode(),
+            "name",
+            name
+        ), it
+    )
+}
+
+inline fun RBuilder.styledLabel(block: StyledDOMBuilder<LABEL>.() -> Unit) = styledTag(block) { LABEL(emptyMap, it) }
+
+inline fun RBuilder.styledLegend(block: StyledDOMBuilder<LEGEND>.() -> Unit) = styledTag(block) { LEGEND(emptyMap, it) }
+
+inline fun RBuilder.styledMeter(block: StyledDOMBuilder<METER>.() -> Unit) = styledTag(block) { METER(emptyMap, it) }
+
+inline fun RBuilder.styledOptgroup(label: String? = null, block: StyledDOMBuilder<OPTGROUP>.() -> Unit) =
+    styledTag(block) { OPTGROUP(attributesMapOf("label", label), it) }
+
+inline fun RBuilder.styledOption(content: String = "") = styledTag({ +content }) { OPTION(emptyMap, it) }
+inline fun RBuilder.styledOption(block: StyledDOMBuilder<OPTION>.() -> Unit) = styledTag(block) { OPTION(emptyMap, it) }
+
+inline fun RBuilder.styledOutput(block: StyledDOMBuilder<OUTPUT>.() -> Unit) = styledTag(block) { OUTPUT(emptyMap, it) }
+
+inline fun RBuilder.styledProgress(block: StyledDOMBuilder<PROGRESS>.() -> Unit) =
+    styledTag(block) { PROGRESS(emptyMap, it) }
+
+inline fun RBuilder.styledSelect(block: StyledDOMBuilder<SELECT>.() -> Unit) = styledTag(block) { SELECT(emptyMap, it) }
+
+inline fun RBuilder.styledTextarea(
+    rows: String? = null,
+    cols: String? = null,
+    wrap: TextAreaWrap? = null,
+    content: String = ""
+) = styledTag({ +content }) { TEXTAREA(attributesMapOf("rows", rows, "cols", cols, "wrap", wrap?.enumEncode()), it) }
+
+inline fun RBuilder.styledTextarea(
+    rows: String? = null,
+    cols: String? = null,
+    wrap: TextAreaWrap? = null,
+    block: StyledDOMBuilder<TEXTAREA>.() -> Unit
+) = styledTag(block) { TEXTAREA(attributesMapOf("rows", rows, "cols", cols, "wrap", wrap?.enumEncode()), it) }
+
+/* Interactive elements */
+
+inline fun RBuilder.styledDetails(block: StyledDOMBuilder<DETAILS>.() -> Unit) =
+    styledTag(block) { DETAILS(emptyMap, it) }
+
+inline fun RBuilder.styledDialog(block: StyledDOMBuilder<DIALOG>.() -> Unit) = styledTag(block) { DIALOG(emptyMap, it) }
+
+// TODO MENU isn't defined in kotlinx.html
+
+inline fun RBuilder.styledSummary(block: StyledDOMBuilder<SUMMARY>.() -> Unit) =
+    styledTag(block) { SUMMARY(emptyMap, it) }
+
+/* Web Components */
+
+// TODO SLOT isn't defined in kotlinx.html
+
+// TODO TEMPLATE isn't defined in kotlinx.html

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,4 +48,7 @@ include("kotlin-ring-ui")
 // Kotlin/JS: styled-components wrappers
 include("kotlin-styled")
 
+// Kotlin/JS: styled-components kotlin implementation
+include("kotlin-styled-next")
+
 include("kotlin-wrappers-bom")


### PR DESCRIPTION
This PR add styled-components implementation in kotlin. I've tried to save most of the interfaces and the main flow.

One of the main differences from styled-components is missing prefixer in this implementation