### PR TITLE
Stylesheet inject on getClassname in styled-next

### DIFF
--- a/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
@@ -92,6 +92,7 @@ class CssHolder(private val sheet: StyleSheet, internal vararg val ruleSets: Rul
     operator fun provideDelegate(thisRef: Any?, providingProperty: KProperty<*>): ReadOnlyProperty<Any?, RuleSet> {
         val className = sheet.getClassName(providingProperty)
         classNamesToInject[className] = true
+        sheet.inject()
         return ReadOnlyProperty { _, property ->
             {
                 sheet.injectImports()

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -1,21 +1,15 @@
 package test
 
 import kotlinx.browser.document
-import kotlinx.css.CssBuilder
-import kotlinx.css.backgroundColor
-import kotlinx.css.color
-import kotlinx.css.px
+import kotlinx.css.*
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.css.CSSRuleList
 import org.w3c.dom.css.CSSStyleSheet
 import react.Props
 import react.fc
 import runTest
-import styled.StyleSheet
-import styled.css
-import styled.cssMarker
+import styled.*
 import styled.sheets.importStyleId
-import styled.styledSpan
 import test.styleSheets.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -197,5 +191,29 @@ class StyleSheetTest : TestBase() {
         }
         clearAndInject(styledComponent)
         assertCssInjected("StaticStyleSheet-prefixedProperty", "-webkit-box-align" to "center")
+    }
+
+
+    object StaticStyleSheetObject : StyleSheet("StaticStyleSheetObject", isStatic = true) {
+        val property by css {
+            color = rgb(3, 4, 5)
+        }
+    }
+
+    @Test
+    fun getClassName() = runTest {
+        val expectedColor = rgb(3, 4, 5).toString()
+        val styledComponent = fc<Props> {
+            styledSpan {
+                css {
+                    +StaticStyleSheetObject.getClassName { it::property }
+                }
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        getRules().forEach { println(it.cssText) }
+        assertContains(element.className, "StaticStyleSheetObject-property")
+        assertEquals(expectedColor, element.color())
+        assertCssInjected("StaticStyleSheetObject-property", "color" to expectedColor)
     }
 }


### PR DESCRIPTION
Я проверил - в `kotlin-styled` тоже не инжектятся стили если сделать getClassName, а инжектятся когда какую-то ещё пропертю взяли (у меня же был баг что в этот момент они только планировались к инжекту).
 
Есть два варианта - либо сделать так, чтобы при любом getClassName инжектились стили дополнительно (как пока и сделал в этом PR), либо оставить поведение `kotlin-styled`