### PR TITLE
Tretikoff/fix stylesheet static initialization

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/CssBuilder.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/CssBuilder.kt
@@ -264,15 +264,8 @@ open class CssBuilderImpl(
                 .also { hashCode -> memoizedHashCode = hashCode }
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as CssBuilderImpl
-
-        return hashCode() == other.hashCode()
-                && rules == other.rules
-                && multiRules == other.multiRules
-                && declarations == other.declarations
+    override fun equals(other: Any?) = this.calculateEquals(other) { otherCss ->
+        rules == otherCss.rules && multiRules == otherCss.multiRules && declarations == otherCss.declarations
     }
 
     override val rules = mutableListOf<Rule>()

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/Rule.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/Rule.kt
@@ -4,6 +4,12 @@ internal typealias Selector = String
 
 data class Rule(
     val selector: Selector,
+    @Deprecated("Left for compatibility with old api")
+    val passStaticClassesToParent: Boolean = false,
+    @Deprecated("Left for compatibility with old api")
+    val block: CssBuilder.() -> Unit = {
+        append(css)
+    },
     val css: CssBuilder,
 ) {
     private var memoizedHashCode: Int? = null
@@ -12,14 +18,15 @@ data class Rule(
         return memoizedHashCode ?: (selector.hashCode() + css.hashCode()).also { hash -> memoizedHashCode = hash }
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as Rule
-
-        return hashCode() == other.hashCode()
-                && selector == other.selector
-                && css == other.css
+    override fun equals(other: Any?) = this.calculateEquals(other) { otherRule ->
+        selector == otherRule.selector && css == otherRule.css
     }
+}
+
+internal inline fun <reified T : Any> T.calculateEquals(other: Any?, componentEquals: T.(T) -> Boolean): Boolean {
+    if (this === other) return true
+    if (other == null || this::class != other::class) return false
+
+    other as T
+    return this.hashCode() == other.hashCode() && componentEquals(this, other)
 }

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/Rule.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/Rule.kt
@@ -1,7 +1,25 @@
 package kotlinx.css
 
+internal typealias Selector = String
+
 data class Rule(
-    val selector: String,
-    val passStaticClassesToParent: Boolean = false,
-    val block: RuleSet,
-)
+    val selector: Selector,
+    val css: CssBuilder,
+) {
+    private var memoizedHashCode: Int? = null
+
+    override fun hashCode(): Int {
+        return memoizedHashCode ?: (selector.hashCode() + css.hashCode()).also { hash -> memoizedHashCode = hash }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as Rule
+
+        return hashCode() == other.hashCode()
+                && selector == other.selector
+                && css == other.css
+    }
+}

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/RuleContainer.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/RuleContainer.kt
@@ -9,9 +9,9 @@ interface RuleContainer {
     fun StringBuilder.buildRules(indent: String) {
         val resolvedRules = resolveRules(rules, multiRules)
 
-        resolvedRules.forEach { (selector, css) ->
-            appendLine("$selector {")
-            append(css)
+        resolvedRules.forEach {
+            appendLine("${it.selector} {")
+            append(it.css)
             appendLine("}")
         }
     }
@@ -24,7 +24,7 @@ interface RuleContainer {
         rules.forEach {
             val foundRule = resolvedRules[it.selector]
             if (foundRule == null) {
-                resolvedRules[it.selector] = Rule(it.selector, CssBuilder().apply { append(it.css) })
+                resolvedRules[it.selector] = Rule(it.selector, css = CssBuilder().apply { append(it.css) })
             } else {
                 // if css with the selector already exists - append new css to the old one
                 foundRule.css.append(it.css)
@@ -45,7 +45,7 @@ interface RuleContainer {
     }
 
     fun rule(selector: String, passStaticClassesToParent: Boolean, repeatable: Boolean = false, css: CssBuilder) =
-        Rule(selector, css).also {
+        Rule(selector, passStaticClassesToParent, css = css).also {
             css.parent = if (passStaticClassesToParent) this else null
             (if (repeatable) multiRules else rules).add(it)
         }

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/RuleContainer.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/RuleContainer.kt
@@ -2,46 +2,51 @@ package kotlinx.css
 
 @CssDsl
 interface RuleContainer {
-    fun StringBuilder.buildRules(indent: String) {
-        val resolvedRules = LinkedHashMap<String, CssBuilder>()
-        rules.forEach { (selector, passStaticClassesToParent, block) ->
-            if (!resolvedRules.containsKey(selector)) {
-                resolvedRules[selector] = CssBuilder(
-                    "$indent  ",
-                    allowClasses = false,
-                    parent = if (passStaticClassesToParent) this@RuleContainer else null
-                )
-            }
-            val rule = resolvedRules[selector]!!
-            rule.block()
-        }
-
-        resolvedRules.forEach {
-            append("${it.key} {\n")
-            append(it.value)
-            append("}\n")
-        }
-
-        multiRules.forEach { (selector, passStaticClassesToParent, block) ->
-            val blockBuilder = CssBuilder(
-                "$indent  ",
-                allowClasses = false,
-                parent = if (passStaticClassesToParent) this@RuleContainer else null
-            ).apply(block)
-
-            append("$selector {\n")
-            append(blockBuilder)
-            append("}\n")
-        }
-    }
-
+    val indent: String
     val rules: MutableList<Rule>
     val multiRules: MutableList<Rule>
 
+    fun StringBuilder.buildRules(indent: String) {
+        val resolvedRules = resolveRules(rules, multiRules)
+
+        resolvedRules.forEach { (selector, css) ->
+            appendLine("$selector {")
+            append(css)
+            appendLine("}")
+        }
+    }
+
+    /**
+     * @return all [multiRules], but only the first occurrence of a regular rule from [rules]
+     */
+    fun resolveRules(rules: List<Rule>, multiRules: List<Rule>): List<Rule> {
+        val resolvedRules = LinkedHashMap<String, Rule>()
+        rules.forEach {
+            val foundRule = resolvedRules[it.selector]
+            if (foundRule == null) {
+                resolvedRules[it.selector] = Rule(it.selector, CssBuilder().apply { append(it.css) })
+            } else {
+                // if css with the selector already exists - append new css to the old one
+                foundRule.css.append(it.css)
+            }
+        }
+        return multiRules + resolvedRules.values
+    }
+
     fun rule(selector: String, block: RuleSet) = rule(selector, passStaticClassesToParent = false, block = block)
 
-    fun rule(selector: String, passStaticClassesToParent: Boolean, repeatable: Boolean = false, block: RuleSet) =
-        Rule(selector, passStaticClassesToParent, block).apply {
-            (if (repeatable) multiRules else rules).add(this)
+    fun rule(selector: String, passStaticClassesToParent: Boolean, repeatable: Boolean = false, block: RuleSet): Rule {
+        val css = CssBuilder(
+            "$indent  ",
+            allowClasses = false,
+            parent = if (passStaticClassesToParent) this else null
+        ).apply(block)
+        return rule(selector, passStaticClassesToParent, repeatable, css)
+    }
+
+    fun rule(selector: String, passStaticClassesToParent: Boolean, repeatable: Boolean = false, css: CssBuilder) =
+        Rule(selector, css).also {
+            css.parent = if (passStaticClassesToParent) this else null
+            (if (repeatable) multiRules else rules).add(it)
         }
 }

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
@@ -6,7 +6,37 @@ import kotlinx.css.properties.*
 import kotlin.js.JsName
 import kotlin.reflect.KProperty
 
-typealias CssDeclarations = LinkedHashMap<String, Any>
+class CssDeclarations : MutableMap<String, Any> by LinkedHashMap() {
+    private var stringDecl: String? = null
+        get() = field ?: buildString {
+            this@CssDeclarations.forEach { (k, v) ->
+                append("${k.hyphenize()}: ${v};\n")
+            }
+        }.also { field = it }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as CssDeclarations
+
+        return hashCode() == other.hashCode()
+                && stringDecl == other.stringDecl
+    }
+
+    override fun hashCode(): Int {
+        return stringDecl.hashCode()
+    }
+
+    override fun toString(): String {
+        return stringDecl!!
+    }
+
+    operator fun set(name: String, value: Any) {
+        put(name, value)
+        stringDecl = null
+    }
+}
+
 
 interface StyledElement {
     val declarations: CssDeclarations

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
@@ -14,13 +14,8 @@ class CssDeclarations : MutableMap<String, Any> by LinkedHashMap() {
             }
         }.also { field = it }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as CssDeclarations
-
-        return hashCode() == other.hashCode()
-                && stringDecl == other.stringDecl
+    override fun equals(other: Any?) = this.calculateEquals(other) { otherDecls ->
+        stringDecl == otherDecls.stringDecl
     }
 
     override fun hashCode(): Int {

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
@@ -3,6 +3,7 @@ package kotlinx.css.properties
 import kotlinx.css.Rule
 import kotlinx.css.RuleContainer
 import kotlinx.css.RuleSet
+import kotlinx.css.calculateEquals
 
 interface KeyframesBuilder : RuleContainer {
     fun from(block: RuleSet) = rule("from", block)
@@ -31,10 +32,5 @@ class KeyframesBuilderImpl(override val indent: String = "") : KeyframesBuilder 
             .also { hashCode -> memoizedHashCode = hashCode }
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as KeyframesBuilderImpl
-        return rules == other.rules && multiRules == other.multiRules
-    }
+    override fun equals(other: Any?) = calculateEquals(other) { t2 -> rules == t2.rules && multiRules == t2.multiRules }
 }

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/properties/Keyframes.kt
@@ -16,12 +16,25 @@ fun KeyframesBuilder(indent: String = ""): KeyframesBuilder {
     return KeyframesBuilderImpl(indent)
 }
 
-class KeyframesBuilderImpl(private val indent: String = "") : KeyframesBuilder {
+class KeyframesBuilderImpl(override val indent: String = "") : KeyframesBuilder {
+    override val rules = mutableListOf<Rule>()
+    override val multiRules = mutableListOf<Rule>()
+
     override fun toString() =
         buildString {
             buildRules(indent)
         }
 
-    override val rules = mutableListOf<Rule>()
-    override val multiRules = mutableListOf<Rule>()
+    private var memoizedHashCode: Int? = null
+    override fun hashCode(): Int {
+        return memoizedHashCode ?: (rules.sumOf { it.hashCode() } + multiRules.sumOf { it.hashCode() })
+            .also { hashCode -> memoizedHashCode = hashCode }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as KeyframesBuilderImpl
+        return rules == other.rules && multiRules == other.multiRules
+    }
 }

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/CssBuilderEquality.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/CssBuilderEquality.kt
@@ -1,0 +1,55 @@
+package kotlinx.css
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CssBuilderEquality {
+    private fun CssBuilder.addDeclarations() {
+        position = Position.relative
+        display = Display.inlineBlock
+        width = 16.px
+        height = 16.px
+    }
+
+    @Test
+    fun testBuildersEquality() {
+        val first = CssBuilder().apply { addDeclarations() }
+        val second = CssBuilder().apply { addDeclarations() }
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun testBuildNotChangeEquality() {
+        val first = CssBuilder().apply {
+            specific { addDeclarations() }
+            color = Color.blue
+            specific { color = Color.red }
+        }
+        val second = CssBuilder().apply {
+            specific { addDeclarations() }
+            color = Color.blue
+            specific { color = Color.red }
+        }
+        first.toString()
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun testDeepBuildersEquality() {
+        val first = CssBuilder().apply {
+            addDeclarations()
+            specific {
+                addDeclarations()
+                ancestorHover { addDeclarations() }
+            }
+        }
+        val second = CssBuilder().apply {
+            addDeclarations()
+            specific {
+                addDeclarations()
+                ancestorHover { addDeclarations() }
+            }
+        }
+        assertEquals(first, second)
+    }
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/StructEffects.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StructEffects.kt
@@ -1,0 +1,54 @@
+package styled
+
+import react.*
+
+private data class MemoizedResult<T>(
+    val args: Array<out dynamic>,
+    val value: T,
+    val cleanups: Array<Cleanup>
+) {
+    fun cleanup() {
+        cleanups.forEach { it() }
+    }
+}
+
+internal fun <T> useStructMemo(vararg dependencies: dynamic, callback: EffectBuilder.() -> T): T {
+    return rawUseMemo(getMemoizedCallback(dependencies, callback), dependencies)!!
+}
+
+internal fun <T> getMemoizedCallback(
+    args: Array<out dynamic>,
+    callback: EffectBuilder.() -> T,
+): () -> T {
+    val prevResultRef = useRef<MemoizedResult<T>>(null)
+    useEffect(prevResultRef) {
+        cleanup {
+            prevResultRef.current?.cleanup()
+        }
+    }
+    return {
+        val prevResult = prevResultRef.current
+        val equal = prevResult.argsEqual(args)
+        if (prevResult != null && equal) prevResult.value else {
+            prevResult?.cleanup()
+            val cleanups = arrayOf<Cleanup>()
+            callback(cleanups.unsafeCast<EffectBuilder>()).also { result ->
+                prevResultRef.current = MemoizedResult(args, result, cleanups)
+            }
+        }
+    }
+}
+
+private fun <T> MemoizedResult<T>?.argsEqual(args: Array<out dynamic>): Boolean {
+    if (this == null) return false
+    if (this.args.size != args.size) {
+        if (isDevelopment()) console.warn("Calling useEffect with different number of dependencies: ${this.args.joinToString()} and ${args.joinToString()}")
+        return false
+    }
+    var index = -1
+    return this.args.all { prevArg: Any ->
+        index++
+        val newArg: Any = args[index]
+        prevArg == newArg
+    }
+}

--- a/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
@@ -2,6 +2,7 @@ package styled
 
 import kotlinx.css.CssBuilder
 import kotlinx.css.RuleSet
+import kotlin.js.Promise
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty0
@@ -115,9 +116,8 @@ class CssHolder(private val sheet: StyleSheet, internal vararg val ruleSets: Rul
 }
 
 fun <T : StyleSheet> T.getClassName(getClass: (T) -> KProperty0<RuleSet>): String {
-    return getClassName(getClass(this)).also {
-        scheduleToInject(it)
-        GlobalStyles.injectScheduled()
+    return getClassName(getClass(this)).also { className ->
+        Promise.resolve(Unit).then { scheduleToInject(className); GlobalStyles.injectScheduled() }
     }
 }
 

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -1,180 +1,78 @@
 package styled
 
-import kotlinx.css.*
-import kotlinx.css.properties.KeyframesBuilder
+import kotlinx.css.CssBuilder
+import kotlinx.css.Rule
 
 internal typealias ClassName = String
 internal typealias Selector = String
 internal typealias AnimationName = String
 
-internal data class StyledRule(
-    val selector: Selector,
-    val passStaticClassesToParent: Boolean = false,
-    val css: StyledCss
-) {
-    private var memoizedHashCode: Int? = null
-
-    override fun hashCode(): Int {
-        return memoizedHashCode ?: (selector.hashCode() + css.hashCode()).also { hash -> memoizedHashCode = hash }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as StyledRule
-
-        return hashCode() == other.hashCode()
-                && selector == other.selector
-                && css == other.css
-    }
-}
+private fun withMedia(selector: Selector) = selector.trim().startsWith("@media")
+private fun withContainer(selector: Selector) = selector.trim().startsWith("@container")
+private fun withAmpersand(selector: Selector) = selector.contains("&")
+private fun withFontFace(selector: Selector) = selector.trim().startsWith("@font-face")
+private fun withSupports(selector: Selector) = selector.trim().startsWith("@supports")
+private fun withCustomHandle(selector: Selector) =
+    withMedia(selector) || withContainer(selector) || withSupports(selector) || withAmpersand(selector) || withFontFace(
+        selector
+    )
 
 /**
- * StyledCss is used to efficiently build CSS rules from the DSL representation.
+ * @param outerSelector is the selector
+ * @param indent is indentation for pretty-printing the resulting CSS string
+ * @return the list of built rules in string representation.
+ * Each resulting rule can be injected to a CSS Object Model or plain stylesheet.
  */
-internal open class StyledCss(
-    declarations: CssDeclarations?,
-    private val rules: List<StyledRule>
-) {
-    private val declarationBlock = declarations?.buildPrefixedString("  ") ?: ""
+internal fun CssBuilder.getCssRules(outerSelector: String?, indent: String = ""): List<String> {
+    val declarationBlock = declarations.buildPrefixedString("  ")
 
-    private fun withMedia(selector: Selector) = selector.trim().startsWith("@media")
-    private fun withContainer(selector: Selector) = selector.trim().startsWith("@container")
-    private fun withAmpersand(selector: Selector) = selector.contains("&")
-    private fun withFontFace(selector: Selector) = selector.trim().startsWith("@font-face")
-    private fun withSupports(selector: Selector) = selector.trim().startsWith("@supports")
-    private fun withCustomHandle(selector: Selector) =
-        withMedia(selector) || withContainer(selector) || withSupports(selector) || withAmpersand(selector) || withFontFace(selector)
-
-    private var memoizedHashCode: Int? = null
-    override fun hashCode(): Int {
-        return memoizedHashCode ?: (rules.sumOf { it.hashCode() } + declarationBlock.hashCode())
-            .also { hashCode -> memoizedHashCode = hashCode }
+    val result = mutableListOf<String>()
+    val (rules, handleRules) = (rules + multiRules).partition { !withCustomHandle(it.selector) }
+    if (declarationBlock.isNotEmpty() && outerSelector != null) {
+        result.add(
+            buildString {
+                appendLine("$indent$outerSelector {")
+                append(declarationBlock)
+                appendLine("$indent}")
+            }
+        )
     }
+    result.addAll(buildRules(rules, outerSelector ?: ""))
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as StyledCss
-
-        return hashCode() == other.hashCode()
-                && rules == other.rules
-                && declarationBlock == other.declarationBlock
-    }
-
-    /**
-     * @param outerSelector is the selector
-     * @param indent is indentation for pretty-printing the resulting CSS string
-     * @return the list of built rules in string representation.
-     * Each resulting rule can be injected to a CSS Object Model or plain stylesheet.
-     */
-    fun getCssRules(outerSelector: String?, indent: String = ""): List<String> {
-        val result = mutableListOf<String>()
-        val (rules, handleRules) = rules.partition { !withCustomHandle(it.selector) }
-        if (declarationBlock.isNotEmpty() && outerSelector != null) {
+    handleRules.forEach { (selector, css) ->
+        val resolvedSelector = resolveRelativeSelector(selector, outerSelector)
+        if (withMedia(resolvedSelector)) {
             result.add(
                 buildString {
-                    appendLine("$indent$outerSelector {")
-                    append(declarationBlock)
+                    appendLine("$indent$selector {")
+                    css.getCssRules(outerSelector, "  $indent").forEach { appendLine(it); }
                     appendLine("$indent}")
                 }
             )
+        } else if (withContainer(resolvedSelector) || withSupports(resolvedSelector)) {
+            result.add(
+                buildString {
+                    append("$indent$selector {\n")
+                    css.getCssRules("  $indent").forEach { appendLine(it); }
+                    append("$indent}\n")
+                }
+            )
+        } else {
+            result.addAll(css.getCssRules(resolvedSelector))
         }
-        result.addAll(buildRules(rules, outerSelector ?: ""))
-
-        handleRules.forEach { (selector, _, css) ->
-            val resolvedSelector = resolveRelativeSelector(selector, outerSelector)
-            if (withMedia(resolvedSelector)) {
-                result.add(
-                    buildString {
-                        append("$indent$selector {\n")
-                        css.getCssRules(outerSelector, "  $indent").forEach { appendLine(it); }
-                        append("$indent}\n")
-                    }
-                )
-            } else if (withContainer(resolvedSelector) || withSupports(resolvedSelector)) {
-                result.add(
-                    buildString {
-                        append("$indent$selector {\n")
-                        css.getCssRules("  $indent").forEach { appendLine(it); }
-                        append("$indent}\n")
-                    }
-                )
-            } else {
-                result.addAll(css.getCssRules(resolvedSelector))
-            }
-        }
-        return result
     }
+    return result
+}
 
-    private fun resolveRelativeSelector(selector: Selector, selfClassName: ClassName?): Selector {
-        if (selfClassName == null) return selector
-        return selfClassName.split(",").joinToString { selector.replace("&", it.trim()) }
-    }
+private fun resolveRelativeSelector(selector: Selector, selfClassName: ClassName?): Selector {
+    if (selfClassName == null) return selector
+    return selfClassName.split(",").joinToString { selector.replace("&", it.trim()) }
 }
 
 private fun isPseudoClass(selector: Selector) = selector.trim().startsWith(":")
-private fun buildRules(rules: List<StyledRule>, outerSelector: String): List<String> {
-    return rules.flatMap { (selector, _, css) ->
+private fun buildRules(rules: List<Rule>, outerSelector: String): List<String> {
+    return rules.flatMap { (selector, css) ->
         val delimiter = if (isPseudoClass(selector)) "" else " "
         css.getCssRules(selector.split(",").joinToString { "$outerSelector$delimiter${it.trim()}" })
     }
-}
-
-private fun Rule.toStyledRule(parent: RuleContainer, block: RuleSet = this.block): StyledRule {
-    return StyledRule(
-        selector,
-        passStaticClassesToParent,
-        CssBuilder(allowClasses = false, parent = if (passStaticClassesToParent) parent else null)
-            .apply { block() }
-            .toStyledCss()
-    )
-}
-
-/**
- * @return all [multiRules], but only the first occurrence of a regular rule from [rules]
- */
-private fun resolveRules(rules: List<Rule>, multiRules: List<Rule>, parent: RuleContainer): List<StyledRule> {
-    val resolvedRules = LinkedHashMap<String, Rule>()
-    val newRules = mutableListOf<StyledRule>()
-    rules.forEach {
-        if (!resolvedRules.containsKey(it.selector)) {
-            resolvedRules[it.selector] = it
-        }
-        newRules.add(resolvedRules[it.selector]!!.toStyledRule(parent, it.block))
-    }
-    newRules.addAll(multiRules.map { it.toStyledRule(parent) })
-    return newRules
-}
-
-internal fun CssBuilder.toStyledCss(): StyledCss {
-    val resolvedRules = resolveRules(rules = rules, multiRules = multiRules, parent = this)
-    return StyledCss(declarations, rules = resolvedRules)
-}
-
-internal class StyledKeyframes(private val rules: List<StyledRule>) {
-    override fun hashCode(): Int {
-        return rules.sumOf { it.hashCode() }
-    }
-
-    override fun toString(): String {
-        return buildString {
-            rules.forEach { (selector, _, css) ->
-                append(css.getCssRules(selector).joinToString("\n"))
-            }
-        }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-        other as StyledKeyframes
-        return rules == other.rules
-    }
-}
-
-internal fun KeyframesBuilder.toStyledKeyframes(): StyledKeyframes {
-    val resolvedRules = resolveRules(rules = rules, multiRules = multiRules, parent = this)
-    return StyledKeyframes(rules = resolvedRules)
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyledCss.kt
@@ -39,7 +39,7 @@ internal fun CssBuilder.getCssRules(outerSelector: String?, indent: String = "")
     }
     result.addAll(buildRules(rules, outerSelector ?: ""))
 
-    handleRules.forEach { (selector, css) ->
+    handleRules.forEach { (selector, _, _, css) ->
         val resolvedSelector = resolveRelativeSelector(selector, outerSelector)
         if (withMedia(resolvedSelector)) {
             result.add(
@@ -71,7 +71,7 @@ private fun resolveRelativeSelector(selector: Selector, selfClassName: ClassName
 
 private fun isPseudoClass(selector: Selector) = selector.trim().startsWith(":")
 private fun buildRules(rules: List<Rule>, outerSelector: String): List<String> {
-    return rules.flatMap { (selector, css) ->
+    return rules.flatMap { (selector, _, _, css) ->
         val delimiter = if (isPseudoClass(selector)) "" else " "
         css.getCssRules(selector.split(",").joinToString { "$outerSelector$delimiter${it.trim()}" })
     }

--- a/kotlin-styled-next/src/main/kotlin/styled/sheets/DevSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/sheets/DevSheet.kt
@@ -3,10 +3,10 @@ package styled.sheets
 import kotlinx.dom.appendText
 
 /**
-* A stylesheet that is injected by setting the text of a <style> tag. Useful in development mode,
-* because the stylesheet can be easily viewed using devtools, but relatively slow.
-* Consider using [StyledNext.getCss], [StyledNext.downloadCss] instead.
-*/
+ * A stylesheet that is injected by setting the text of a <style> tag. Useful in development mode,
+ * because the stylesheet can be easily viewed using devtools, but relatively slow.
+ * Consider using [StyledNext.getCss], [StyledNext.downloadCss] instead.
+ */
 internal class DevSheet(type: RuleType) : AbstractSheet(type) {
     private val style by lazy { appendStyleElement() }
     private val scheduledRules = mutableListOf<String>()

--- a/kotlin-styled-next/src/test/kotlin/TestUtils.kt
+++ b/kotlin-styled-next/src/test/kotlin/TestUtils.kt
@@ -75,6 +75,10 @@ class TestScope : CoroutineScope by testScope {
         return getStyle(pseudoElt).color
     }
 
+    fun Element.alignContent(pseudoElt: String? = null): String {
+        return getStyle(pseudoElt).alignContent
+    }
+
     fun CSSRuleList.forEach(block: (rule: CSSRule) -> Unit) {
         for (i in 0 until this.length) {
             val value = this[i]

--- a/kotlin-styled-next/src/test/kotlin/benchmark/AddStyledElements.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/AddStyledElements.kt
@@ -2,8 +2,8 @@ package benchmark
 
 import StyledElementsFactory.getStyledComponent
 import TestScope
+import kotlinx.css.CssBuilder
 import styled.GlobalStyles
-import styled.StyledCss
 import styled.UsedCssInfo
 import waitForAnimationFrame
 import kotlin.test.Test
@@ -44,7 +44,7 @@ class AddStyledElements : BenchmarkBase() {
      */
     private suspend fun TestScope.addNElements(n: Int): Duration {
         val component = getStyledComponent(n)
-        val cssHolder = TimedLinkedHashMap<StyledCss, UsedCssInfo>()
+        val cssHolder = TimedLinkedHashMap<CssBuilder, UsedCssInfo>()
         GlobalStyles.styledClasses = cssHolder
         val duration = measureTime {
             renderComponent(component)

--- a/kotlin-styled-next/src/test/kotlin/benchmark/ConvertToStyled.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/ConvertToStyled.kt
@@ -1,7 +1,6 @@
 package benchmark
 
 import StyledElementsFactory.getCssBuilders
-import styled.toStyledCss
 import waitFlowCoroutine
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -14,8 +13,7 @@ class ConvertToStyled : BenchmarkBase() {
     private suspend fun convertNCssBuilders(n: Int): Duration {
         val builders = getCssBuilders(n)
         return measureTime {
-            val x = builders.map { it.toStyledCss() }
-            assertFalse(x.isEmpty())
+            assertFalse(builders.isEmpty())
             waitFlowCoroutine()
         }
     }

--- a/kotlin-styled-next/src/test/kotlin/benchmark/DataTypeOperations.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/DataTypeOperations.kt
@@ -3,7 +3,6 @@ package benchmark
 import StyledElementsFactory.getCssBuilders
 import styled.GlobalStyles
 import styled.UsedCssInfo
-import styled.toStyledCss
 import waitFlowCoroutine
 import waitForAnimationFrame
 import kotlin.test.Test
@@ -19,9 +18,9 @@ class DataTypeOperations : BenchmarkBase() {
      * @return duration of all [LinkedHashMap.put] operations
      */
     private suspend fun putNElements(n: Int): Duration {
-        val styledCss = getCssBuilders(n).map { it.toStyledCss() }
+        val builders = getCssBuilders(n)
         return measureTime {
-            styledCss.forEach { GlobalStyles.styledClasses[it] = UsedCssInfo("", 1, 1) }
+            builders.forEach { GlobalStyles.styledClasses[it] = UsedCssInfo("", 1, 1) }
             waitFlowCoroutine()
         }
     }
@@ -35,11 +34,11 @@ class DataTypeOperations : BenchmarkBase() {
         assertTrue(collisionProb in 0.0..1.0)
 
         val collisionsN = (n * collisionProb).toInt()
-        val builders = getCssBuilders(collisionsN).map { it.toStyledCss() }.toMutableList()
+        val builders = getCssBuilders(collisionsN).toMutableList()
         builders.forEach { GlobalStyles.styledClasses[it] = UsedCssInfo("", 1, 1) }
 
         val nonCollisionsN = (n * (1 - collisionProb)).toInt()
-        builders.addAll(getCssBuilders(nonCollisionsN).map { it.toStyledCss() })
+        builders.addAll(getCssBuilders(nonCollisionsN))
         return measureTime {
             builders.map { GlobalStyles.styledClasses[it] }
             waitForAnimationFrame()

--- a/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
@@ -335,7 +335,7 @@ class ElementTest : TestBase() {
         val css = CssBuilder().apply {
             transition("all", 200.ms, Timing.linear)
         }
-        val rule = css.toStyledCss().getCssRules(".someClass").first()
+        val rule = css.getCssRules(".someClass").first()
         assertContains(rule, "-moz-transition: all 200ms linear 0s")
         assertContains(rule, "-webkit-transition: all 200ms linear 0s")
     }

--- a/kotlin-styled-next/src/test/kotlin/test/ForwardCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ForwardCssTest.kt
@@ -1,0 +1,57 @@
+package test
+
+import kotlinx.css.backgroundColor
+import kotlinx.css.color
+import kotlinx.css.rgb
+import react.*
+import runTest
+import styled.CustomStyledProps
+import styled.css
+import styled.forwardCss
+import styled.styledDiv
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+interface SearchBarProps : Props {
+    var onClick: () -> Unit
+    var onChange: (String) -> () -> Unit
+    var inStockOnly: Boolean
+    var filterText: String
+}
+
+
+open class ForwardCssTest : TestBase() {
+    inner class AComponent(props: CustomStyledProps) : RComponent<CustomStyledProps, State>(props) {
+        override fun RBuilder.render() {
+            styledDiv {
+                css {
+                    color = rgb(2, 2, 2)
+                    backgroundColor = rgb(3, 3, 3)
+                    specific {
+                        props.forwardCss(this)
+                    }
+                }
+            }
+        }
+    }
+
+    inner class BComponent(props: CustomStyledProps) : RComponent<CustomStyledProps, State>(props) {
+        override fun RBuilder.render() {
+            child(AComponent::class) {
+                css {
+                    color = rgb(1, 1, 1)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun forwardCssForwards() = runTest {
+        val styledComponent = fc<Props> {
+            child(BComponent::class) {}
+        }
+        val styledElement = clearAndInject(styledComponent)
+        assertEquals(rgb(1, 1, 1).toString(), styledElement.color())
+        assertEquals(rgb(3, 3, 3).toString(), styledElement.getStyle().backgroundColor)
+    }
+}

--- a/kotlin-styled-next/src/test/kotlin/test/ForwardCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ForwardCssTest.kt
@@ -12,14 +12,6 @@ import styled.styledDiv
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-interface SearchBarProps : Props {
-    var onClick: () -> Unit
-    var onChange: (String) -> () -> Unit
-    var inStockOnly: Boolean
-    var filterText: String
-}
-
-
 open class ForwardCssTest : TestBase() {
     inner class AComponent(props: CustomStyledProps) : RComponent<CustomStyledProps, State>(props) {
         override fun RBuilder.render() {

--- a/kotlin-styled-next/src/test/kotlin/test/RelativeSelectorsTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RelativeSelectorsTest.kt
@@ -1,5 +1,6 @@
 package test
 
+import kotlinx.css.Align
 import kotlinx.css.CssBuilder
 import kotlinx.css.backgroundColor
 import kotlinx.css.color
@@ -8,6 +9,7 @@ import react.dom.div
 import react.dom.span
 import react.fc
 import runTest
+import styleSheets.StaticStyleSheet
 import styled.css
 import styled.styledDiv
 import styled.styledSpan
@@ -19,6 +21,8 @@ import kotlin.test.assertNotEquals
  * Check every public interface function in [CssBuilder]
  */
 class RelativeSelectorsTest : TestBase() {
+    private val staticStyleSheet = StaticStyleSheet()
+
     @Test
     fun children() = runTest {
         val styledComponent = fc<Props> {
@@ -325,7 +329,41 @@ class RelativeSelectorsTest : TestBase() {
             }
         }
         val element = clearAndInject(styledComponent)
-        assertEquals(firstColor.toString(), element.color())
         assertEquals(secondColor.toString(), element.childAt(0).color())
+        assertNotEquals(secondColor.toString(), element.color())
+    }
+
+    @Test
+    fun compareToNotSettingsRedundant() = runTest {
+        val styledComponent = fc<Props> {
+            styledDiv {
+                css {
+                    color = firstColor
+                    this > "div" {
+                        +staticStyleSheet.property1
+                        color = secondColor
+                    }
+                }
+                div {}
+                span { div {} }
+                div {}
+            }
+        }
+        val element = clearAndInject(styledComponent)
+        assertAllEquals(secondColor.toString(), element.childAt(0).color(), element.childAt(2).color())
+        assertAllNotEquals(
+            secondColor.toString(),
+            element.color(),
+            element.childAt(1).color(),
+            element.childAt(1).childAt(0).color()
+        )
+
+        assertAllEquals(Align.end.toString(), element.childAt(0).alignContent(), element.childAt(2).alignContent())
+        assertAllNotEquals(
+            Align.end.toString(),
+            element.alignContent(),
+            element.childAt(1).alignContent(),
+            element.childAt(1).childAt(0).alignContent()
+        )
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
@@ -13,11 +13,11 @@ import org.w3c.dom.HTMLElement
 import react.Props
 import react.fc
 import runTest
+import styleSheets.StaticStyleSheet
 import styled.animation
 import styled.css
 import styled.styledDiv
 import styled.styledSpan
-import styleSheets.StaticStyleSheet
 import unmount
 import waitForAnimationFrame
 import kotlin.test.BeforeTest
@@ -30,10 +30,11 @@ class RemoveCssTest : TestBase() {
     private val thirdRoot by lazy { createDOMElement() }
     private var staticStyleSheet = StaticStyleSheet()
 
-    private fun TestScope.injectAdditional(component: Component, root: HTMLElement = secondRoot): Element {
+    private suspend fun TestScope.injectAdditional(component: Component, root: HTMLElement = secondRoot): Element {
         renderComponent(component, root)
         val element = root.firstElementChild
         assertNotNull(element)
+        waitForAnimationFrame()
         return element
     }
 

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -8,9 +8,9 @@ import org.w3c.dom.css.CSSStyleSheet
 import react.Props
 import react.fc
 import runTest
+import styleSheets.*
 import styled.*
 import styled.sheets.importStyleId
-import styleSheets.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -41,7 +41,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetInjectedWithoutComponent() = runTest {
+    fun injectedWithoutComponent() = runTest {
         CssBuilder().apply {
             +staticStyleSheet.property1
         }
@@ -106,7 +106,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetStatic() = runTest {
+    fun static() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -130,7 +130,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetSpecific() = runTest {
+    fun specific() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -201,7 +201,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetGetClassname() = runTest {
+    fun getClassnameInjects() = runTest {
         val expectedColor = rgb(3, 4, 5).toString()
         val styledComponent = fc<Props> {
             styledSpan {

--- a/kotlin-styled-next/src/test/kotlin/test/StyledCssEqualityTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyledCssEqualityTest.kt
@@ -17,11 +17,11 @@ class StyledCssEqualityTest : TestBase() {
     fun simpleCssBuilders() {
         val first = CssBuilder().apply {
             addSomeCss()
-        }.toStyledCss()
+        }
 
         val second = CssBuilder().apply {
             addSomeCss()
-        }.toStyledCss()
+        }
 
         assertEquals(first.hashCode(), second.hashCode())
         assertEquals(first, second)
@@ -32,12 +32,12 @@ class StyledCssEqualityTest : TestBase() {
         val first = CssBuilder().apply {
             backgroundColor = Color.blue
             height = 18.px
-        }.toStyledCss()
+        }
 
         val second = CssBuilder().apply {
             height = 18.px
             backgroundColor = Color.blue
-        }.toStyledCss()
+        }
 
         assertNotEquals(first, second)
     }
@@ -46,10 +46,10 @@ class StyledCssEqualityTest : TestBase() {
     fun assertKeyframesEquals() {
         val first = KeyframesBuilder().apply {
             addRotation()
-        }.toStyledKeyframes()
+        }
         val second = KeyframesBuilder().apply {
             addRotation()
-        }.toStyledKeyframes()
+        }
         assertEquals(first.hashCode(), second.hashCode())
         assertEquals(first, second)
     }
@@ -62,7 +62,7 @@ class StyledCssEqualityTest : TestBase() {
                 addRotation()
             }
             padding = "1px 2px 3px 4px"
-        }.toStyledCss()
+        }
 
         val second = CssBuilder().apply {
             backgroundColor = Color.blue
@@ -70,7 +70,7 @@ class StyledCssEqualityTest : TestBase() {
                 addRotation()
             }
             padding = "1px 2px 3px 4px"
-        }.toStyledCss()
+        }
 
         assertEquals(first.hashCode(), second.hashCode())
         assertEquals(first, second)

--- a/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
@@ -11,9 +11,7 @@ import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.css.CSSRuleList
 import org.w3c.dom.get
 import runTest
-import kotlin.test.BeforeTest
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 open class TestBase {
     protected val firstColor = rgb(1, 1, 1)
@@ -79,5 +77,13 @@ open class TestBase {
 
     protected fun Element.asInput(): HTMLInputElement {
         return this as HTMLInputElement
+    }
+
+    protected fun assertAllNotEquals(expected: Any, vararg actual: Any) {
+        actual.forEach { assertNotEquals(expected, it) }
+    }
+
+    protected fun assertAllEquals(expected: Any, vararg actual: Any) {
+        actual.forEach { assertEquals(expected, it) }
     }
 }


### PR DESCRIPTION
Добавился отложенный инжект в `getClassName` чтобы не обращаться к неинициализированным делегатам во время статической инициализации стайлшитов (в IR компиляторе)

Should be merged after https://github.com/JetBrains/kotlin-wrappers/pull/940