### PR TITLE
[ring-ui] Add Footer component

### DIFF
--- a/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
@@ -3,7 +3,17 @@
 
 package ringui
 
+import kotlinext.js.ReadonlyArray
 import react.ComponentClass
+import react.dom.WithClassName
+
+// https://github.com/JetBrains/ring-ui/blob/master/components/footer/footer.js
+external interface FooterProps : WithClassName {
+    var floating: Boolean
+    var left: ReadonlyArray<IFooterItem>
+    var center: ReadonlyArray<IFooterItem>
+    var right: ReadonlyArray<IFooterItem>
+}
 
 @JsName("default")
 external val Footer: ComponentClass<FooterProps>

--- a/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
@@ -1,0 +1,11 @@
+@file:JsModule("@jetbrains/ring-ui/components/footer/footer")
+@file:JsNonModule
+
+package ringui
+
+import react.ComponentClass
+
+@JsName("default")
+external val Footer: ComponentClass<FooterProps>
+
+//It seems that FooterColumn and FooterLine are not supposed to be used outside of Footer itself (in other words, only Footer should use them)

--- a/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/Footer.kt
@@ -7,7 +7,6 @@ import kotlinext.js.ReadonlyArray
 import react.ComponentClass
 import react.dom.WithClassName
 
-// https://github.com/JetBrains/ring-ui/blob/master/components/footer/footer.js
 external interface FooterProps : WithClassName {
     var floating: Boolean
     var left: ReadonlyArray<IFooterItem>
@@ -17,5 +16,3 @@ external interface FooterProps : WithClassName {
 
 @JsName("default")
 external val Footer: ComponentClass<FooterProps>
-
-//It seems that FooterColumn and FooterLine are not supposed to be used outside of Footer itself (in other words, only Footer should use them)

--- a/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
@@ -1,0 +1,26 @@
+package ringui
+
+import kotlinext.js.ReadonlyArray
+import react.dom.HTMLAttributeAnchorTarget
+import react.dom.WithClassName
+
+external interface FooterItem {
+    //Empty, as Footer props accept only plain arrays of either Any (it will convert it into String), either FooterDataItem
+}
+
+inline fun FooterItem(string: String): FooterItem = string.unsafeCast<FooterItem>()
+
+external interface FooterDataItem : FooterItem {
+    var copyright: String
+    var url: String
+    var label: String
+    var title: String
+    var target: HTMLAttributeAnchorTarget
+}
+
+external interface FooterProps : WithClassName {
+    var floating: Boolean
+    var left: ReadonlyArray<FooterItem>
+    var center: ReadonlyArray<FooterItem>
+    var right: ReadonlyArray<FooterItem>
+}

--- a/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
@@ -2,9 +2,7 @@ package ringui
 
 import react.dom.HTMLAttributeAnchorTarget
 
-sealed external interface IFooterItem {
-    
-}
+sealed external interface IFooterItem
 
 inline fun IFooterItem(string: String): IFooterItem =
     string.unsafeCast<IFooterItem>()

--- a/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
@@ -1,26 +1,18 @@
-package ringui
+package by.enrollie.eversity_web.components
 
-import kotlinext.js.ReadonlyArray
 import react.dom.HTMLAttributeAnchorTarget
-import react.dom.WithClassName
 
-external interface FooterItem {
-    //Empty, as Footer props accept only plain arrays of either Any (it will convert it into String), either FooterDataItem
+sealed external interface IFooterItem {
+    //Empty, as Footer props accept only plain arrays of either Any (it will convert it into String), either FooterItem
 }
 
-inline fun FooterItem(string: String): FooterItem = string.unsafeCast<FooterItem>()
+inline fun FooterItem(string: String): IFooterItem =
+    string.unsafeCast<IFooterItem>()
 
-external interface FooterDataItem : FooterItem {
+external interface FooterItem : IFooterItem {
     var copyright: String
     var url: String
     var label: String
     var title: String
     var target: HTMLAttributeAnchorTarget
-}
-
-external interface FooterProps : WithClassName {
-    var floating: Boolean
-    var left: ReadonlyArray<FooterItem>
-    var center: ReadonlyArray<FooterItem>
-    var right: ReadonlyArray<FooterItem>
 }

--- a/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
@@ -3,10 +3,10 @@ package ringui
 import react.dom.HTMLAttributeAnchorTarget
 
 sealed external interface IFooterItem {
-    //Empty, as Footer props accept only plain arrays of either Any (it will convert it into String), either FooterItem
+    
 }
 
-inline fun FooterItem(string: String): IFooterItem =
+inline fun IFooterItem(string: String): IFooterItem =
     string.unsafeCast<IFooterItem>()
 
 external interface FooterItem : IFooterItem {

--- a/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
+++ b/kotlin-ring-ui/src/main/kotlin/ringui/FooterItem.kt
@@ -1,4 +1,4 @@
-package by.enrollie.eversity_web.components
+package ringui
 
 import react.dom.HTMLAttributeAnchorTarget
 


### PR DESCRIPTION
``` FooterItem ``` and ``` FooterDataItem ``` are called so because in Ring UI they are referred to as "item":
```js
function renderItem(item) {
    if (isValidElement(item)) {
      return item;
    }
// ...
```
```js
const element = (item.copyright ? copyright(item.copyright) : '') + (item.label || item);
```
```js
FooterLine.propTypes = {
  item: PropTypes.oneOfType([
    PropTypes.object,
    PropTypes.array,
    PropTypes.string
  ])
};
```