### PR TITLE
[kotlin-styled-next] prefixer for styles

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleList.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleList.kt
@@ -1,11 +1,15 @@
 package kotlinx.css
 
-open class StyleList<in T>(private val delimiter: String) {
+open class StyleList<T>(private val delimiter: String) {
     private val list = mutableListOf<T>()
 
     override fun toString() = when {
         list.isEmpty() -> "none"
         else -> list.joinToString(delimiter)
+    }
+
+    fun<R> map(transform: (T) -> R): List<R> {
+        return list.map(transform)
     }
 
     fun clear() = list.clear()

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleList.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleList.kt
@@ -1,15 +1,11 @@
 package kotlinx.css
 
-open class StyleList<T>(private val delimiter: String) {
+open class StyleList<in T>(private val delimiter: String) {
     private val list = mutableListOf<T>()
 
     override fun toString() = when {
         list.isEmpty() -> "none"
         else -> list.joinToString(delimiter)
-    }
-
-    fun<R> map(transform: (T) -> R): List<R> {
-        return list.map(transform)
     }
 
     fun clear() = list.clear()

--- a/kotlin-styled-next/src/main/kotlin/styled/CssBuilder.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/CssBuilder.kt
@@ -14,14 +14,5 @@ fun CssBuilder.animation(
     builder: KeyframesBuilder.() -> Unit,
 ) {
     val name = GlobalStyles.scheduleToInject(builder)
-    declarations["animation"] = Animation(
-        duration,
-        timing,
-        delay,
-        iterationCount,
-        direction,
-        fillMode,
-        playState,
-        name
-    )
+    animation(name, duration, timing, delay, iterationCount, direction, fillMode, playState)
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
@@ -145,7 +145,7 @@ object GlobalStyles {
             val usedKeyframeInfo = injectedKeyframes[keyframes] ?: throw IllegalStateException("Trying to remove non-existent keyframe")
             usedKeyframeInfo.usedBy--
             if (usedKeyframeInfo.usedBy == 0) {
-                scheduledToDeleteKeyframes.add(Pair(animationName, keyframes))
+                scheduledToDeleteKeyframes.add(animationName to keyframes)
             }
         }
         sheet.requestClean { clean(sheet) }
@@ -178,7 +178,7 @@ object GlobalStyles {
     internal fun getInjectedClassNames(styledCss: StyledCss): Pair<ClassName, List<ClassName>> {
         val selfClassName = getInjectedClassName(styledCss)
         val externalClassNames = styledCss.classes
-        return Pair(selfClassName, externalClassNames)
+        return selfClassName to externalClassNames
     }
 
     /**

--- a/kotlin-styled-next/src/main/kotlin/styled/InlineStylePrefixer.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/InlineStylePrefixer.kt
@@ -4,7 +4,7 @@
 package styled
 
 /**
- * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/prefix.md)
+ * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/createPrefixer.md)
  *
  * @param data an object containing a valid prefixMap and a plugins list
  * @return custom prefix function
@@ -12,7 +12,7 @@ package styled
 external fun createPrefixer(data: dynamic): dynamic
 
 /**
- * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/createPrefixer.md)
+ * [Online Documentation](https://github.com/rofrischmann/inline-style-prefixer/blob/master/docs/api/prefix.md)
  *
  * @param style an object containing valid style declarations
  * @return an object containing all style declarations with vendor prefixes

--- a/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
@@ -57,8 +57,8 @@ private fun CssDeclarations.mapToObj(): dynamic {
     return res
 }
 
-internal fun CssDeclarations.buildPrefixedString(): String {
-   val res = mapToObj()
+internal fun CssDeclarations.buildPrefixedString(indent: String = ""): String {
+    val res = mapToObj()
 
     val prefixed = prefix(res) as Object
     return buildString {
@@ -66,10 +66,11 @@ internal fun CssDeclarations.buildPrefixedString(): String {
             val value = prefixed.asDynamic()[it]
 
             if (value is JsArray) {
-                val displayValue = value.find(js("function(element) { return !element.startsWith('-') }"))
-                appendLine("${it.hyphenize()}: ${displayValue};")
+                for (i in 0 until value.length as Int) {
+                    appendLine("$indent${it.hyphenize()}: ${value[i]};")
+                }
             } else {
-                appendLine("${it.hyphenize()}: ${value};")
+                appendLine("$indent${it.hyphenize()}: ${value};")
             }
         }
     }

--- a/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/InlineStyles.kt
@@ -2,7 +2,9 @@ package styled
 
 import kotlinext.js.Object
 import kotlinext.js.js
+import kotlinx.css.CssDeclarations
 import kotlinx.css.StyledElement
+import kotlinx.css.hyphenize
 import react.dom.RDOMBuilder
 import react.dom.setProp
 
@@ -17,13 +19,7 @@ fun RDOMBuilder<*>.inlineStyles(prefix: Boolean = true, builder: StyledElement.(
 private external class JsArray
 
 fun StyledElement.toStyle(prefix: Boolean = true): Any {
-    val res = js { }
-    declarations.forEach { (key, value) ->
-        res[key] = when (value) {
-            is String, is Number -> value
-            else -> value.toString()
-        }
-    }
+    val res = declarations.mapToObj()
 
     if (!prefix) {
         return res
@@ -48,4 +44,33 @@ fun StyledElement.toStyle(prefix: Boolean = true): Any {
     }
 
     return prefixed
+}
+
+private fun CssDeclarations.mapToObj(): dynamic {
+    val res = js { }
+    forEach { (key, value) ->
+        res[key] = when (value) {
+            is String, is Number -> value
+            else -> value.toString()
+        }
+    }
+    return res
+}
+
+internal fun CssDeclarations.buildPrefixedString(): String {
+   val res = mapToObj()
+
+    val prefixed = prefix(res) as Object
+    return buildString {
+        Object.keys(prefixed).forEach {
+            val value = prefixed.asDynamic()[it]
+
+            if (value is JsArray) {
+                val displayValue = value.find(js("function(element) { return !element.startsWith('-') }"))
+                appendLine("${it.hyphenize()}: ${displayValue};")
+            } else {
+                appendLine("${it.hyphenize()}: ${value};")
+            }
+        }
+    }
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
@@ -118,7 +118,7 @@ fun customStyled(type: String): ComponentType<StyledProps> {
                 GlobalStyles.checkGeneratedCss(generatedClasses, selfClassName, type)
             }
             GlobalStyles.injectScheduled()
-            Pair(styledCss, (classes + selfClassName).joinToString(" "))
+            styledCss to (classes + selfClassName).joinToString(" ")
         }
 
         useEffect(css) {

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
@@ -126,7 +126,7 @@ fun customStyled(type: String): ComponentType<StyledProps> {
         }
 
         val newProps = clone(props)
-        newProps.className = (if (props.className != undefined) props.className else "") + classNames
+        newProps.className = (if (props.className != undefined) props.className + " " else "") + classNames
         newProps.ref = rRef
         newProps.asDynamic().css = undefined
         child(createElement(type, newProps))

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -40,7 +40,7 @@ internal open class StyledCss(
     val classes: List<String>,
 ) {
     internal val animationNames = mutableListOf<AnimationName>()
-    private val declarations = declarations?.buildPrefixedString() ?: ""
+    private val declarationBlock = declarations?.buildPrefixedString("  ") ?: ""
 
     init {
         declarations?.forEach { (_, value) ->
@@ -60,7 +60,7 @@ internal open class StyledCss(
 
     private var memoizedHashCode: Int? = null
     override fun hashCode(): Int {
-        return memoizedHashCode ?: (rules.sumOf { it.hashCode() } + declarations.hashCode())
+        return memoizedHashCode ?: (rules.sumOf { it.hashCode() } + declarationBlock.hashCode())
             .also { hashCode -> memoizedHashCode = hashCode }
     }
 
@@ -71,7 +71,7 @@ internal open class StyledCss(
 
         return hashCode() == other.hashCode()
                 && rules == other.rules
-                && declarations == other.declarations
+                && declarationBlock == other.declarationBlock
     }
 
     /**
@@ -83,11 +83,11 @@ internal open class StyledCss(
     fun getCssRules(outerSelector: String?, indent: String = ""): List<String> {
         val result = mutableListOf<String>()
         val (rules, handleRules) = rules.partition { !withCustomHandle(it.selector) }
-        if (declarations.isNotEmpty() && outerSelector != null) {
+        if (declarationBlock.isNotEmpty() && outerSelector != null) {
             result.add(
                 buildString {
                     appendLine("$indent$outerSelector {")
-                    append(declarations)
+                    append(declarationBlock)
                     appendLine("$indent}")
                 }
             )

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -1,7 +1,7 @@
 package styled
 
 import kotlinx.css.*
-import kotlinx.css.properties.Animation
+import kotlinx.css.properties.Animations
 import kotlinx.css.properties.KeyframesBuilder
 
 internal typealias ClassName = String
@@ -35,16 +35,17 @@ internal data class StyledRule(
  * StyledCss is used to efficiently build CSS rules from the DSL representation.
  */
 internal open class StyledCss(
-    declarations: LinkedHashMap<String, Any>?,
+    declarations: CssDeclarations?,
     private val rules: List<StyledRule>,
     val classes: List<String>,
 ) {
     internal val animationNames = mutableListOf<AnimationName>()
-    private val declarations = buildString {
-        declarations?.forEach { (key, value) ->
-            append("${key.hyphenize()}: ${value};\n")
-            if (value is Animation) {
-                animationNames.add(value.name)
+    private val declarations = declarations?.buildPrefixedString() ?: ""
+
+    init {
+        declarations?.forEach { (_, value) ->
+            if (value is Animations) {
+                animationNames.addAll(value.map { it.name })
             }
         }
     }
@@ -85,9 +86,9 @@ internal open class StyledCss(
         if (declarations.isNotEmpty() && outerSelector != null) {
             result.add(
                 buildString {
-                    append("$indent$outerSelector {\n")
+                    appendLine("$indent$outerSelector {")
                     append(declarations)
-                    append("$indent}\n")
+                    appendLine("$indent}")
                 }
             )
         }

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -39,16 +39,7 @@ internal open class StyledCss(
     private val rules: List<StyledRule>,
     val classes: List<String>,
 ) {
-    internal val animationNames = mutableListOf<AnimationName>()
     private val declarationBlock = declarations?.buildPrefixedString("  ") ?: ""
-
-    init {
-        declarations?.forEach { (_, value) ->
-            if (value is Animations) {
-                animationNames.addAll(value.map { it.name })
-            }
-        }
-    }
 
     private fun withMedia(selector: Selector) = selector.trim().startsWith("@media")
     private fun withContainer(selector: Selector) = selector.trim().startsWith("@container")

--- a/kotlin-styled-next/src/test/kotlin/TestUtils.kt
+++ b/kotlin-styled-next/src/test/kotlin/TestUtils.kt
@@ -117,7 +117,6 @@ class TestScope : CoroutineScope by testScope {
         GlobalStyles.injectedStyleSheetRules.clear()
         GlobalStyles.injectedKeyframes.clear()
         GlobalStyles.keyframeByName.clear()
-        GlobalStyles.scheduledToDeleteKeyframes.clear()
         GlobalStyles.styledClasses.clear()
         GlobalStyles.scheduledToDelete.clear()
     }

--- a/kotlin-styled-next/src/test/kotlin/TestUtils.kt
+++ b/kotlin-styled-next/src/test/kotlin/TestUtils.kt
@@ -78,10 +78,23 @@ class TestScope : CoroutineScope by testScope {
         return getStyle(pseudoElt).color
     }
 
-    fun CSSRuleList.forEach(block: (rule: CSSRule?) -> Unit) {
+    fun CSSRuleList.forEach(block: (rule: CSSRule) -> Unit) {
         for (i in 0 until this.length) {
-            block(this[i])
+            val value = this[i]
+            assertNotNull(value)
+            block(value)
         }
+    }
+
+    fun CSSRuleList.find(predicate: (rule: CSSRule) -> Boolean): CSSRule? {
+        for (i in 0 until this.length) {
+            val value = this[i]
+            assertNotNull(value)
+            if (predicate(value)) {
+                return value
+            }
+        }
+        return null
     }
 
     fun assertChildrenCount(n: Int) {

--- a/kotlin-styled-next/src/test/kotlin/test/AtRulesTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/AtRulesTest.kt
@@ -32,7 +32,7 @@ class AtRulesTest : TestBase() {
         }
         val element = clearAndInject(styledComponent)
         assertEquals(firstColor.toString(), element.childAt(0).color())
-        assertCssInjected("@supports $query", listOf("color" to firstColor.toString()))
+        assertCssInjected("@supports $query", "color" to firstColor.toString())
     }
 
     @Test
@@ -47,7 +47,7 @@ class AtRulesTest : TestBase() {
             }
         }
         clearAndInject(styledComponent)
-        assertCssInjected("@font-face", listOf("font-family" to "Roboto"))
+        assertCssInjected("@font-face", "font-family" to "Roboto")
     }
 
     @Test
@@ -65,7 +65,7 @@ class AtRulesTest : TestBase() {
         clearAndInject(styledComponent)
         assertCssInjected(
             "@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)",
-            listOf("font-size" to "18px")
+            "font-size" to "18px"
         )
     }
 
@@ -83,9 +83,8 @@ class AtRulesTest : TestBase() {
         }
         clearAndInject(styledComponent)
         assertCssInjected(
-            "@media $query", listOf(
-                "text-transform" to "capitalize",
-            )
+            "@media $query",
+            "text-transform" to "capitalize",
         )
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
@@ -2,9 +2,11 @@ package test
 
 import kotlinx.css.*
 import kotlinx.css.properties.*
+import kotlinx.html.classes
 import org.w3c.dom.css.get
 import org.w3c.dom.get
 import react.Props
+import react.dom.attrs
 import react.dom.div
 import react.dom.span
 import react.fc
@@ -290,6 +292,19 @@ class ElementTest : TestBase() {
         GlobalStyles.sheet.injectScheduled()
         assertCssInjected(firstClassName, listOf("color" to firstColor.toString()))
         assertCssInjected(secondClassName, listOf("background-color" to secondColor.toString()))
+    }
+
+    @Test
+    fun externalClassName() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                attrs {classes = setOf("classname")}
+                css {
+                }
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        assertContains("classname ksc-", element.className)
     }
 
     @Test

--- a/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
@@ -1,57 +1,284 @@
 package test
 
 import kotlinx.css.*
+import kotlinx.css.properties.*
+import org.w3c.dom.css.get
+import org.w3c.dom.get
 import react.Props
+import react.dom.div
+import react.dom.span
 import react.fc
 import runTest
-import styled.GlobalStyles
-import styled.css
-import styled.styledDiv
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import styled.*
+import kotlin.test.*
 
 class ElementTest : TestBase() {
     @Test
-    fun min() = runTest {
+    fun styledElement() = runTest {
         val styledComponent = fc<Props> {
-            styledDiv {
+            styledSpan {
                 css {
-                    paddingLeft = min(1.px, 2.px)
+                    backgroundColor = Color.blue
+                    height = 15.px
                 }
             }
         }
-        val element = clearAndInject(styledComponent)
-        assertEquals("1px", element.getStyle().paddingLeft)
+        val styledElement = clearAndInject(styledComponent)
+        assertCssInjected(
+            styledElement.className, listOf(
+                "background-color" to Color.blue.toString(),
+                "height" to 15.px.toString()
+            )
+        )
+    }
+
+
+    @Test
+    fun innerElementPseudoClass() = runTest {
+        val styledComponent = fc<Props> {
+            styledDiv {
+                styledInput {
+                    css {
+                        color = firstColor
+                        ":focus" {
+                            color = secondColor
+                        }
+                    }
+                }
+            }
+        }
+        val child = clearAndInject(styledComponent).children[0]
+        assertNotNull(child)
+
+        assertEquals(firstColor.toString(), child.getStyle().color)
+
+        child.asInput().focus()
+        assertEquals(secondColor.toString(), child.getStyle().color)
     }
 
     @Test
-    fun max() = runTest {
+    fun multipleInnerCss() = runTest {
         val styledComponent = fc<Props> {
-            styledDiv {
+            styledSpan {
                 css {
-                    paddingLeft = max(1.px, 2.px)
+                    ":first-child" {
+                        ":first-child" {
+                            backgroundColor = firstColor
+                        }
+                    }
                 }
             }
+            styledSpan {}
         }
         val element = clearAndInject(styledComponent)
-        assertEquals("2px", element.getStyle().paddingLeft)
+        assertEquals(firstColor.toString(), element.getStyle().backgroundColor)
+        val rule = getRules()[0]
+        assertNotNull(rule)
+        assertTrue(rule.cssText.contains("${element.className}:first-child:first-child"))
     }
 
     @Test
-    fun clamp() = runTest {
-        val styledComponent = fc<Props> {
+    fun keyframesNotInjectedWithoutComponent() = runTest {
+        CssBuilder().apply {
+            animation {
+                addRotation()
+            }
+        }
+        val rules = getStylesheet().cssRules
+        assertEquals(2, sheet.scheduledGroups.size)
+        assertEquals(0, rules.length)
+    }
+
+    /**
+     *  Check that two different styled components with the same CSS use the same class
+     */
+    @Test
+    fun cssReuse() = runTest {
+        val first = fc<Props> {
+            styledSpan {
+                css {
+                    addSomeCss()
+                }
+            }
+        }
+        val second = fc<Props> {
             styledDiv {
                 css {
-                    paddingTop = clamp(2.px, 3.px, 4.px) // value inside bounds
-                    paddingLeft = clamp(2.px, 1.px, 4.px) // value lesser than lower bound
-                    paddingRight = clamp(2.px, 5.px, 4.px) // value greater than higher bound
+                    addSomeCss()
+                }
+            }
+            div {
+                styledH1 {
+                    css {
+                        addSomeCss()
+                    }
+                }
+            }
+        }
+        val firstElement = clearAndInject(first)
+        val secondElement = inject(second)
+        val rules = getStylesheet().cssRules
+        assertEquals(firstElement.className, secondElement.className)
+        assertEquals(1, rules.length)
+    }
+
+    /**
+     * Add second CSS block to a component and check that it's processed correctly
+     */
+    @Test
+    fun styledElementSecondCSS() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    backgroundColor = firstColor
+                    height = 15.px
+                }
+
+                css {
+                    backgroundColor = secondColor
+                    width = 30.px
                 }
             }
         }
         val element = clearAndInject(styledComponent)
-        assertEquals("3px", element.getStyle().paddingTop)
-        assertEquals("2px", element.getStyle().paddingLeft)
-        assertEquals("4px", element.getStyle().paddingRight)
+        val style = element.getStyle()
+        assertEquals(secondColor.toString(), style.backgroundColor)
+        assertEquals("15px", style.height)
+        assertEquals("30px", style.width)
+    }
+
+    @Test
+    fun styledElementPropertyRedeclare() = runTest {
+        val firstColor = rgb(12, 16, 18)
+        val secondColor = rgb(15, 15, 25)
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    backgroundColor = firstColor
+                    height = 15.px
+                    backgroundColor = secondColor
+                }
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        val style = element.getStyle()
+        assertEquals(secondColor.toString(), style.backgroundColor)
+        assertEquals("15px", style.height)
+    }
+
+    @Test
+    fun specificTest() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    specific {
+                        color = secondColor
+                    }
+                    color = firstColor
+                }
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        val className = element.className
+        assertCssInjected(".$className", listOf("color" to firstColor.toString()))
+        assertCssInjected(".$className.$className", listOf("color" to secondColor.toString()))
+
+        assertEquals(secondColor.toString(), element.getStyle().color)
+    }
+
+    @Test
+    fun commaSelector() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    "div, span" {
+                        color = firstColor
+                    }
+                }
+                div {}
+                span {}
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        assertEquals(firstColor.toString(), element.childAt(0).getStyle().color)
+        assertEquals(firstColor.toString(), element.childAt(1).getStyle().color)
+    }
+
+    @Test
+    fun commaSelectorSpaced() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    "  div , span   " {
+                        color = firstColor
+                    }
+                }
+                div {}
+                span {}
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        assertEquals(firstColor.toString(), element.childAt(0).getStyle().color)
+        assertEquals(firstColor.toString(), element.childAt(1).getStyle().color)
+    }
+
+    @Test
+    fun animationTest() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    animation(
+                        5.s,
+                        Timing.linear,
+                        3.s,
+                        IterationCount.infinite,
+                        AnimationDirection.reverse,
+                        FillMode.forwards,
+                        PlayState.running
+                    ) {
+                        addRotation()
+                    }
+                }
+            }
+        }
+        val classname = clearAndInject(styledComponent).className
+        val rules = getStylesheet().cssRules
+        val keyframeIdx = (0 until rules.length).first { i ->
+            val rule = rules[i]
+            rule != null && rule.cssText.contains("@keyframes")
+        }
+        val keyframeName = rules[keyframeIdx]!!.cssText.substringAfter("@keyframes ").substringBefore("{").trim()
+        assertCssInjected(
+            classname, listOf(
+                "animation" to "5s linear 3s infinite reverse forwards running $keyframeName",
+            )
+        )
+        assertCssInjected(
+            "@keyframes", listOf(
+                "transform" to "rotate(0deg)",
+                "transform" to "rotate(360deg)"
+            )
+        )
+    }
+
+
+    @Test
+    fun setCustomProperty() = runTest {
+        val styledComponent = fc<Props> {
+            styledDiv {
+                css {
+                    setCustomProperty("first-color", firstColor)
+                }
+                styledSpan {
+                    css {
+                        color = Color("first-color".toCustomProperty())
+                    }
+                }
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        assertEquals(firstColor.toString(), element.getStyle().getPropertyValue("--first-color").trim())
+        assertEquals(firstColor.toString(), element.childAt(0).color())
     }
 
     @Test
@@ -63,5 +290,27 @@ class ElementTest : TestBase() {
         GlobalStyles.sheet.injectScheduled()
         assertCssInjected(firstClassName, listOf("color" to firstColor.toString()))
         assertCssInjected(secondClassName, listOf("background-color" to secondColor.toString()))
+    }
+
+    @Test
+    fun multipleAnimations() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    animation { addRotation() }
+                    animation {
+                        from { opacity = 0 }
+                        to { opacity = 1 }
+                    }
+                }
+            }
+        }
+        clearAndInject(styledComponent)
+        val rule = getRules()[0]?.cssText
+        assertNotNull(rule)
+        assertContains("opacity: 0", rule)
+        assertContains("opacity: 1", rule)
+        assertContains("transform: rotate(0deg)", rule)
+        assertContains("transform: rotate(180deg)", rule)
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/PseudoClassRulesTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/PseudoClassRulesTest.kt
@@ -32,7 +32,7 @@ class PseudoClassRulesTest : TestBase() {
         assertEquals(firstColor.toString(), element.getStyle().color)
 
         // We can't set :active with plain js
-        assertCssInjected("${element.className}:active", listOf("color" to secondColor.toString()))
+        assertCssInjected("${element.className}:active", "color" to secondColor.toString())
     }
 
     @Test
@@ -259,7 +259,7 @@ class PseudoClassRulesTest : TestBase() {
         assertEquals(firstColor.toString(), element.color())
 
         // We can't set :hover with plain js (https://stackoverflow.com/questions/4347116/trigger-css-hover-with-js)
-        assertCssInjected("${element.className}:hover", listOf("color" to secondColor.toString()))
+        assertCssInjected("${element.className}:hover", "color" to secondColor.toString())
     }
 
     @Test
@@ -693,6 +693,6 @@ class PseudoClassRulesTest : TestBase() {
         }
         val element = clearAndInject(styledComponent)
         // We can't check that the user had visited the link, https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector
-        assertCssInjected("${element.className} a:visited", listOf("color" to secondColor.toString()))
+        assertCssInjected("${element.className} a:visited", "color" to secondColor.toString())
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/PseudoElementsTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/PseudoElementsTest.kt
@@ -67,7 +67,7 @@ class PseudoElementsTest : TestBase() {
         }
         val element = clearAndInject(styledComponent)
         // Checking computed css not working for placeholder pseudo element in chrome, https://bugs.chromium.org/p/chromium/issues/detail?id=850744
-        assertCssInjected("${element.className}::placeholder", listOf("color" to firstColor.toString()))
+        assertCssInjected("${element.className}::placeholder", "color" to firstColor.toString())
     }
 
     @Test

--- a/kotlin-styled-next/src/test/kotlin/test/RelativeSelectorsTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RelativeSelectorsTest.kt
@@ -100,7 +100,7 @@ class RelativeSelectorsTest : TestBase() {
             }
         }
         val element = clearAndInject(styledComponent)
-        assertCssInjected(".ancestor:hover .${element.childAt(0).className}", listOf("color" to secondColor.toString()))
+        assertCssInjected(".ancestor:hover .${element.childAt(0).className}", "color" to secondColor.toString())
     }
 
 

--- a/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
@@ -206,7 +206,8 @@ class RemoveCssTest : TestBase() {
         assertEquals(3, getRules().length)
 
         clear()
-        assertEquals(0, getRules().length)
+        // 2 rules remaining are keyframes, which we do not remove
+        assertEquals(2, getRules().length)
     }
 
     @Test
@@ -221,7 +222,8 @@ class RemoveCssTest : TestBase() {
         assertEquals(3, getRules().length)
 
         clear()
-        assertEquals(0, getRules().length)
+        // 2 rules remaining are keyframes, which we do not remove
+        assertEquals(2, getRules().length)
     }
 
     @Test

--- a/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
@@ -26,11 +26,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class RemoveCssTest : TestBase() {
-    val secondRoot by lazy { createDOMElement() }
-    val thirdRoot by lazy { createDOMElement() }
+    private val secondRoot by lazy { createDOMElement() }
+    private val thirdRoot by lazy { createDOMElement() }
     private var staticStyleSheet = StaticStyleSheet()
 
-    fun TestScope.injectAdditional(component: Component, root: HTMLElement = secondRoot): Element {
+    private fun TestScope.injectAdditional(component: Component, root: HTMLElement = secondRoot): Element {
         renderComponent(component, root)
         val element = root.firstElementChild
         assertNotNull(element)

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -1,7 +1,9 @@
 package test
 
 import kotlinx.browser.document
+import kotlinx.css.Align
 import kotlinx.css.CssBuilder
+import kotlinx.css.alignItems
 import kotlinx.css.px
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.css.CSSRuleList
@@ -64,15 +66,14 @@ class StyleSheetTest : TestBase() {
         }
         val styledElement = clearAndInject(styledComponent)
         assertCssInjected(
-            styledElement.className, listOf(
-                "min-height" to 66.px.toString(),
-                "padding" to 0.px.toString()
-            )
+            styledElement.className,
+            "min-height" to 66.px.toString(),
+            "padding" to 0.px.toString()
         )
     }
 
     @Test
-    fun styleSheetStaticTest() = runTest {
+    fun styleSheetStatic() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -85,20 +86,18 @@ class StyleSheetTest : TestBase() {
         assertContains(classNames, "StaticStyleSheet-property1")
         assertContains(classNames, "StaticStyleSheet-property2")
         assertCssInjected(
-            "StaticStyleSheet-property1", listOf(
-                "align-content" to "end",
-            )
+            "StaticStyleSheet-property1",
+            "align-content" to "end",
         )
         assertCssInjected(
-            "StaticStyleSheet-property2", listOf(
-                "padding" to 40.px.toString(),
-                "min-height" to 50.px.toString(),
-            )
+            "StaticStyleSheet-property2",
+            "padding" to 40.px.toString(),
+            "min-height" to 50.px.toString(),
         )
     }
 
     @Test
-    fun styleSheetSpecificTest() = runTest {
+    fun styleSheetSpecific() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -110,10 +109,9 @@ class StyleSheetTest : TestBase() {
         val element = clearAndInject(styledComponent)
         val className = element.className
         assertCssInjected(
-            ".$className.$className", listOf(
-                "padding" to 80.px.toString(),
-                "border" to "none"
-            )
+            ".$className.$className",
+            "padding" to 80.px.toString(),
+            "border" to "none"
         )
 
         assertEquals("80px", element.getStyle().padding)
@@ -147,5 +145,18 @@ class StyleSheetTest : TestBase() {
         clearAndInject(styledComponent)
         inject(styledComponent)
         assertEquals(4, getImportRules().length)
+    }
+
+    @Test
+    fun elementCssPrefixed() = runTest {
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    +staticStyleSheet.prefixedProperty
+                }
+            }
+        }
+        clearAndInject(styledComponent)
+        assertCssInjected("StaticStyleSheet-prefixedProperty", "-webkit-box-align" to "center")
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/StyledCssEqualityTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyledCssEqualityTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNotEquals
 /**
  * Check that [StyledCss] and [StyledKeyframes] with the same content are equal and have the same hash code
  */
-class StyledCssEquality : TestBase() {
+class StyledCssEqualityTest : TestBase() {
     @Test
     fun simpleCssBuilders() {
         val first = CssBuilder().apply {

--- a/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
@@ -26,7 +26,7 @@ open class TestBase {
     /**
      * Assert that injected CSS for [selector] contains all of the [declarations]
      */
-    protected fun TestScope.assertCssInjected(selector: String, declarations: List<Pair<String, String>>) {
+    protected fun TestScope.assertCssInjected(selector: String, vararg declarations: Pair<String, String>) {
         assertCssInjected(selector, declarations.map { (property, value) -> "$property: $value" })
     }
 

--- a/kotlin-styled-next/src/test/kotlin/test/styleSheets/StaticStyleSheet.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/styleSheets/StaticStyleSheet.kt
@@ -1,6 +1,10 @@
 package test.styleSheets
 
 import kotlinx.css.*
+import kotlinx.css.properties.Timing
+import kotlinx.css.properties.Transitions
+import kotlinx.css.properties.ms
+import kotlinx.css.properties.transition
 import styled.StyleSheet
 
 internal class StaticStyleSheet : StyleSheet("StaticStyleSheet", isStatic = true) {
@@ -11,5 +15,9 @@ internal class StaticStyleSheet : StyleSheet("StaticStyleSheet", isStatic = true
     val property2 by css {
         padding(40.px)
         minHeight = 50.px
+    }
+
+    val prefixedProperty by css {
+        alignItems = Align.center
     }
 }


### PR DESCRIPTION
This pull request includes features (each one with the tests):
- fix multiple animations in a component
- fix classname appending to an existsing external classname
- add prefixer