### PR TITLE
Remove deprecated `useMemo` and `useCallback` signatures

### DIFF
--- a/kotlin-react/src/main/kotlin/react/useCallback.kt
+++ b/kotlin-react/src/main/kotlin/react/useCallback.kt
@@ -11,14 +11,3 @@ inline fun <T : Function<*>> useCallback(
     callback: T,
 ): T =
     rawUseCallback(callback, dependencies)
-
-/**
- * Only works inside [fc]
- * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
- */
-@Deprecated("Inconsistent hooks API")
-inline fun <T : Function<*>> useCallback(
-    callback: T,
-    dependencies: RDependenciesArray,
-): T =
-    rawUseCallback(callback, dependencies)

--- a/kotlin-react/src/main/kotlin/react/useMemo.kt
+++ b/kotlin-react/src/main/kotlin/react/useMemo.kt
@@ -11,15 +11,3 @@ inline fun <T> useMemo(
     noinline callback: () -> T,
 ): T =
     rawUseMemo(callback, dependencies)
-
-/**
- * Only works inside [fc]
- * @see <a href="https://reactjs.org/docs/hooks-state.html#hooks-and-function-components">Hooks and Function Components</a>
- */
-@Deprecated("Inconsistent hooks API")
-inline fun <T> useMemo(
-    noinline callback: () -> T,
-    dependencies: RDependenciesArray,
-): T =
-    rawUseMemo(callback, dependencies)
-


### PR DESCRIPTION
cc @sgrishchenko @aerialist7 