### PR TITLE
Strict bounds for `ElementType` type parameter

### DIFF
--- a/kotlin-react/src/main/kotlin/react/ElementType.kt
+++ b/kotlin-react/src/main/kotlin/react/ElementType.kt
@@ -1,3 +1,3 @@
 package react
 
-external interface ElementType<in P : Any>
+external interface ElementType<in P : Props>


### PR DESCRIPTION
cc @sgrishchenko 