### PR TITLE
`Dependencies` type alias is introduced, `RDependenciesArray` is deprecated

### DIFF
--- a/kotlin-react/src/main/kotlin/react/Dependencies.kt
+++ b/kotlin-react/src/main/kotlin/react/Dependencies.kt
@@ -4,8 +4,3 @@ import kotlinext.js.ReadonlyArray
 
 typealias Dependencies = ReadonlyArray<dynamic>
 
-@Deprecated(
-    message = "Legacy API",
-    replaceWith = ReplaceWith("Dependencies", "react.Dependencies")
-)
-typealias RDependenciesArray = Dependencies

--- a/kotlin-react/src/main/kotlin/react/Dependencies.kt
+++ b/kotlin-react/src/main/kotlin/react/Dependencies.kt
@@ -1,0 +1,11 @@
+package react
+
+import kotlinext.js.ReadonlyArray
+
+typealias Dependencies = ReadonlyArray<dynamic>
+
+@Deprecated(
+    message = "Legacy API",
+    replaceWith = ReplaceWith("Dependencies", "react.Dependencies")
+)
+typealias RDependenciesArray = Dependencies

--- a/kotlin-react/src/main/kotlin/react/Dependencies.legacy.kt
+++ b/kotlin-react/src/main/kotlin/react/Dependencies.legacy.kt
@@ -1,0 +1,7 @@
+package react
+
+@Deprecated(
+    message = "Legacy API",
+    replaceWith = ReplaceWith("Dependencies", "react.Dependencies")
+)
+typealias RDependenciesArray = Dependencies

--- a/kotlin-react/src/main/kotlin/react/Raw.kt
+++ b/kotlin-react/src/main/kotlin/react/Raw.kt
@@ -12,26 +12,26 @@ external fun <P : Props> rawForwardRef(
 @JsName("useEffect")
 external fun rawUseEffect(
     effect: () -> Cleanup?,
-    dependencies: RDependenciesArray = definedExternally,
+    dependencies: Dependencies = definedExternally,
 )
 
 // Layout Effect Hook (16.8+)
 @JsName("useLayoutEffect")
 external fun rawUseLayoutEffect(
     effect: () -> Cleanup?,
-    dependencies: RDependenciesArray = definedExternally,
+    dependencies: Dependencies = definedExternally,
 )
 
 // Callback Hook (16.8+)
 @JsName("useCallback")
 external fun <T : Function<*>> rawUseCallback(
     callback: T,
-    dependencies: RDependenciesArray,
+    dependencies: Dependencies,
 ): T
 
 // Memo Hook (16.8+)
 @JsName("useMemo")
 external fun <T> rawUseMemo(
     callback: () -> T,
-    dependencies: RDependenciesArray,
+    dependencies: Dependencies,
 ): T

--- a/kotlin-react/src/main/kotlin/react/useEffect.kt
+++ b/kotlin-react/src/main/kotlin/react/useEffect.kt
@@ -1,9 +1,5 @@
 package react
 
-import kotlinext.js.ReadonlyArray
-
-typealias RDependenciesArray = ReadonlyArray<dynamic>
-
 typealias Cleanup = () -> Unit
 
 /**

--- a/kotlin-react/src/main/kotlin/react/useImperativeHandle.kt
+++ b/kotlin-react/src/main/kotlin/react/useImperativeHandle.kt
@@ -12,5 +12,5 @@ package react
 external fun useImperativeHandle(
     ref: Ref<*>,
     createInstance: () -> dynamic,
-    inputs: RDependenciesArray,
+    dependencies: Dependencies,
 )


### PR DESCRIPTION
cc @turansky @aerialist7 