### PR TITLE
DOM and CSS Unions. Escaping strategy is changed.

### DIFF
--- a/kotlin-csstype/src/main/generated/csstype/AdvancedPseudosRuleBuilder.kt
+++ b/kotlin-csstype/src/main/generated/csstype/AdvancedPseudosRuleBuilder.kt
@@ -63,7 +63,7 @@ interface AdvancedPseudosRuleBuilder<T : Any> : RuleBuilder<T> {
         ":host-context($selector)"(block)
     }
 
-    inline fun __is__(
+    inline fun `is`(
         selector: String,
         block: T.() -> Unit,
     ) {

--- a/kotlin-csstype/src/main/generated/csstype/FontVariantPosition.kt
+++ b/kotlin-csstype/src/main/generated/csstype/FontVariantPosition.kt
@@ -8,11 +8,11 @@
 package csstype
 
 // language=JavaScript
-@JsName("""(/*union*/{normal: 'normal', sub: 'sub', sup: 'super'}/*union*/)""")
+@JsName("""(/*union*/{normal: 'normal', sub: 'sub', super: 'super'}/*union*/)""")
 sealed external interface FontVariantPosition {
     companion object {
         val normal: FontVariantPosition
         val sub: FontVariantPosition
-        val sup: FontVariantPosition
+        val `super`: FontVariantPosition
     }
 }

--- a/kotlin-csstype/src/main/generated/csstype/HtmlAttributes.kt
+++ b/kotlin-csstype/src/main/generated/csstype/HtmlAttributes.kt
@@ -8,7 +8,7 @@ package csstype
 
 // language=JavaScript
 @JsName(
-    """(/*union*/{abbr: '[abbr]', acceptCharset: '[accept-charset]', accept: '[accept]', accesskey: '[accesskey]', action: '[action]', align: '[align]', alink: '[alink]', allow: '[allow]', allowfullscreen: '[allowfullscreen]', allowpaymentrequest: '[allowpaymentrequest]', alt: '[alt]', archive: '[archive]', async: '[async]', autobuffer: '[autobuffer]', autocapitalize: '[autocapitalize]', autocomplete: '[autocomplete]', autofocus: '[autofocus]', autoplay: '[autoplay]', axis: '[axis]', background: '[background]', behavior: '[behavior]', bgcolor: '[bgcolor]', border: '[border]', bottommargin: '[bottommargin]', buffered: '[buffered]', cellpadding: '[cellpadding]', cellspacing: '[cellspacing]', char: '[char]', charoff: '[charoff]', charset: '[charset]', checked: '[checked]', cite: '[cite]', __class__: '[class]', classid: '[classid]', clear: '[clear]', code: '[code]', codebase: '[codebase]', codetype: '[codetype]', color: '[color]', cols: '[cols]', colspan: '[colspan]', command: '[command]', compact: '[compact]', content: '[content]', contenteditable: '[contenteditable]', contextmenu: '[contextmenu]', controls: '[controls]', coords: '[coords]', crossorigin: '[crossorigin]', __data__: '[data]', datafld: '[datafld]', datasrc: '[datasrc]', datetime: '[datetime]', declare: '[declare]', decoding: '[decoding]', default: '[default]', defer: '[defer]', dir: '[dir]', direction: '[direction]', dirname: '[dirname]', disabled: '[disabled]', download: '[download]', draggable: '[draggable]', enctype: '[enctype]', enterkeyhint: '[enterkeyhint]', exportparts: '[exportparts]', face: '[face]', __for__: '[for]', form: '[form]', formaction: '[formaction]', formenctype: '[formenctype]', formmethod: '[formmethod]', formnovalidate: '[formnovalidate]', formtarget: '[formtarget]', frame: '[frame]', frameborder: '[frameborder]', headers: '[headers]', height: '[height]', hidden: '[hidden]', high: '[high]', href: '[href]', hreflang: '[hreflang]', hspace: '[hspace]', httpEquiv: '[http-equiv]', icon: '[icon]', id: '[id]', imagesizes: '[imagesizes]', imagesrcset: '[imagesrcset]', inputmode: '[inputmode]', integrity: '[integrity]', intrinsicsize: '[intrinsicsize]', __is__: '[is]', ismap: '[ismap]', itemid: '[itemid]', itemprop: '[itemprop]', itemref: '[itemref]', itemscope: '[itemscope]', itemtype: '[itemtype]', kind: '[kind]', label: '[label]', lang: '[lang]', language: '[language]', leftmargin: '[leftmargin]', link: '[link]', loading: '[loading]', longdesc: '[longdesc]', loop: '[loop]', low: '[low]', manifest: '[manifest]', marginheight: '[marginheight]', marginwidth: '[marginwidth]', max: '[max]', maxlength: '[maxlength]', mayscript: '[mayscript]', media: '[media]', method: '[method]', methods: '[methods]', min: '[min]', minlength: '[minlength]', mozOpaque: '[moz-opaque]', mozallowfullscreen: '[mozallowfullscreen]', mozcurrentsampleoffset: '[mozcurrentsampleoffset]', msallowfullscreen: '[msallowfullscreen]', multiple: '[multiple]', muted: '[muted]', __name__: '[name]', nohref: '[nohref]', nomodule: '[nomodule]', nonce: '[nonce]', noresize: '[noresize]', noshade: '[noshade]', novalidate: '[novalidate]', nowrap: '[nowrap]', __object__: '[object]', onafterprint: '[onafterprint]', onbeforeprint: '[onbeforeprint]', onbeforeunload: '[onbeforeunload]', onblur: '[onblur]', onerror: '[onerror]', onfocus: '[onfocus]', onhashchange: '[onhashchange]', onlanguagechange: '[onlanguagechange]', onload: '[onload]', onmessage: '[onmessage]', onoffline: '[onoffline]', ononline: '[ononline]', onpopstate: '[onpopstate]', onredo: '[onredo]', onresize: '[onresize]', onstorage: '[onstorage]', onundo: '[onundo]', onunload: '[onunload]', __open__: '[open]', optimum: '[optimum]', part: '[part]', ping: '[ping]', placeholder: '[placeholder]', played: '[played]', poster: '[poster]', prefetch: '[prefetch]', preload: '[preload]', profile: '[profile]', radiogroup: '[radiogroup]', readonly: '[readonly]', referrerpolicy: '[referrerpolicy]', rel: '[rel]', required: '[required]', rev: '[rev]', reversed: '[reversed]', rightmargin: '[rightmargin]', rows: '[rows]', rowspan: '[rowspan]', rules: '[rules]', sandboxAllowDownloads: '[sandbox-allow-downloads]', sandboxAllowModals: '[sandbox-allow-modals]', sandboxAllowPopupsToEscapeSandbox: '[sandbox-allow-popups-to-escape-sandbox]', sandboxAllowPopups: '[sandbox-allow-popups]', sandboxAllowPresentation: '[sandbox-allow-presentation]', sandboxAllowSameOrigin: '[sandbox-allow-same-origin]', sandboxAllowStorageAccessByUserActivation: '[sandbox-allow-storage-access-by-user-activation]', sandboxAllowTopNavigationByUserActivation: '[sandbox-allow-top-navigation-by-user-activation]', sandbox: '[sandbox]', scope: '[scope]', scoped: '[scoped]', scrollamount: '[scrollamount]', scrolldelay: '[scrolldelay]', scrolling: '[scrolling]', selected: '[selected]', shape: '[shape]', size: '[size]', sizes: '[sizes]', slot: '[slot]', span: '[span]', spellcheck: '[spellcheck]', src: '[src]', srcdoc: '[srcdoc]', srclang: '[srclang]', srcset: '[srcset]', standby: '[standby]', start: '[start]', style: '[style]', summary: '[summary]', tabindex: '[tabindex]', target: '[target]', text: '[text]', title: '[title]', topmargin: '[topmargin]', translate: '[translate]', truespeed: '[truespeed]', type: '[type]', usemap: '[usemap]', valign: '[valign]', __value__: '[value]', valuetype: '[valuetype]', version: '[version]', vlink: '[vlink]', volume: '[volume]', vspace: '[vspace]', webkitallowfullscreen: '[webkitallowfullscreen]', width: '[width]', wrap: '[wrap]', xmlns: '[xmlns]'}/*union*/)"""
+    """(/*union*/{abbr: '[abbr]', acceptCharset: '[accept-charset]', accept: '[accept]', accesskey: '[accesskey]', action: '[action]', align: '[align]', alink: '[alink]', allow: '[allow]', allowfullscreen: '[allowfullscreen]', allowpaymentrequest: '[allowpaymentrequest]', alt: '[alt]', archive: '[archive]', async: '[async]', autobuffer: '[autobuffer]', autocapitalize: '[autocapitalize]', autocomplete: '[autocomplete]', autofocus: '[autofocus]', autoplay: '[autoplay]', axis: '[axis]', background: '[background]', behavior: '[behavior]', bgcolor: '[bgcolor]', border: '[border]', bottommargin: '[bottommargin]', buffered: '[buffered]', cellpadding: '[cellpadding]', cellspacing: '[cellspacing]', char: '[char]', charoff: '[charoff]', charset: '[charset]', checked: '[checked]', cite: '[cite]', class: '[class]', classid: '[classid]', clear: '[clear]', code: '[code]', codebase: '[codebase]', codetype: '[codetype]', color: '[color]', cols: '[cols]', colspan: '[colspan]', command: '[command]', compact: '[compact]', content: '[content]', contenteditable: '[contenteditable]', contextmenu: '[contextmenu]', controls: '[controls]', coords: '[coords]', crossorigin: '[crossorigin]', data: '[data]', datafld: '[datafld]', datasrc: '[datasrc]', datetime: '[datetime]', declare: '[declare]', decoding: '[decoding]', default: '[default]', defer: '[defer]', dir: '[dir]', direction: '[direction]', dirname: '[dirname]', disabled: '[disabled]', download: '[download]', draggable: '[draggable]', enctype: '[enctype]', enterkeyhint: '[enterkeyhint]', exportparts: '[exportparts]', face: '[face]', for: '[for]', form: '[form]', formaction: '[formaction]', formenctype: '[formenctype]', formmethod: '[formmethod]', formnovalidate: '[formnovalidate]', formtarget: '[formtarget]', frame: '[frame]', frameborder: '[frameborder]', headers: '[headers]', height: '[height]', hidden: '[hidden]', high: '[high]', href: '[href]', hreflang: '[hreflang]', hspace: '[hspace]', httpEquiv: '[http-equiv]', icon: '[icon]', id: '[id]', imagesizes: '[imagesizes]', imagesrcset: '[imagesrcset]', inputmode: '[inputmode]', integrity: '[integrity]', intrinsicsize: '[intrinsicsize]', is: '[is]', ismap: '[ismap]', itemid: '[itemid]', itemprop: '[itemprop]', itemref: '[itemref]', itemscope: '[itemscope]', itemtype: '[itemtype]', kind: '[kind]', label: '[label]', lang: '[lang]', language: '[language]', leftmargin: '[leftmargin]', link: '[link]', loading: '[loading]', longdesc: '[longdesc]', loop: '[loop]', low: '[low]', manifest: '[manifest]', marginheight: '[marginheight]', marginwidth: '[marginwidth]', max: '[max]', maxlength: '[maxlength]', mayscript: '[mayscript]', media: '[media]', method: '[method]', methods: '[methods]', min: '[min]', minlength: '[minlength]', mozOpaque: '[moz-opaque]', mozallowfullscreen: '[mozallowfullscreen]', mozcurrentsampleoffset: '[mozcurrentsampleoffset]', msallowfullscreen: '[msallowfullscreen]', multiple: '[multiple]', muted: '[muted]', htmlName: '[name]', nohref: '[nohref]', nomodule: '[nomodule]', nonce: '[nonce]', noresize: '[noresize]', noshade: '[noshade]', novalidate: '[novalidate]', nowrap: '[nowrap]', object: '[object]', onafterprint: '[onafterprint]', onbeforeprint: '[onbeforeprint]', onbeforeunload: '[onbeforeunload]', onblur: '[onblur]', onerror: '[onerror]', onfocus: '[onfocus]', onhashchange: '[onhashchange]', onlanguagechange: '[onlanguagechange]', onload: '[onload]', onmessage: '[onmessage]', onoffline: '[onoffline]', ononline: '[ononline]', onpopstate: '[onpopstate]', onredo: '[onredo]', onresize: '[onresize]', onstorage: '[onstorage]', onundo: '[onundo]', onunload: '[onunload]', open: '[open]', optimum: '[optimum]', part: '[part]', ping: '[ping]', placeholder: '[placeholder]', played: '[played]', poster: '[poster]', prefetch: '[prefetch]', preload: '[preload]', profile: '[profile]', radiogroup: '[radiogroup]', readonly: '[readonly]', referrerpolicy: '[referrerpolicy]', rel: '[rel]', required: '[required]', rev: '[rev]', reversed: '[reversed]', rightmargin: '[rightmargin]', rows: '[rows]', rowspan: '[rowspan]', rules: '[rules]', sandboxAllowDownloads: '[sandbox-allow-downloads]', sandboxAllowModals: '[sandbox-allow-modals]', sandboxAllowPopupsToEscapeSandbox: '[sandbox-allow-popups-to-escape-sandbox]', sandboxAllowPopups: '[sandbox-allow-popups]', sandboxAllowPresentation: '[sandbox-allow-presentation]', sandboxAllowSameOrigin: '[sandbox-allow-same-origin]', sandboxAllowStorageAccessByUserActivation: '[sandbox-allow-storage-access-by-user-activation]', sandboxAllowTopNavigationByUserActivation: '[sandbox-allow-top-navigation-by-user-activation]', sandbox: '[sandbox]', scope: '[scope]', scoped: '[scoped]', scrollamount: '[scrollamount]', scrolldelay: '[scrolldelay]', scrolling: '[scrolling]', selected: '[selected]', shape: '[shape]', size: '[size]', sizes: '[sizes]', slot: '[slot]', span: '[span]', spellcheck: '[spellcheck]', src: '[src]', srcdoc: '[srcdoc]', srclang: '[srclang]', srcset: '[srcset]', standby: '[standby]', start: '[start]', style: '[style]', summary: '[summary]', tabindex: '[tabindex]', target: '[target]', text: '[text]', title: '[title]', topmargin: '[topmargin]', translate: '[translate]', truespeed: '[truespeed]', type: '[type]', usemap: '[usemap]', valign: '[valign]', value: '[value]', valuetype: '[valuetype]', version: '[version]', vlink: '[vlink]', volume: '[volume]', vspace: '[vspace]', webkitallowfullscreen: '[webkitallowfullscreen]', width: '[width]', wrap: '[wrap]', xmlns: '[xmlns]'}/*union*/)"""
 )
 external enum class HtmlAttributes {
     abbr,
@@ -43,7 +43,7 @@ external enum class HtmlAttributes {
     charset,
     checked,
     cite,
-    __class__,
+    `class`,
     classid,
     clear,
     code,
@@ -60,7 +60,7 @@ external enum class HtmlAttributes {
     controls,
     coords,
     crossorigin,
-    __data__,
+    data,
     datafld,
     datasrc,
     datetime,
@@ -78,7 +78,7 @@ external enum class HtmlAttributes {
     enterkeyhint,
     exportparts,
     face,
-    __for__,
+    `for`,
     form,
     formaction,
     formenctype,
@@ -102,7 +102,7 @@ external enum class HtmlAttributes {
     inputmode,
     integrity,
     intrinsicsize,
-    __is__,
+    `is`,
     ismap,
     itemid,
     itemprop,
@@ -136,7 +136,7 @@ external enum class HtmlAttributes {
     msallowfullscreen,
     multiple,
     muted,
-    __name__,
+    htmlName,
     nohref,
     nomodule,
     nonce,
@@ -144,7 +144,7 @@ external enum class HtmlAttributes {
     noshade,
     novalidate,
     nowrap,
-    __object__,
+    `object`,
     onafterprint,
     onbeforeprint,
     onbeforeunload,
@@ -163,7 +163,7 @@ external enum class HtmlAttributes {
     onstorage,
     onundo,
     onunload,
-    __open__,
+    open,
     optimum,
     part,
     ping,
@@ -223,7 +223,7 @@ external enum class HtmlAttributes {
     type,
     usemap,
     valign,
-    __value__,
+    value,
     valuetype,
     version,
     vlink,

--- a/kotlin-csstype/src/main/generated/csstype/VerticalAlign.kt
+++ b/kotlin-csstype/src/main/generated/csstype/VerticalAlign.kt
@@ -8,14 +8,14 @@
 package csstype
 
 // language=JavaScript
-@JsName("""(/*union*/{baseline: 'baseline', bottom: 'bottom', middle: 'middle', sub: 'sub', sup: 'super', textBottom: 'text-bottom', textTop: 'text-top', top: 'top'}/*union*/)""")
+@JsName("""(/*union*/{baseline: 'baseline', bottom: 'bottom', middle: 'middle', sub: 'sub', super: 'super', textBottom: 'text-bottom', textTop: 'text-top', top: 'top'}/*union*/)""")
 sealed external interface VerticalAlign {
     companion object {
         val baseline: VerticalAlign
         val bottom: VerticalAlign
         val middle: VerticalAlign
         val sub: VerticalAlign
-        val sup: VerticalAlign
+        val `super`: VerticalAlign
         val textBottom: VerticalAlign
         val textTop: VerticalAlign
         val top: VerticalAlign

--- a/kotlin-react-dom/src/main/generated/react/dom/aria/AriaChecked.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/aria/AriaChecked.kt
@@ -4,11 +4,11 @@ package react.dom.aria
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', mixed: 'mixed', __true__: 'true'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', mixed: 'mixed', true: 'true'}/*union*/)""")
 external enum class AriaChecked {
-    __false__,
+    `false`,
     mixed,
-    __true__,
+    `true`,
 
     ;
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/aria/AriaCurrent.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/aria/AriaCurrent.kt
@@ -4,10 +4,10 @@ package react.dom.aria
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', __true__: 'true', page: 'page', step: 'step', location: 'location', date: 'date', time: 'time'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', true: 'true', page: 'page', step: 'step', location: 'location', date: 'date', time: 'time'}/*union*/)""")
 external enum class AriaCurrent {
-    __false__,
-    __true__,
+    `false`,
+    `true`,
     page,
     step,
     location,

--- a/kotlin-react-dom/src/main/generated/react/dom/aria/AriaHasPopup.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/aria/AriaHasPopup.kt
@@ -4,10 +4,10 @@ package react.dom.aria
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', __true__: 'true', menu: 'menu', listbox: 'listbox', tree: 'tree', grid: 'grid', dialog: 'dialog'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', true: 'true', menu: 'menu', listbox: 'listbox', tree: 'tree', grid: 'grid', dialog: 'dialog'}/*union*/)""")
 external enum class AriaHasPopup {
-    __false__,
-    __true__,
+    `false`,
+    `true`,
     menu,
     listbox,
     tree,

--- a/kotlin-react-dom/src/main/generated/react/dom/aria/AriaInvalid.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/aria/AriaInvalid.kt
@@ -4,10 +4,10 @@ package react.dom.aria
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', __true__: 'true', grammar: 'grammar', spelling: 'spelling'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', true: 'true', grammar: 'grammar', spelling: 'spelling'}/*union*/)""")
 external enum class AriaInvalid {
-    __false__,
-    __true__,
+    `false`,
+    `true`,
     grammar,
     spelling,
 

--- a/kotlin-react-dom/src/main/generated/react/dom/aria/AriaPressed.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/aria/AriaPressed.kt
@@ -4,11 +4,11 @@ package react.dom.aria
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', mixed: 'mixed', __true__: 'true'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', mixed: 'mixed', true: 'true'}/*union*/)""")
 external enum class AriaPressed {
-    __false__,
+    `false`,
     mixed,
-    __true__,
+    `true`,
 
     ;
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/Capture.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/Capture.kt
@@ -4,10 +4,10 @@ package react.dom.html
 
 @Suppress("NAME_CONTAINS_ILLEGAL_CHARS")
 // language=JavaScript
-@JsName("""(/*union*/{__false__: 'false', __true__: 'true', user: 'user', environment: 'environment'}/*union*/)""")
+@JsName("""(/*union*/{false: 'false', true: 'true', user: 'user', environment: 'environment'}/*union*/)""")
 external enum class Capture {
-    __false__,
-    __true__,
+    `false`,
+    `true`,
     user,
     environment,
 


### PR DESCRIPTION
Exception:
`csstype.HtmlAttributes.__name__` -> `csstype.HtmlAttributes.htmlName`

cc @turansky @aerialist7 