### PR TITLE
`RProps` is removed from react-router-dom

### DIFF
--- a/examples/src/main/kotlin/example/ReactRouterDom.kt
+++ b/examples/src/main/kotlin/example/ReactRouterDom.kt
@@ -2,7 +2,6 @@ package example
 
 import react.Props
 import react.RBuilder
-import react.RProps
 import react.dom.*
 import react.fc
 import react.router.dom.*
@@ -11,7 +10,7 @@ val Home = fc<Props> { h2 { +"Home" } }
 val About = fc<Props> { h2 { +"About" } }
 
 val Topics = fc<Props> {
-    val match = useRouteMatch<RProps>() ?: return@fc
+    val match = useRouteMatch<Props>() ?: return@fc
 
     div {
         h2 { +"Topics" }
@@ -34,7 +33,7 @@ val Topics = fc<Props> {
     }
 }
 
-external interface TopicProps : RProps {
+external interface TopicProps : Props {
     val topicId: String
 }
 

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/helpers.kt
@@ -3,8 +3,8 @@ package react.router.dom
 import react.*
 import kotlin.reflect.KClass
 
-fun <P : RProps> withRouter(klazz: KClass<out Component<P, *>>): ComponentClass<P> =
+fun <P : Props> withRouter(klazz: KClass<out Component<P, *>>): ComponentClass<P> =
     rawWithRouter(klazz.react)
 
-fun <P : RProps> withRouter(component: FC<P>): ComponentClass<P> =
+fun <P : Props> withRouter(component: FC<P>): ComponentClass<P> =
     rawWithRouter(component)

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -2,9 +2,9 @@ package react.router.dom
 
 import kotlinext.js.Object
 import kotlinext.js.jsObject
-import react.RProps
+import react.Props
 
-fun <T : RProps> useParams(): T? {
+fun <T : Props> useParams(): T? {
     val params = rawUseParams()
 
     return if (Object.keys(params).isNotEmpty()) {
@@ -12,7 +12,7 @@ fun <T : RProps> useParams(): T? {
     } else null
 }
 
-fun <T : RProps> useRouteMatch(
+fun <T : Props> useRouteMatch(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -5,7 +5,7 @@ package react.router.dom
 
 import kotlinext.js.Record
 import react.ComponentClass
-import react.RProps
+import react.Props
 
 external fun useHistory(): History
 
@@ -15,10 +15,10 @@ external fun useLocation(): Location
 external fun rawUseParams(): Record<String, String>
 
 @JsName("useRouteMatch")
-external fun <T : RProps> rawUseRouteMatch(options: dynamic): Match<T>
+external fun <T : Props> rawUseRouteMatch(options: dynamic): Match<T>
 
 @JsName("matchPath")
-external fun <T : RProps> rawMatchPath(pathName: String, options: dynamic): Match<T>?
+external fun <T : Props> rawMatchPath(pathName: String, options: dynamic): Match<T>?
 
 @JsName("withRouter")
-external fun <T : RProps> rawWithRouter(component: dynamic): ComponentClass<T>
+external fun <T : Props> rawWithRouter(component: dynamic): ComponentClass<T>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -62,7 +62,7 @@ external interface NavLinkProps<T : Props> : LinkProps {
     var location: Location
 }
 
-external interface RouteResultProps<T : Props> {
+external interface RouteResultProps<T : Props> : Props {
     var history: History
     var location: Location
     var match: Match<T>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -9,21 +9,21 @@ external val HashRouter: ComponentClass<HashRouterProps>
 
 external val BrowserRouter: ComponentClass<BrowserRouterProps>
 
-external val Switch: ComponentClass<RProps>
+external val Switch: ComponentClass<PropsWithChildren>
 
-external class Route<T : RProps> : Component<RouteProps<T>, State> {
+external class Route<T : Props> : Component<RouteProps<T>, State> {
     override fun render(): ReactElement?
 }
 
 external val Link: ComponentClass<LinkProps>
 
-external class NavLink<T : RProps> : Component<NavLinkProps<T>, State> {
+external class NavLink<T : Props> : Component<NavLinkProps<T>, State> {
     override fun render(): ReactElement?
 }
 
 external val Redirect: ComponentClass<RedirectProps>
 
-external interface RouterProps : RProps {
+external interface RouterProps : PropsWithChildren {
     var history: History
 }
 
@@ -62,7 +62,7 @@ external interface NavLinkProps<T : Props> : LinkProps {
     var location: Location
 }
 
-external interface RouteResultProps<T : Props> : Props {
+external interface RouteResultProps<T : Props> {
     var history: History
     var location: Location
     var match: Match<T>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -13,7 +13,7 @@ fun RBuilder.hashRouter(
     basename: String = "",
     hashType: HashType = HashType.slash,
     getUserConfirmation: GetUserConfirmation? = null,
-    handler: RHandler<PropsWithChildren>,
+    handler: Render,
 ) {
     HashRouter {
         attrs {
@@ -31,7 +31,7 @@ fun RBuilder.browserRouter(
     getUserConfirmation: GetUserConfirmation? = null,
     forceRefresh: Boolean = false,
     keyLength: Int = 6,
-    handler: RHandler<PropsWithChildren>,
+    handler: Render,
 ) {
     BrowserRouter {
         attrs {
@@ -46,7 +46,7 @@ fun RBuilder.browserRouter(
 }
 
 fun RBuilder.switch(
-    handler: RHandler<PropsWithChildren>,
+    handler: Render,
 ) {
     Switch(handler)
 }
@@ -117,7 +117,7 @@ fun RBuilder.routeLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
-    handler: RHandler<PropsWithChildren>?,
+    handler: Render?,
 ) {
     Link {
         attrs {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -13,7 +13,7 @@ fun RBuilder.hashRouter(
     basename: String = "",
     hashType: HashType = HashType.slash,
     getUserConfirmation: GetUserConfirmation? = null,
-    handler: Render,
+    handler: RHandler<PropsWithChildren>,
 ) {
     HashRouter {
         attrs {
@@ -31,7 +31,7 @@ fun RBuilder.browserRouter(
     getUserConfirmation: GetUserConfirmation? = null,
     forceRefresh: Boolean = false,
     keyLength: Int = 6,
-    handler: Render,
+    handler: RHandler<PropsWithChildren>,
 ) {
     BrowserRouter {
         attrs {
@@ -46,7 +46,7 @@ fun RBuilder.browserRouter(
 }
 
 fun RBuilder.switch(
-    handler: Render,
+    handler: RHandler<PropsWithChildren>,
 ) {
     Switch(handler)
 }
@@ -117,7 +117,7 @@ fun RBuilder.routeLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
-    handler: Render?,
+    handler: RHandler<PropsWithChildren>?,
 ) {
     Link {
         attrs {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -13,7 +13,7 @@ fun RBuilder.hashRouter(
     basename: String = "",
     hashType: HashType = HashType.slash,
     getUserConfirmation: GetUserConfirmation? = null,
-    handler: RHandler<RProps>,
+    handler: RHandler<PropsWithChildren>,
 ) {
     HashRouter {
         attrs {
@@ -31,7 +31,7 @@ fun RBuilder.browserRouter(
     getUserConfirmation: GetUserConfirmation? = null,
     forceRefresh: Boolean = false,
     keyLength: Int = 6,
-    handler: RHandler<RProps>,
+    handler: RHandler<PropsWithChildren>,
 ) {
     BrowserRouter {
         attrs {
@@ -46,7 +46,7 @@ fun RBuilder.browserRouter(
 }
 
 fun RBuilder.switch(
-    handler: RHandler<RProps>,
+    handler: RHandler<PropsWithChildren>,
 ) {
     Switch(handler)
 }
@@ -57,7 +57,7 @@ fun RBuilder.route(
     exact: Boolean = false,
     strict: Boolean = false,
 ) {
-    child<RouteProps<RProps>, Route<RProps>> {
+    child<RouteProps<Props>, Route<Props>> {
         attrs {
             this.path = path
             this.exact = exact
@@ -69,7 +69,7 @@ fun RBuilder.route(
 
 fun RBuilder.route(
     vararg path: String,
-    component: KClass<out Component<RProps, *>>,
+    component: KClass<out Component<Props, *>>,
     exact: Boolean = false,
     strict: Boolean = false,
 ) {
@@ -81,7 +81,7 @@ fun RBuilder.route(
     )
 }
 
-fun <T : RProps> RBuilder.route(
+fun <T : Props> RBuilder.route(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
@@ -103,7 +103,7 @@ fun RBuilder.route(
     strict: Boolean = false,
     render: Render,
 ) {
-    child<RouteProps<RProps>, Route<RProps>> {
+    child<RouteProps<Props>, Route<Props>> {
         attrs {
             this.path = path
             this.exact = exact
@@ -117,7 +117,7 @@ fun RBuilder.routeLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
-    handler: RHandler<RProps>?,
+    handler: RHandler<PropsWithChildren>?,
 ) {
     Link {
         attrs {
@@ -129,7 +129,7 @@ fun RBuilder.routeLink(
     }
 }
 
-fun <T : RProps> RBuilder.navLink(
+fun <T : Props> RBuilder.navLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
@@ -171,7 +171,7 @@ fun RBuilder.redirect(
     }
 }
 
-fun <T : RProps> matchPath(
+fun <T : Props> matchPath(
     patName: String,
     vararg path: String,
     exact: Boolean = false,

--- a/kotlin-react/src/main/kotlin/react/Props.kt
+++ b/kotlin-react/src/main/kotlin/react/Props.kt
@@ -6,11 +6,10 @@ external interface PropsWithChildren : Props {
     var children: Array<out ReactNode>?
 }
 
-// TODO: deprecate it
-//@Deprecated(
-//    message = "Legacy type alias",
-//    replaceWith = ReplaceWith("PropsWithChildren", "react.PropsWithChildren"),
-//)
+@Deprecated(
+    message = "Legacy type alias",
+    replaceWith = ReplaceWith("PropsWithChildren", "react.PropsWithChildren"),
+)
 typealias RProps = PropsWithChildren
 
 var Props.key: Key


### PR DESCRIPTION
cc @turansky @aerialist7 