### PR TITLE
Use `Record` for `Route` `Params` to prevent wrong typings

### DIFF
--- a/examples/src/main/kotlin/example/ReactRouterDom.kt
+++ b/examples/src/main/kotlin/example/ReactRouterDom.kt
@@ -1,5 +1,6 @@
 package example
 
+import kotlinext.js.get
 import react.Props
 import react.RBuilder
 import react.dom.*
@@ -10,7 +11,7 @@ val Home = fc<Props> { h2 { +"Home" } }
 val About = fc<Props> { h2 { +"About" } }
 
 val Topics = fc<Props> {
-    val match = useRouteMatch<Props>() ?: return@fc
+    val match = useRouteMatch() ?: return@fc
 
     div {
         h2 { +"Topics" }
@@ -33,12 +34,8 @@ val Topics = fc<Props> {
     }
 }
 
-external interface TopicProps : Props {
-    val topicId: String
-}
-
 val Topic = fc<Props> {
-    val topicId = useParams<TopicProps>()?.topicId ?: return@fc
+    val topicId = useParams()["topicId"] ?: return@fc
 
     h3 { +"Requested topic ID: $topicId" }
 }

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/alias.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/alias.kt
@@ -1,3 +1,7 @@
 package react.router.dom
 
+import kotlinext.js.Record
+
+typealias Params = Record<String, String>
+
 typealias GetUserConfirmation = (message: String, callback: (Boolean) -> Unit) -> Unit

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/hooks.kt
@@ -1,23 +1,13 @@
 package react.router.dom
 
-import kotlinext.js.Object
 import kotlinext.js.jsObject
-import react.Props
 
-fun <T : Props> useParams(): T? {
-    val params = rawUseParams()
-
-    return if (Object.keys(params).isNotEmpty()) {
-        params.unsafeCast<T>()
-    } else null
-}
-
-fun <T : Props> useRouteMatch(
+fun useRouteMatch(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false,
-): Match<T>? {
+): Match? {
     if (path.isEmpty()) {
         return rawUseRouteMatch(null)
     }

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/imports.kt
@@ -3,7 +3,6 @@
 
 package react.router.dom
 
-import kotlinext.js.Record
 import react.ComponentClass
 import react.Props
 
@@ -11,14 +10,13 @@ external fun useHistory(): History
 
 external fun useLocation(): Location
 
-@JsName("useParams")
-external fun rawUseParams(): Record<String, String>
+external fun useParams(): Params
 
 @JsName("useRouteMatch")
-external fun <T : Props> rawUseRouteMatch(options: dynamic): Match<T>
+external fun rawUseRouteMatch(options: dynamic): Match?
 
 @JsName("matchPath")
-external fun <T : Props> rawMatchPath(pathName: String, options: dynamic): Match<T>?
+external fun rawMatchPath(pathName: String, options: dynamic): Match?
 
 @JsName("withRouter")
 external fun <T : Props> rawWithRouter(component: dynamic): ComponentClass<T>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routing.kt
@@ -11,15 +11,11 @@ external val BrowserRouter: ComponentClass<BrowserRouterProps>
 
 external val Switch: ComponentClass<PropsWithChildren>
 
-external class Route<T : Props> : Component<RouteProps<T>, State> {
-    override fun render(): ReactElement?
-}
+external val Route : ComponentClass<RouteProps>
 
 external val Link: ComponentClass<LinkProps>
 
-external class NavLink<T : Props> : Component<NavLinkProps<T>, State> {
-    override fun render(): ReactElement?
-}
+external val NavLink : ComponentClass<NavLinkProps>
 
 external val Redirect: ComponentClass<RedirectProps>
 
@@ -40,12 +36,12 @@ external interface HashRouterProps : RouterProps {
     var hashType: String
 }
 
-external interface RouteProps<T : Props> : Props {
+external interface RouteProps : Props {
     var path: Array<out String>
     var exact: Boolean
     var strict: Boolean
     var component: ComponentType<*>
-    var render: (props: RouteResultProps<T>) -> ReactElement?
+    var render: (props: RouteResultProps) -> ReactElement?
 }
 
 external interface LinkProps : PropsWithChildren {
@@ -54,18 +50,18 @@ external interface LinkProps : PropsWithChildren {
     var className: String?
 }
 
-external interface NavLinkProps<T : Props> : LinkProps {
+external interface NavLinkProps: LinkProps {
     var activeClassName: String
     var exact: Boolean
     var strict: Boolean
-    var isActive: ((match: Match<T>?, location: Location) -> Boolean)?
+    var isActive: ((match: Match?, location: Location) -> Boolean)?
     var location: Location
 }
 
-external interface RouteResultProps<T : Props> : Props {
+external interface RouteResultProps : Props {
     var history: History
     var location: Location
-    var match: Match<T>
+    var match: Match
 }
 
 external interface History {
@@ -86,11 +82,11 @@ external interface Location {
     var search: String
 }
 
-external interface Match<T : Props> {
+external interface Match {
     var isExact: Boolean
     var url: String
     var path: String
-    var params: T
+    var params: Params
 }
 
 external interface RedirectProps : Props {

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -57,7 +57,7 @@ fun RBuilder.route(
     exact: Boolean = false,
     strict: Boolean = false,
 ) {
-    child<RouteProps<Props>, Route<Props>> {
+    Route {
         attrs {
             this.path = path
             this.exact = exact
@@ -81,34 +81,18 @@ fun RBuilder.route(
     )
 }
 
-fun <T : Props> RBuilder.route(
+fun RBuilder.route(
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
-    render: RBuilder.(RouteResultProps<T>) -> Unit,
+    render: RBuilder.(RouteResultProps) -> Unit,
 ) {
-    child<RouteProps<T>, Route<T>> {
+    Route {
         attrs {
             this.path = path
             this.exact = exact
             this.strict = strict
             this.render = { props -> buildElements({ render(props) }) }
-        }
-    }
-}
-
-fun RBuilder.route(
-    vararg path: String,
-    exact: Boolean = false,
-    strict: Boolean = false,
-    render: Render,
-) {
-    child<RouteProps<Props>, Route<Props>> {
-        attrs {
-            this.path = path
-            this.exact = exact
-            this.strict = strict
-            this.render = { buildElements(render) }
         }
     }
 }
@@ -129,17 +113,17 @@ fun RBuilder.routeLink(
     }
 }
 
-fun <T : Props> RBuilder.navLink(
+fun RBuilder.navLink(
     to: String,
     replace: Boolean = false,
     className: String? = null,
     activeClassName: String = "active",
     exact: Boolean = false,
     strict: Boolean = false,
-    isActive: ((match: Match<T>?, location: Location) -> Boolean)? = null,
-    handler: RHandler<NavLinkProps<T>>?,
+    isActive: ((match: Match?, location: Location) -> Boolean)? = null,
+    handler: RHandler<NavLinkProps>?,
 ) {
-    child<NavLinkProps<T>, NavLink<T>> {
+    NavLink {
         attrs {
             this.to = to
             this.replace = replace
@@ -171,13 +155,13 @@ fun RBuilder.redirect(
     }
 }
 
-fun <T : Props> matchPath(
-    patName: String,
+fun matchPath(
+    pathName: String,
     vararg path: String,
     exact: Boolean = false,
     strict: Boolean = false,
     sensitive: Boolean = false,
-): Match<T>? {
+): Match? {
     val options: RouteMatchOptions = jsObject {
         this.path = path
         this.exact = exact
@@ -185,5 +169,5 @@ fun <T : Props> matchPath(
         this.sensitive = sensitive
     }
 
-    return rawMatchPath(patName, options)
+    return rawMatchPath(pathName, options)
 }


### PR DESCRIPTION
### Breaking change!!!
### Problem
With existing implementation I can declare something like this:
```kotlin
external interface MyRouteParams : Props {
    val first: Int
    val second: Int
}

val MyComponent = fc<Props> {
    val params = useParams<MyRouteParams>() ?: return@fc

    println(params.first + params.second) // => for path /:first/:second and url /1/2 it will be string "12"
}
```
### Solution
Prevent opportunity of creation `Params` type with non-string types of values. Use just `Record<String. String>` or `Params` type alias.

### Migration 
Before:
```kotlin
external interface SomeProps : Props {
    val someId: String
}

val someId = useParams<SomeProps>()?.someId
```
After:
```kotlin
val someId = useParams()["someId"]
```
Also you can declare constant with you param and reuse it in you path:
```kotlin
val SOME_ID = "someId"

route("some/path/:$SOME_ID", component = Component)

val someId = useParams()[SOME_ID]
```  

cc @turansky @aerialist7 
