### PR TITLE
`RProps` is removed from react-redux

### DIFF
--- a/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Helpers.kt
@@ -2,12 +2,12 @@ package react.redux
 
 import kotlinext.js.js
 import react.HOC
-import react.RProps
+import react.Props
 
 fun <A, R> rConnect(
-    options: (Options<Any, RProps, RProps, DispatchProps<A, R>>.() -> Unit) = {},
-): HOC<DispatchProps<A, R>, RProps> {
-    return connect<Any, A, R, RProps, RProps, RProps, DispatchProps<A, R>>(
+    options: (Options<Any, Props, Props, DispatchProps<A, R>>.() -> Unit) = {},
+): HOC<DispatchProps<A, R>, Props> {
+    return connect<Any, A, R, Props, Props, Props, DispatchProps<A, R>>(
         undefined,
         undefined,
         undefined,
@@ -15,15 +15,15 @@ fun <A, R> rConnect(
             getDisplayName = { name: String -> "RConnect($name)" }
             methodName = "rConnect"
             options(this)
-        }.unsafeCast<Options<Any, RProps, RProps, DispatchProps<A, R>>>()
+        }.unsafeCast<Options<Any, Props, Props, DispatchProps<A, R>>>()
     )
 }
 
-fun <S, OP : RProps, P : RProps> rConnect(
+fun <S, OP : Props, P : Props> rConnect(
     mapStateToProps: P.(S, OP) -> Unit,
     options: (Options<S, OP, P, P>.() -> Unit) = {},
 ): HOC<P, OP> {
-    return connect<S, Any, Any, OP, P, RProps, P>(
+    return connect<S, Any, Any, OP, P, Props, P>(
         { state: S, ownProps: OP ->
             js {
                 mapStateToProps(this, state, ownProps)
@@ -39,11 +39,11 @@ fun <S, OP : RProps, P : RProps> rConnect(
     )
 }
 
-fun <A, R, OP : RProps, P : RProps> rConnect(
+fun <A, R, OP : Props, P : Props> rConnect(
     mapDispatchToProps: P.((A) -> R, OP) -> Unit,
-    options: (Options<Any, OP, RProps, P>.() -> Unit) = {},
+    options: (Options<Any, OP, Props, P>.() -> Unit) = {},
 ): HOC<P, OP> {
-    return connect<Any, A, R, OP, RProps, P, P>(
+    return connect<Any, A, R, OP, Props, P, P>(
         undefined,
         { dispatch, ownProps ->
             js {
@@ -55,11 +55,11 @@ fun <A, R, OP : RProps, P : RProps> rConnect(
             getDisplayName = { name: String -> "RConnect($name)" }
             methodName = "rConnect"
             options(this)
-        }.unsafeCast<Options<Any, OP, RProps, P>>()
+        }.unsafeCast<Options<Any, OP, Props, P>>()
     )
 }
 
-fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> rConnect(
+fun <S, A, R, OP : Props, SP : Props, DP : Props, P : Props> rConnect(
     mapStateToProps: SP.(S, OP) -> Unit,
     mapDispatchToProps: DP.((A) -> R, OP) -> Unit,
     options: (Options<S, OP, SP, P>.() -> Unit) = {},
@@ -84,7 +84,7 @@ fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> rConnect(
     )
 }
 
-fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> rConnect(
+fun <S, A, R, OP : Props, SP : Props, DP : Props, P : Props> rConnect(
     mapStateToProps: SP.(S, OP) -> Unit,
     mapDispatchToProps: DP.((A) -> R, OP) -> Unit,
     mergeProps: P.(SP, DP, OP) -> Unit,

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Imports.kt
@@ -10,19 +10,19 @@ external class Provider : Component<ProviderProps, State> {
     override fun render(): ReactElement?
 }
 
-external interface ProviderProps : RProps {
+external interface ProviderProps : PropsWithChildren {
     var store: Store<*, *, *>
     var context: Context<*>
 }
 
-external fun <S, A, R, OP : RProps, SP : RProps, DP : RProps, P : RProps> connect(
+external fun <S, A, R, OP : Props, SP : Props, DP : Props, P : Props> connect(
     mapStateToProps: ((S, OP) -> SP)? = definedExternally,
     mapDispatchToProps: (((A) -> R, OP) -> DP)? = definedExternally,
     mergeProps: ((SP, DP, OP) -> P)? = definedExternally,
     options: Options<S, OP, SP, P>? = definedExternally,
 ): HOC<P, OP>
 
-external fun <S, A, R, OP : RProps, P : RProps> connectAdvanced(
+external fun <S, A, R, OP : Props, P : Props> connectAdvanced(
     selectorFactory: SelectorFactory<S, A, R, OP, P>,
     options: ConnectOptions<P> = definedExternally,
 ): HOC<P, OP>

--- a/kotlin-react-redux/src/main/kotlin/react/redux/Types.kt
+++ b/kotlin-react-redux/src/main/kotlin/react/redux/Types.kt
@@ -1,9 +1,9 @@
 package react.redux
 
 import react.ComponentClass
-import react.RProps
+import react.Props
 
-external interface ConnectOptions<P : RProps> : FactoryOptions<P> {
+external interface ConnectOptions<P : Props> : FactoryOptions<P> {
     var getDisplayName: ((String) -> String)?
     var methodName: String?
     var renderCountProp: String?
@@ -12,7 +12,7 @@ external interface ConnectOptions<P : RProps> : FactoryOptions<P> {
     var withRef: Boolean?
 }
 
-external interface Options<S, OP : RProps, SP : RProps, P : RProps> : ConnectOptions<P> {
+external interface Options<S, OP : Props, SP : Props, P : Props> : ConnectOptions<P> {
     var pure: Boolean?
     var areStatesEqual: ((S, S) -> Boolean)?
     var areOwnPropsEqual: ((OP, OP) -> Boolean)?
@@ -20,7 +20,7 @@ external interface Options<S, OP : RProps, SP : RProps, P : RProps> : ConnectOpt
     var areMergedPropsEqual: ((P, P) -> Boolean)?
 }
 
-external interface FactoryOptions<P : RProps> {
+external interface FactoryOptions<P : Props> {
     var displayName: String?
     var wrappedComponentName: String?
     var wrappedComponent: ComponentClass<P>?
@@ -30,6 +30,6 @@ typealias Selector<S, OP, P> = (S, OP) -> P
 
 typealias SelectorFactory<S, A, R, OP, P> = ((A) -> R, FactoryOptions<P>) -> Selector<S, OP, P>
 
-interface DispatchProps<A, R> : RProps {
+interface DispatchProps<A, R> : Props {
     var dispatch: (A) -> R
 }


### PR DESCRIPTION
cc @turansky @aerialist7 