### PR TITLE
Inject scheduled only when css and stylesheet classes changed

### DIFF
--- a/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/GlobalStyles.kt
@@ -6,8 +6,16 @@ import react.StateInstance
 import styled.sheets.*
 import kotlin.collections.*
 
-data class UsedCssInfo(val className: ClassName, var usedBy: Int, val groupId: Int, var styleSheetClasses: List<String> = listOf())
+data class UsedCssInfo(
+    val className: ClassName,
+    var usedBy: Int,
+    val groupId: Int,
+    var associatedClasses: MutableSet<String> = mutableSetOf()
+)
 internal typealias InjectedCssHolder = LinkedHashMap<StyledCss, UsedCssInfo>
+internal fun List<String>.toClassName(): String {
+    return this.joinToString(" ")
+}
 
 /**
  * Inject CSS rules defined in [css] into the DOM
@@ -48,8 +56,9 @@ object GlobalStyles {
         val info = styledClasses[css]
         return if (info != null) {
             // If we have the same CSS but with other static stylesheets we need to inject them
-            if (info.styleSheetClasses != css.classes) {
-                info.styleSheetClasses = css.classes
+            val className = css.classes.toClassName()
+            if (!info.associatedClasses.contains(className)) {
+                info.associatedClasses.add(className)
                 injectScheduled()
             }
             info.usedBy++
@@ -67,7 +76,8 @@ object GlobalStyles {
         val rules = css.getCssRules(selector)
         val groupId = sheet.scheduleToInject(rules)
 
-        styledClasses[css] = UsedCssInfo(className, 1, groupId, css.classes)
+        // TODO we can store classnames as single string in StyledCss
+        styledClasses[css] = UsedCssInfo(className, 1, groupId, mutableSetOf(css.classes.toClassName()))
         return className
     }
 

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledComponents.kt
@@ -118,7 +118,6 @@ fun customStyled(type: String): ComponentType<StyledProps> {
             if (generatedClasses != null) {
                 GlobalStyles.checkGeneratedCss(generatedClasses, selfClassName, type)
             }
-            GlobalStyles.injectScheduled()
             styledCss to (classes + selfClassName).joinToString(" ")
         }
 


### PR DESCRIPTION
В предыдущей версии была проблема с тем, что когда приходило много одинаковых CSS, они не ставились в очередь на инжект, но инжект уже запланированных классов все равно происходил. Таким образом мы много раз обращались к браузерному API, из-за чего страдала производительность

Сейчас мы инжектим CSS только если рендерим компонент, в котором есть новые CSS, при этом проверяя что не добавилось новый стайлшитов