### PR TITLE
Prepare Component Props for more strict restrictions

### DIFF
--- a/kotlin-react-query/src/main/kotlin/react/query/QueryErrorResetBoundary.kt
+++ b/kotlin-react-query/src/main/kotlin/react/query/QueryErrorResetBoundary.kt
@@ -14,7 +14,7 @@ external interface QueryErrorResetBoundaryValue {
 external val useQueryErrorResetBoundary: () -> QueryErrorResetBoundaryValue
 
 external interface QueryErrorResetBoundaryProps : react.Props {
-    var  children: dynamic
+    var children: dynamic
 }
 
 external val QueryErrorResetBoundary: react.FC<QueryErrorResetBoundaryProps>

--- a/kotlin-react-query/src/main/kotlin/react/query/QueryErrorResetBoundary.kt
+++ b/kotlin-react-query/src/main/kotlin/react/query/QueryErrorResetBoundary.kt
@@ -13,8 +13,8 @@ external interface QueryErrorResetBoundaryValue {
 
 external val useQueryErrorResetBoundary: () -> QueryErrorResetBoundaryValue
 
-external interface QueryErrorResetBoundaryProps : react.RProps {
-    var children: dynamic
+external interface QueryErrorResetBoundaryProps : react.Props {
+    var  children: dynamic
 }
 
 external val QueryErrorResetBoundary: react.FC<QueryErrorResetBoundaryProps>

--- a/kotlin-react/src/main/kotlin/react/Component.kt
+++ b/kotlin-react/src/main/kotlin/react/Component.kt
@@ -3,7 +3,7 @@
 
 package react
 
-abstract external class Component<P : RProps, S : State>(
+abstract external class Component<P : Props, S : State>(
     props: P = definedExternally,
 ) {
     val props: P

--- a/kotlin-react/src/main/kotlin/react/ComponentClass.kt
+++ b/kotlin-react/src/main/kotlin/react/ComponentClass.kt
@@ -3,9 +3,9 @@ package react
 import kotlin.reflect.KClass
 
 // TODO: Should extend RComponentClassStatics, but has problems with generic params
-external interface ComponentClass<in P : RProps> :
+external interface ComponentClass<in P : Props> :
     ComponentType<P>,
-    RComponentClassStatics<RProps, State, Context<*>?>
+    RComponentClassStatics<Props, State, Context<*>?>
 
 @Deprecated(
     message = "Legacy type alias",
@@ -13,14 +13,14 @@ external interface ComponentClass<in P : RProps> :
 )
 typealias RClass<P> = ComponentClass<P>
 
-val <P : RProps> KClass<out Component<P, *>>.react: ComponentClass<P>
+val <P : Props> KClass<out Component<P, *>>.react: ComponentClass<P>
     get() = js.unsafeCast<ComponentClass<P>>()
 
 @Deprecated("Legacy type alias. Use `.react` instead")
-inline val <P : RProps> KClass<out Component<P, *>>.rClass: ComponentClass<P>
+inline val <P : Props> KClass<out Component<P, *>>.rClass: ComponentClass<P>
     get() = react
 
-external interface RComponentClassStatics<P : RProps, S : State, C : Context<*>?> {
+external interface RComponentClassStatics<P : Props, S : State, C : Context<*>?> {
     var displayName: String?
     var defaultProps: P?
     var contextType: C
@@ -42,6 +42,6 @@ external interface RComponentClassStatics<P : RProps, S : State, C : Context<*>?
  *
  * in your class components
  */
-open class RStatics<P : RProps, S : State, C : Component<P, S>, CTX : Context<*>?>(
+open class RStatics<P : Props, S : State, C : Component<P, S>, CTX : Context<*>?>(
     klazz: KClass<C>,
 ) : RComponentClassStatics<P, S, CTX> by klazz.js.unsafeCast<RComponentClassStatics<P, S, CTX>>()

--- a/kotlin-react/src/main/kotlin/react/ComponentType.kt
+++ b/kotlin-react/src/main/kotlin/react/ComponentType.kt
@@ -1,3 +1,3 @@
 package react
 
-external interface ComponentType<in P : RProps> : ElementType<P>
+external interface ComponentType<in P : Props> : ElementType<P>

--- a/kotlin-react/src/main/kotlin/react/Context.kt
+++ b/kotlin-react/src/main/kotlin/react/Context.kt
@@ -3,13 +3,13 @@
 
 package react
 
-external interface ProviderProps<T> : RProps {
+external interface ProviderProps<T> : PropsWithChildren {
     var value: T
 }
 
 external interface Provider<T> : ComponentClass<ProviderProps<T>>
 
-external interface ConsumerProps<T> : RProps {
+external interface ConsumerProps<T> : Props {
     var children: (T) -> Any
 }
 

--- a/kotlin-react/src/main/kotlin/react/Fragment.kt
+++ b/kotlin-react/src/main/kotlin/react/Fragment.kt
@@ -4,4 +4,4 @@
 package react
 
 // Fragment (16+)
-external val Fragment: ComponentClass<RProps>
+external val Fragment: ComponentClass<PropsWithChildren>

--- a/kotlin-react/src/main/kotlin/react/FunctionComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/FunctionComponent.kt
@@ -2,7 +2,7 @@
 
 package react
 
-external interface FunctionComponent<in P : RProps> :
+external interface FunctionComponent<in P : Props> :
     ComponentType<P> {
     var displayName: String?
 }
@@ -13,7 +13,7 @@ typealias FC<P> = FunctionComponent<P>
 /**
  * Get function component from [func]
  */
-fun <P : RProps> fc(
+fun <P : Props> fc(
     func: RBuilder.(props: P) -> Unit,
 ): FC<P> {
     val component = { props: P ->
@@ -27,7 +27,7 @@ fun <P : RProps> fc(
 /**
  * Get function component from [func] with [displayName]
  */
-fun <P : RProps> fc(
+fun <P : Props> fc(
     displayName: String,
     func: RBuilder.(props: P) -> Unit,
 ): FC<P> =
@@ -36,7 +36,7 @@ fun <P : RProps> fc(
 /**
  * Get function component from [func]
  */
-inline fun <P : RProps> functionComponent(
+inline fun <P : Props> functionComponent(
     noinline func: RBuilder.(props: P) -> Unit,
 ): FC<P> =
     fc(func)
@@ -44,7 +44,7 @@ inline fun <P : RProps> functionComponent(
 /**
  * Get function component from [func] with [displayName]
  */
-inline fun <P : RProps> functionComponent(
+inline fun <P : Props> functionComponent(
     displayName: String,
     noinline func: RBuilder.(props: P) -> Unit,
 ): FC<P> =

--- a/kotlin-react/src/main/kotlin/react/FunctionalComponent.legacy.kt
+++ b/kotlin-react/src/main/kotlin/react/FunctionalComponent.legacy.kt
@@ -12,7 +12,7 @@ typealias FunctionalComponent<P> = FunctionComponent<P>
     message = "Legacy type alias",
     replaceWith = ReplaceWith("fc(displayName, func)", "react.fc")
 )
-inline fun <P : RProps> functionalComponent(
+inline fun <P : Props> functionalComponent(
     displayName: String? = null,
     noinline func: RBuilder.(props: P) -> Unit,
 ): FC<P> =

--- a/kotlin-react/src/main/kotlin/react/HOC.kt
+++ b/kotlin-react/src/main/kotlin/react/HOC.kt
@@ -2,24 +2,24 @@ package react
 
 import kotlinext.js.JsFunction
 
-external interface HOC<out P : RProps, in R : RProps> : JsFunction<Nothing?, ComponentClass<R>>
+external interface HOC<out P : Props, in R : Props> : JsFunction<Nothing?, ComponentClass<R>>
 
-operator fun <P : RProps, R : RProps> HOC<P, R>.invoke(component: ComponentClass<P>) =
+operator fun <P : Props, R : Props> HOC<P, R>.invoke(component: ComponentClass<P>) =
     call(null, component)
 
-operator fun <P : RProps, R : RProps> HOC<P, R>.invoke(component: RBuilder.(P) -> Unit) =
+operator fun <P : Props, R : Props> HOC<P, R>.invoke(component: RBuilder.(P) -> Unit) =
     call(null, { props: P ->
         buildElements {
             component(props)
         }
     })
 
-operator fun <P : RProps, R : RProps> HOC<P, R>.invoke(config: Any, component: RBuilder.(P) -> Unit) =
+operator fun <P : Props, R : Props> HOC<P, R>.invoke(config: Any, component: RBuilder.(P) -> Unit) =
     call(null, { props: P ->
         buildElements {
             component(props)
         }
     }, config)
 
-fun <P : RProps> allOf(vararg hocs: HOC<P, P>): (component: ComponentClass<P>) -> ComponentClass<P> =
+fun <P : Props> allOf(vararg hocs: HOC<P, P>): (component: ComponentClass<P>) -> ComponentClass<P> =
     { hocs.fold(it) { acc, hoc -> hoc(acc) } }

--- a/kotlin-react/src/main/kotlin/react/IntrinsicType.kt
+++ b/kotlin-react/src/main/kotlin/react/IntrinsicType.kt
@@ -2,9 +2,9 @@
 
 package react
 
-external interface IntrinsicType<in P : RProps> : ElementType<P>
+external interface IntrinsicType<in P : Props> : ElementType<P>
 
-inline fun <P : RProps> IntrinsicType(
+inline fun <P : Props> IntrinsicType(
     tagName: String,
 ): IntrinsicType<P> =
     tagName.unsafeCast<IntrinsicType<P>>()

--- a/kotlin-react/src/main/kotlin/react/Profiler.kt
+++ b/kotlin-react/src/main/kotlin/react/Profiler.kt
@@ -3,7 +3,7 @@
 
 package react
 
-external interface ProfilerProps : RProps {
+external interface ProfilerProps : PropsWithChildren {
     var id: String
     var onRender: (
         id: String,

--- a/kotlin-react/src/main/kotlin/react/Props.kt
+++ b/kotlin-react/src/main/kotlin/react/Props.kt
@@ -1,18 +1,26 @@
 package react
 
-external interface RProps
+external interface Props
 
-val RProps.children: Any
-    get() = asDynamic().children
+external interface PropsWithChildren : Props {
+    var children: Array<out ReactNode>?
+}
 
-var RProps.key: Key
+// TODO: deprecate it
+//@Deprecated(
+//    message = "Legacy type alias",
+//    replaceWith = ReplaceWith("PropsWithChildren", "react.PropsWithChildren"),
+//)
+typealias RProps = PropsWithChildren
+
+var Props.key: Key
     @Deprecated(message = "Write-only property", level = DeprecationLevel.HIDDEN)
     get() = error("")
     set(value) {
         asDynamic().key = value
     }
 
-var RProps.ref: Ref<*>
+var Props.ref: Ref<*>
     @Deprecated(message = "Write-only property", level = DeprecationLevel.HIDDEN)
     get() = error("")
     set(value) {

--- a/kotlin-react/src/main/kotlin/react/PureComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/PureComponent.kt
@@ -3,7 +3,7 @@
 
 package react
 
-abstract external class PureComponent<P : RProps, S : State>(
+abstract external class PureComponent<P : Props, S : State>(
     props: P = definedExternally,
 ) : Component<P, S> {
 

--- a/kotlin-react/src/main/kotlin/react/RBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/RBuilder.kt
@@ -23,7 +23,7 @@ interface RBuilder {
         childList.add(this)
     }
 
-    fun <P : RProps> child(
+    fun <P : Props> child(
         type: ElementType<P>,
         props: P,
         children: List<Any>,
@@ -31,7 +31,7 @@ interface RBuilder {
         child(createElement(type, props, *children.toTypedArray()))
     }
 
-    fun <P : RProps> child(
+    fun <P : Props> child(
         type: ElementType<P>,
         props: P,
         handler: RHandler<P>,
@@ -43,7 +43,7 @@ interface RBuilder {
         child(type, props, children)
     }
 
-    operator fun <P : RProps> ElementType<P>.invoke(
+    operator fun <P : Props> ElementType<P>.invoke(
         handler: RHandler<P>,
     ) {
         child(this, jsObject(), handler)
@@ -70,14 +70,14 @@ interface RBuilder {
         message = "Ambiguous API",
         replaceWith = ReplaceWith("child(this, props, children)"),
     )
-    fun <P : RProps> ComponentClass<P>.node(
+    fun <P : Props> ComponentClass<P>.node(
         props: P,
         children: List<Any> = emptyList(),
     ) {
         child(this, clone(props), children)
     }
 
-    fun <P : RProps> child(
+    fun <P : Props> child(
         klazz: KClass<out Component<P, *>>,
         handler: RHandler<P>,
     ) {
@@ -88,7 +88,7 @@ interface RBuilder {
         message = "Ambiguous API",
         replaceWith = ReplaceWith("child(klazz.react, props, children)"),
     )
-    fun <P : RProps> node(
+    fun <P : Props> node(
         klazz: KClass<out Component<P, *>>,
         props: P,
         children: List<Any> = emptyList(),
@@ -96,7 +96,7 @@ interface RBuilder {
         child(klazz.react, props, children)
     }
 
-    fun RProps.children() {
+    fun PropsWithChildren.children() {
         childList.addAll(Children.toArray(children))
     }
 
@@ -162,7 +162,7 @@ interface RBuilder {
 fun RBuilder(): RBuilder =
     RBuilderImpl()
 
-inline fun <P : RProps, reified C : Component<P, *>> RBuilder.child(
+inline fun <P : Props, reified C : Component<P, *>> RBuilder.child(
     noinline handler: RHandler<P>,
 ) {
     child(C::class, handler)
@@ -172,7 +172,7 @@ inline fun <P : RProps, reified C : Component<P, *>> RBuilder.child(
     message = "Ambiguous API",
     ReplaceWith("child(C::class.rClass, props, children)"),
 )
-inline fun <P : RProps, reified C : Component<P, *>> RBuilder.node(
+inline fun <P : Props, reified C : Component<P, *>> RBuilder.node(
     props: P,
     children: List<Any> = emptyList(),
 ) {
@@ -206,7 +206,7 @@ inline fun <T : RBuilder> buildElement(rBuilder: T, handler: T.() -> Unit): Reac
 inline fun buildElement(handler: Render): ReactElement =
     buildElement(RBuilder(), handler)
 
-interface RElementBuilder<out P : RProps> : RBuilder {
+interface RElementBuilder<out P : Props> : RBuilder {
     val attrs: P
 
     fun attrs(handler: P.() -> Unit) {
@@ -228,10 +228,10 @@ interface RElementBuilder<out P : RProps> : RBuilder {
         }
 }
 
-fun <P : RProps> RElementBuilder(attrs: P): RElementBuilder<P> =
+fun <P : Props> RElementBuilder(attrs: P): RElementBuilder<P> =
     RElementBuilderImpl(attrs)
 
-open class RElementBuilderImpl<out P : RProps>(override val attrs: P) : RElementBuilder<P>, RBuilderImpl()
+open class RElementBuilderImpl<out P : Props>(override val attrs: P) : RElementBuilder<P>, RBuilderImpl()
 
 typealias RHandler<P> = RElementBuilder<P>.() -> Unit
 
@@ -239,7 +239,7 @@ typealias RHandler<P> = RElementBuilder<P>.() -> Unit
  * Append function component [component] as child of current builder
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-fun <P : RProps> RBuilder.child(
+fun <P : Props> RBuilder.child(
     component: FC<P>,
     props: P = jsObject(),
     handler: RHandler<P> = {},

--- a/kotlin-react/src/main/kotlin/react/RComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/RComponent.kt
@@ -2,7 +2,7 @@ package react
 
 import kotlinext.js.jsObject
 
-abstract class RComponent<P : RProps, S : State> : Component<P, S> {
+abstract class RComponent<P : Props, S : State> : Component<P, S> {
     constructor() : super() {
         state = jsObject { init() }
     }
@@ -15,10 +15,6 @@ abstract class RComponent<P : RProps, S : State> : Component<P, S> {
 
     // if you use this method, don't forget to pass props to the constructor first
     open fun S.init(props: P) {}
-
-    fun RBuilder.children() {
-        props.children()
-    }
 
     abstract fun RBuilder.render()
 

--- a/kotlin-react/src/main/kotlin/react/RPureComponent.kt
+++ b/kotlin-react/src/main/kotlin/react/RPureComponent.kt
@@ -2,7 +2,7 @@ package react
 
 import kotlinext.js.jsObject
 
-abstract class RPureComponent<P : RProps, S : State> : PureComponent<P, S> {
+abstract class RPureComponent<P : Props, S : State> : PureComponent<P, S> {
     constructor() : super() {
         state = jsObject { init() }
     }
@@ -15,10 +15,6 @@ abstract class RPureComponent<P : RProps, S : State> : PureComponent<P, S> {
 
     // if you use this method, don't forget to pass props to the constructor first
     open fun S.init(props: P) {}
-
-    fun RBuilder.children() {
-        props.children()
-    }
 
     abstract fun RBuilder.render()
 

--- a/kotlin-react/src/main/kotlin/react/Raw.kt
+++ b/kotlin-react/src/main/kotlin/react/Raw.kt
@@ -4,7 +4,7 @@
 package react
 
 @JsName("forwardRef")
-external fun <P : RProps> rawForwardRef(forward: (props: P, ref: Ref<*>) -> dynamic): ComponentType<P>
+external fun <P : Props> rawForwardRef(forward: (props: P, ref: Ref<*>) -> dynamic): ComponentType<P>
 
 // Effect Hook (16.8+)
 @JsName("useEffect")

--- a/kotlin-react/src/main/kotlin/react/React.kt
+++ b/kotlin-react/src/main/kotlin/react/React.kt
@@ -8,7 +8,7 @@ fun Children.forEachElement(children: Any?, handler: (ReactElement) -> Unit) =
         element?.let(handler)
     }
 
-inline fun <P : RProps> cloneElement(
+inline fun <P : Props> cloneElement(
     element: ReactElement,
     vararg child: Any?,
     props: P.() -> Unit,

--- a/kotlin-react/src/main/kotlin/react/ReactElement.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactElement.kt
@@ -4,22 +4,22 @@
 package react
 
 external interface ReactElement : ReactNode {
-    val props: RProps
+    val props: Props
 }
 
-external fun <P : RProps> createElement(
+external fun <P : Props> createElement(
     type: String,
     props: P = definedExternally,
     vararg child: Any?,
 ): ReactElement
 
-external fun <P : RProps> createElement(
+external fun <P : Props> createElement(
     type: ElementType<P>,
     props: P = definedExternally,
     vararg child: Any?,
 ): ReactElement
 
-external fun <P : RProps> cloneElement(
+external fun <P : Props> cloneElement(
     element: ReactElement,
     props: P = definedExternally,
     vararg child: Any?,

--- a/kotlin-react/src/main/kotlin/react/StrictMode.kt
+++ b/kotlin-react/src/main/kotlin/react/StrictMode.kt
@@ -4,4 +4,4 @@
 package react
 
 // StrictMode (16.3+)
-external val StrictMode: ComponentClass<RProps>
+external val StrictMode: ComponentClass<PropsWithChildren>

--- a/kotlin-react/src/main/kotlin/react/Suspense.kt
+++ b/kotlin-react/src/main/kotlin/react/Suspense.kt
@@ -3,6 +3,6 @@
 
 package react
 
-external interface SuspenseProps : RProps
+external interface SuspenseProps : PropsWithChildren
 
 external val Suspense: ComponentClass<SuspenseProps>

--- a/kotlin-react/src/main/kotlin/react/forwardRef.kt
+++ b/kotlin-react/src/main/kotlin/react/forwardRef.kt
@@ -1,6 +1,6 @@
 package react
 
-fun <P : RProps> forwardRef(handler: RBuilder.(P, Ref<*>) -> Unit): ComponentType<P> =
+fun <P : Props> forwardRef(handler: RBuilder.(P, Ref<*>) -> Unit): ComponentType<P> =
     rawForwardRef { props, ref ->
         buildElements { handler(props, ref) }
     }

--- a/kotlin-react/src/main/kotlin/react/lazy.kt
+++ b/kotlin-react/src/main/kotlin/react/lazy.kt
@@ -5,11 +5,11 @@ package react
 
 import kotlin.js.Promise
 
-external interface ComponentModule<in P : RProps> {
+external interface ComponentModule<in P : Props> {
     val default: ComponentType<P>
 }
 
 // Lazy (16.6+)
-external fun <P : RProps> lazy(
+external fun <P : Props> lazy(
     factory: () -> Promise<ComponentModule<P>>,
 ): ComponentType<P>

--- a/kotlin-react/src/main/kotlin/react/memo.kt
+++ b/kotlin-react/src/main/kotlin/react/memo.kt
@@ -4,7 +4,7 @@
 package react
 
 // Memo (16.6+)
-external fun <P : RProps> memo(
+external fun <P : Props> memo(
     fc: FC<P>,
     areEqual: (P, P) -> Boolean = definedExternally,
 ): FC<P>

--- a/kotlin-ring-ui/src/main/kotlin/ringui/Checkbox.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Checkbox.kt
@@ -3,7 +3,6 @@
 
 package ringui
 
-import org.w3c.dom.Node
 import org.w3c.dom.events.InputEvent
 import react.ComponentClass
 import react.dom.WithClassName
@@ -21,7 +20,6 @@ external interface CheckboxProps : WithClassName {
     var indeterminate: Boolean
     var disabled: Boolean
     var onChange: (InputEvent) -> Unit
-    var children: Node
 }
 
 @JsName("default")


### PR DESCRIPTION
There are typing vulnerability of currents props: every component now can have children with type `Array<ReactNode>`, even it is not declared obviously. Also there is conflict of names and now there are difficulties with creation of children with custom type (e.g. render children)
This PR - first step to make `Props` more strict.
[TS typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L824)
Part of #358
cc @turansky @aerialist7 