### PR TITLE
Strict type for `VirtualItem.measureRef`

### DIFF
--- a/kotlin-react-virtual/src/main/kotlin/react/virtual/VirtualItem.kt
+++ b/kotlin-react-virtual/src/main/kotlin/react/virtual/VirtualItem.kt
@@ -1,11 +1,12 @@
 package react.virtual
 
 import org.w3c.dom.HTMLElement
+import react.RefCallback
 
 external interface VirtualItem {
     val index: Int
     val start: Int
     val size: Int
     val end: Int
-    val measureRef: (el: HTMLElement?) -> Unit
+    val measureRef: RefCallback<HTMLElement>
 }


### PR DESCRIPTION
Fix #651 comments

cc @sgrishchenko @aerialist7 