### PR TITLE
Fix static initialization

### DIFF
--- a/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/StyleSheet.kt
@@ -2,6 +2,7 @@ package styled
 
 import kotlinx.css.CssBuilder
 import kotlinx.css.RuleSet
+import kotlin.js.Promise
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty0
@@ -115,9 +116,8 @@ class CssHolder(private val sheet: StyleSheet, internal vararg val ruleSets: Rul
 }
 
 fun <T : StyleSheet> T.getClassName(getClass: (T) -> KProperty0<RuleSet>): String {
-    return getClassName(getClass(this)).also {
-        scheduleToInject(it)
-        GlobalStyles.injectScheduled()
+    return getClassName(getClass(this)).also { className ->
+        Promise.resolve(Unit).then { scheduleToInject(className); GlobalStyles.injectScheduled() }
     }
 }
 

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -41,7 +41,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetInjectedWithoutComponent() = runTest {
+    fun injectedWithoutComponent() = runTest {
         CssBuilder().apply {
             +staticStyleSheet.property1
         }
@@ -106,7 +106,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetStatic() = runTest {
+    fun static() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -130,7 +130,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetSpecific() = runTest {
+    fun specific() = runTest {
         val styledComponent = fc<Props> {
             styledSpan {
                 css {
@@ -201,7 +201,7 @@ class StyleSheetTest : TestBase() {
     }
 
     @Test
-    fun styleSheetGetClassname() = runTest {
+    fun getClassnameInjects() = runTest {
         val expectedColor = rgb(3, 4, 5).toString()
         val styledComponent = fc<Props> {
             styledSpan {


### PR DESCRIPTION
Добавился отложенный инжект в getClassName чтобы не обращаться к неинициализированным делегатам во время статической инициализации стайлшитов (в IR компиляторе)