### PR TITLE
React. Add missed `ReactPortal.children`

### DIFF
--- a/kotlin-react/src/main/kotlin/react/ReactPortal.kt
+++ b/kotlin-react/src/main/kotlin/react/ReactPortal.kt
@@ -1,3 +1,5 @@
 package react
 
-sealed external interface ReactPortal : ReactElement
+sealed external interface ReactPortal : ReactElement {
+    val children: ReactNode
+}


### PR DESCRIPTION
[Source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0a9c9d85e8a9ae8aa4a96abbb2d9feac53dda9f6/types/react/index.d.ts#L192)