### PR TITLE
`RProps` is removed from dom and styled

### DIFF
--- a/kotlin-react-dom/src/main/kotlin/react/dom/RDOMBuilder.kt
+++ b/kotlin-react-dom/src/main/kotlin/react/dom/RDOMBuilder.kt
@@ -9,7 +9,7 @@ external interface InnerHTML {
     var __html: String
 }
 
-external interface WithClassName : RProps {
+external interface WithClassName : PropsWithChildren {
     var className: String?
 }
 

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
@@ -21,7 +21,7 @@ typealias DIVBuilder = StyledDOMBuilder<DIV>.() -> Unit
 typealias SPANBuilder = StyledDOMBuilder<SPAN>.() -> Unit
 typealias INPUTBuilder = StyledDOMBuilder<INPUT>.() -> Unit
 
-external interface CustomStyledProps : RProps {
+external interface CustomStyledProps : Props {
     var css: ArrayList<RuleSet>?
 }
 

--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -21,7 +21,7 @@ typealias DIVBuilder = StyledDOMBuilder<DIV>.() -> Unit
 typealias SPANBuilder = StyledDOMBuilder<SPAN>.() -> Unit
 typealias INPUTBuilder = StyledDOMBuilder<INPUT>.() -> Unit
 
-external interface CustomStyledProps : RProps {
+external interface CustomStyledProps : Props {
     var css: ArrayList<RuleSet>?
 }
 
@@ -132,8 +132,8 @@ private fun injectGlobals(strings: Array<String>) {
     }
 }
 
-private external interface GlobalStylesComponentProps : RProps {
-    var globalStyles: List<ComponentType<RProps>>
+private external interface GlobalStylesComponentProps : Props {
+    var globalStyles: List<ComponentType<*>>
 }
 
 private object GlobalStyles {
@@ -149,9 +149,9 @@ private object GlobalStyles {
         element
     }
 
-    private val styles = mutableListOf<ComponentType<RProps>>()
+    private val styles = mutableListOf<ComponentType<*>>()
 
-    fun add(globalStyle: ComponentType<RProps>) {
+    fun add(globalStyle: ComponentType<*>) {
         styles.add(globalStyle)
         val reactElement = createElement(component, jsObject {
             this.globalStyles = styles

--- a/kotlin-styled/src/main/kotlin/styled/styled-components.kt
+++ b/kotlin-styled/src/main/kotlin/styled/styled-components.kt
@@ -6,7 +6,7 @@ package styled
 import kotlinext.js.TemplateTag
 import react.ComponentClass
 import react.ComponentType
-import react.RProps
+import react.Props
 import react.dom.WithClassName
 
 external interface StyledProps : WithClassName {
@@ -52,7 +52,7 @@ external val css: TemplateTag<dynamic, String>
  * isolated from other components. In the case of createGlobalStyle, this limitation is removed
  * and things like CSS resets or base stylesheets can be applied.
  */
-external val createGlobalStyle: TemplateTag<Nothing, ComponentType<RProps>>
+external val createGlobalStyle: TemplateTag<Nothing, ComponentType<Props>>
 
 /**
  * A utility to help identify styled components.


### PR DESCRIPTION
**WARNING:** small breaking change
`CustomStyledProps` does not includes children anymore. This change has been made according to _Interface Segregation Principle_
#### Migration guide
Before: 
```kotlin
external interface MyButtonProps : CustomStyledProps
```
After:
```kotlin
external interface MyButtonProps : CustomStyledProps, PropsWithChildren
```
**ATTENTION:** add `PropsWithChildren` only if you really need it, only if you somehow use `children` in you component with `CustomStyledProps`

cc @turansky @aerialist7 @tretikoff 
