### PR TITLE
Add new target to kotlin-css to support Apple Silicon architecture while building Kotlin/Native iOS binary

### DIFF
--- a/kotlin-css/build.gradle.kts
+++ b/kotlin-css/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
     iosArm32("iosArm32")
     iosArm64("iosArm64")
     iosX64("iosX64")
+    iosSimulatorArm64()
 
     sourceSets {
         val commonTest by getting {


### PR DESCRIPTION
Without this any library with kotlin-css the dependency won't compile for a binary intended to use in Simulator.