### PR TITLE
Remove unsafe `childFunction`

### DIFF
--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -87,18 +87,6 @@ interface RBuilder {
         klazz.react.invoke(handler)
     }
 
-    fun <T, P : RProps> childFunction(
-        klazz: KClass<out Component<P, *>>,
-        handler: RHandler<P>,
-        children: RBuilder.(T) -> Unit,
-    ) {
-        child(
-            type = klazz.react,
-            props = RElementBuilder(jsObject<P>()).apply(handler).attrs,
-            children = listOf { value: T -> buildElement { children(value) } }
-        )
-    }
-
     @Deprecated(
         message = "Ambiguous API",
         ReplaceWith("child(klazz.rClass, props, children)"),
@@ -113,11 +101,6 @@ interface RBuilder {
 
     fun RProps.children() {
         childList.addAll(Children.toArray(children))
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun <T> RProps.children(value: T) {
-        childList.add((children as (T) -> Any).invoke(value))
     }
 
     /**
@@ -186,13 +169,6 @@ inline fun <P : RProps, reified C : Component<P, *>> RBuilder.child(
     noinline handler: RHandler<P>,
 ) {
     child(C::class, handler)
-}
-
-inline fun <T, P : RProps, reified C : Component<P, *>> RBuilder.childFunction(
-    noinline handler: RHandler<P>,
-    noinline children: RBuilder.(T) -> Unit,
-) {
-    childFunction(C::class, handler, children)
 }
 
 @Deprecated(
@@ -272,25 +248,4 @@ fun <P : RProps> RBuilder.child(
     handler: RHandler<P> = {},
 ) {
     child(component, props, handler)
-}
-
-fun <T, P : RProps> RBuilder.childFunction(
-    component: FC<P>,
-    handler: RHandler<P> = {},
-    children: RBuilder.(T) -> Unit,
-) {
-    childFunction(component, jsObject(), handler, children)
-}
-
-fun <T, P : RProps> RBuilder.childFunction(
-    component: FC<P>,
-    props: P,
-    handler: RHandler<P> = {},
-    children: RBuilder.(T) -> Unit,
-) {
-    child(
-        type = component,
-        props = RElementBuilder(props).apply(handler).attrs,
-        children = listOf { value: T -> buildElement { children(value) } }
-    )
 }

--- a/kotlin-react/src/main/kotlin/react/RComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/RComponent.kt
@@ -20,10 +20,6 @@ abstract class RComponent<P : RProps, S : State> : Component<P, S> {
         props.children()
     }
 
-    fun <T> RBuilder.children(value: T) {
-        props.children(value)
-    }
-
     abstract fun RBuilder.render()
 
     override fun render() = buildElements { render() }

--- a/kotlin-react/src/main/kotlin/react/RPureComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/RPureComponent.kt
@@ -20,10 +20,6 @@ abstract class RPureComponent<P : RProps, S : State> : PureComponent<P, S> {
         props.children()
     }
 
-    fun <T> RBuilder.children(value: T) {
-        props.children(value)
-    }
-
     abstract fun RBuilder.render()
 
     override fun render() = buildElements { render() }


### PR DESCRIPTION
Part of #358
cc @turansky @aerialist7 

`childFunction` and `RProps.children(value: T)` signatures are removed because of unsafety.
These methods can lead to inconsistency and mistakes in codebase of `kotlin-wrappers` users.

Recommended solution for such cases:
```
interface RenderChildrenProps : RProps {
    var children: RBuilder.(value: Int) -> Unit
}

val RenderChildren = fc<RenderChildrenProps> { props ->
    div {
        props.children(this, 42)
    }
}

val Container = fc<RProps> {
    RenderChildren {
        attrs {
            children = { value ->
                span {
                    attrs {
                        jsStyle {
                            color = "red"
                        }
                    }

                    +"$value"
                }
            }
        }
    }
}
``` 