### PR TITLE
`RProps` is removed from Ring UI

### DIFF
--- a/kotlin-ring-ui/src/main/kotlin/ringui/Grid.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Grid.kt
@@ -4,10 +4,10 @@
 package ringui
 
 import react.ComponentClass
-import react.RProps
+import react.PropsWithChildren
 import react.dom.WithClassName
 
-external interface GridProps : RProps
+external interface GridProps : PropsWithChildren
 
 external val Grid: ComponentClass<GridProps>
 

--- a/kotlin-ring-ui/src/main/kotlin/ringui/UserCard.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/UserCard.kt
@@ -4,12 +4,12 @@
 package ringui
 
 import react.ComponentClass
-import react.RProps
+import react.PropsWithChildren
 
 external val UserCard: ComponentClass<UserCardProps>
 
 // https://github.com/JetBrains/ring-ui/blob/master/components/user-card/card.js
-external interface UserCardProps : RProps {
+external interface UserCardProps : PropsWithChildren {
     var user: UserCardModel
     var wording: UserCardWording
 }


### PR DESCRIPTION
cc @turansky @aerialist7 