### PR TITLE
Add `Symbol` declaration

### DIFF
--- a/kotlin-extensions/src/main/kotlin/kotlinext/js/Symbol.kt
+++ b/kotlin-extensions/src/main/kotlin/kotlinext/js/Symbol.kt
@@ -3,5 +3,5 @@ package kotlinext.js
 external interface Symbol
 
 external fun Symbol(
-    key:String,
-):Symbol
+    key: String,
+): Symbol

--- a/kotlin-extensions/src/main/kotlin/kotlinext/js/Symbol.kt
+++ b/kotlin-extensions/src/main/kotlin/kotlinext/js/Symbol.kt
@@ -1,0 +1,7 @@
+package kotlinext.js
+
+external interface Symbol
+
+external fun Symbol(
+    key:String,
+):Symbol

--- a/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
@@ -2,8 +2,9 @@ package react
 
 import kotlinext.js.Object
 import kotlinext.js.ReadonlyArray
+import kotlinext.js.Symbol
 
-private val CHILDREN = js("(Symbol('@@children'))")
+private val CHILDREN = Symbol("@@children")
 
 internal inline var ChildrenBuilder.children: ReadonlyArray<ReactNode>?
     get() = asDynamic()[CHILDREN]


### PR DESCRIPTION
Symbol declaration is required to avoid clash with [Symbol](https://github.com/Kotlin/kotlinx.coroutines/blob/7cc59e4f2b15961f10e94cddd3f2fb7fe331328a/kotlinx-coroutines-core/common/src/internal/Symbol.kt) in coroutines for IR compiler in Kotlin. 