### PR TITLE
Strict `HashRouter.hashType`

### DIFF
--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/HashRouter.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/HashRouter.kt
@@ -8,7 +8,7 @@ import react.ComponentClass
 external interface HashRouterProps : RouterProps {
     var basename: String
     var getUserConfirmation: GetUserConfirmation?
-    var hashType: String
+    var hashType: HashType
 }
 
 external val HashRouter: ComponentClass<HashRouterProps>

--- a/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
+++ b/kotlin-react-router-dom/src/main/kotlin/react/router/dom/routingDsl.kt
@@ -12,7 +12,7 @@ fun RBuilder.hashRouter(
     HashRouter {
         attrs {
             this.basename = basename
-            this.hashType = hashType.name
+            this.hashType = hashType
             this.getUserConfirmation = getUserConfirmation
         }
 


### PR DESCRIPTION
No `name` in external enum

cc @sgrishchenko @aerialist7 