### PR TITLE
React DOM. Remove deprecated `RootOptions`

### DIFF
--- a/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOM.kt
+++ b/kotlin-react-dom/src/main/kotlin/react/dom/ReactDOM.kt
@@ -21,10 +21,9 @@ fun render(
 // TODO rename to render() after React 18 is released
 fun renderIntoRoot(
     container: Element,
-    options: RootOptions? = null,
     handler: Render,
 ) {
-    createRoot(container, options)
+    createRoot(container)
         .render(createElement(handler))
 }
 

--- a/kotlin-react-dom/src/main/kotlin/react/dom/createRoot.kt
+++ b/kotlin-react-dom/src/main/kotlin/react/dom/createRoot.kt
@@ -10,13 +10,8 @@ import org.w3c.dom.Element
 // 18.0+
 external fun createRoot(
     container: Element,
-    options: RootOptions? = definedExternally,
 ): Root
 
 external interface Root {
     fun render(element: dynamic)
-}
-
-external interface RootOptions {
-    var hydrate: Boolean
 }


### PR DESCRIPTION
[Source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cf5fb08bddb488919d99e2c3fea9c71f4fabbfa1/types/react-dom/next.d.ts#L39)