### PR TITLE
Split style sheet into smaller pieces

### DIFF
--- a/kotlin-styled-next/build.gradle.kts
+++ b/kotlin-styled-next/build.gradle.kts
@@ -44,7 +44,8 @@ val printBenchmarkResults by tasks.registering {
             "ConvertToStyled",
             "CssBuildersInject",
             "AddDuplicateCss",
-            "DataTypeOperations"
+            "DataTypeOperations",
+            "InjectCssNPlusOne"
         )
         fileNames.forEach { test ->
             val report = buildDir.resolve("reports/tests/test/classes/benchmark.$test.html").readText()

--- a/kotlin-styled-next/src/main/kotlin/styled/sheets/CSSOMPersistentSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/sheets/CSSOMPersistentSheet.kt
@@ -4,9 +4,8 @@ import org.w3c.dom.css.CSSStyleSheet
 
 // A stylesheet that is injected using the CSSOM API. Useful in production mode because of better performance,
 // but can't be easily edited using devtools.
-internal class CSSOMPersistentSheet(type: RuleType) : AbstractSheet(type) {
-    internal val sheet by lazy { appendStyleElement().sheet as CSSStyleSheet }
-    internal val scheduledRules = mutableListOf<String>()
+internal class CSSOMPersistentSheet(type: RuleType, maxRulesPerSheet: Int? = DEFAULT_MAX_RULES_PER_SHEET) : AbstractSheet(type, maxRulesPerSheet) {
+    private val scheduledRules = mutableListOf<String>()
 
     override fun scheduleToInject(rules: Iterable<String>): GroupId {
         scheduledRules.addAll(rules)
@@ -27,10 +26,13 @@ internal class CSSOMPersistentSheet(type: RuleType) : AbstractSheet(type) {
     }
 
     override fun injectScheduled() {
-        inject(sheet, scheduledRules)
+        if (scheduledRules.isNotEmpty()) {
+            inject(getCurrentStyleElement(scheduledRules.size).cssSheet, scheduledRules)
+        }
     }
 
     override fun clear() {
+        super.clear()
         scheduledRules.clear()
     }
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/sheets/CSSOMSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/sheets/CSSOMSheet.kt
@@ -1,7 +1,16 @@
 package styled.sheets
 
 import kotlinx.browser.window
-import org.w3c.dom.css.CSSStyleSheet
+import org.w3c.dom.HTMLStyleElement
+import org.w3c.dom.asList
+import kotlin.collections.Iterable
+import kotlin.collections.LinkedHashMap
+import kotlin.collections.List
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.contains
+import kotlin.collections.iterator
+import kotlin.collections.set
 
 private typealias Rules = Iterable<String>
 
@@ -16,10 +25,9 @@ internal class CSSOMSheet(
     val type: RuleType,
     val removeMode: RemoveMode = RemoveMode.OnBrowserIdle,
     var cleanTimeout: Int = 30000,
-) : AbstractSheet(type) {
-    internal val sheet by lazy { appendStyleElement().sheet as CSSStyleSheet }
-
-    internal val groups = LinkedHashMap<GroupId, IntRange>()
+    maxRulesPerSheet: Int? = DEFAULT_MAX_RULES_PER_SHEET
+) : AbstractSheet(type, maxRulesPerSheet) {
+    private val groups = LinkedHashMap<GroupId, RulesGroup>()
     internal val scheduledGroups = LinkedHashMap<GroupId, Rules>()
 
     private var groupId: Int = 0
@@ -58,40 +66,112 @@ internal class CSSOMSheet(
                 continue
             }
 
-            val rmGroup = this.groups[groupId] ?: throw IllegalArgumentException("Group $groupId does not exist")
-            groups.remove(groupId)
-            for (i in rmGroup.reversed()) {
-                sheet.deleteRule(i)
+            val removedGroup = groups.remove(groupId) ?: throw IllegalArgumentException("Group $groupId does not exist")
+
+            if (!removedGroup.rulesRange.isEmpty()) {
+                val sheet = removedGroup.element.cssSheet
+                removedGroup.rulesRange.reversed().forEach {
+                    sheet.deleteRule(it)
+                }
+
+                if (sheet.cssRules.length == 0) {
+                    removedGroup.element.removeAndCleanUp()
+                }
             }
 
-            val size = rmGroup.last - rmGroup.first + 1
-            for (group in this.groups) {
-                if (group.key > groupId) {
-                    group.setValue((group.value.first - size)..(group.value.last - size))
+            val rulesShift = removedGroup.rulesRange.last - removedGroup.rulesRange.first + 1
+
+            for (entry in groups) {
+                val (otherGroupId, otherGroup) = entry
+                if (otherGroup.element == removedGroup.element && otherGroupId > groupId) {
+                    val otherRange = otherGroup.rulesRange
+                    val shiftedRange = (otherRange.first - rulesShift)..(otherRange.last - rulesShift)
+                    entry.setValue(otherGroup.copy(rulesRange = shiftedRange))
                 }
             }
         }
+
+        compressSheets()
     }
 
     override fun injectScheduled() {
-        var ruleId = sheet.cssRules.length
-        for ((groupId, rules) in scheduledGroups) {
-            val ruleStart = ruleId
-            for (rule in rules) {
-                try {
-                    sheet.insertRule(rule, ruleId)
-                    ruleId++
-                } catch (e: Throwable) {
-                    /* Browser does not support the rule */
+        if (scheduledGroups.isNotEmpty()) {
+            for ((groupId, rules) in scheduledGroups) {
+                val element = getCurrentStyleElement(rules.count())
+                val ruleStart = element.cssSheet.cssRules.length
+                var ruleId = ruleStart
+                for (rule in rules) {
+                    try {
+                        element.cssSheet.insertRule(rule, ruleId)
+                        ruleId++
+                    } catch (e: Throwable) {
+                        /* Browser does not support the rule */
+                    }
                 }
+                groups[groupId] = RulesGroup(element, ruleStart until ruleId)
             }
-            groups[groupId] = ruleStart until ruleId
+            scheduledGroups.clear()
         }
-        scheduledGroups.clear()
+    }
+
+    /**
+     * Combine successive style sheets with less than [maxRulesPerSheet] rules in total into one style sheet.
+     * It preserves rules order and updates group mapping.
+     */
+    private fun compressSheets() {
+        val maxRulesPerSheet = maxRulesPerSheet ?: return
+
+        // Find successive groups of style elements that can be combined
+        val elementGroups = mutableListOf<List<HTMLStyleElement>>()
+        var currentMergeGroup = mutableListOf<HTMLStyleElement>()
+        var totalRulesCount = 0
+        for (element in usedStyleElements) {
+            val rulesLength = element.cssSheet.cssRules.length
+            if (rulesLength + totalRulesCount > maxRulesPerSheet) {
+                if (currentMergeGroup.size > 1) {
+                    elementGroups += currentMergeGroup
+                }
+                totalRulesCount = 0
+                currentMergeGroup = mutableListOf()
+            }
+            totalRulesCount += rulesLength
+            currentMergeGroup.add(element)
+        }
+        if (currentMergeGroup.size > 1) {
+            elementGroups += currentMergeGroup
+        }
+
+        class RulesGroupUpdate(val element: HTMLStyleElement, val shift: Int)
+
+        // Move all rules in group to first style element and delete other elements.
+        val groupUpdates = mutableMapOf<HTMLStyleElement, RulesGroupUpdate>()
+        elementGroups.forEach { elements ->
+            val reused = elements.first()
+            elements.drop(1).forEach { mergedSheet ->
+                groupUpdates[mergedSheet] = RulesGroupUpdate(reused, reused.cssSheet.cssRules.length)
+                mergedSheet.cssSheet.cssRules.asList().forEach {
+                    reused.cssSheet.insertRule(it.cssText, reused.cssSheet.cssRules.length)
+                }
+                mergedSheet.removeAndCleanUp()
+            }
+        }
+
+        // Update ranges of moved rules
+        for (entry in groups) {
+            val otherGroup = entry.value
+            groupUpdates[otherGroup.element]?.let {
+                val otherRange = otherGroup.rulesRange
+                val shiftedRange = (otherRange.first + it.shift)..(otherRange.last + it.shift)
+                entry.setValue(RulesGroup(element = it.element, rulesRange = shiftedRange))
+            }
+        }
     }
 
     override fun clear() {
+        super.clear()
         groups.clear()
         scheduledGroups.clear()
     }
+
+    private data class RulesGroup(val element: HTMLStyleElement, val rulesRange: IntRange)
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/sheets/DevSheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/sheets/DevSheet.kt
@@ -7,8 +7,7 @@ import kotlinx.dom.appendText
  * because the stylesheet can be easily viewed using devtools, but relatively slow.
  * Consider using [StyledNext.getCss], [StyledNext.downloadCss] instead.
  */
-internal class DevSheet(type: RuleType) : AbstractSheet(type) {
-    private val style by lazy { appendStyleElement() }
+internal class DevSheet(type: RuleType) : AbstractSheet(type, maxRulesPerSheet = null) {
     private val scheduledRules = mutableListOf<String>()
 
     override fun scheduleToInject(rules: Iterable<String>): GroupId {
@@ -17,11 +16,12 @@ internal class DevSheet(type: RuleType) : AbstractSheet(type) {
     }
 
     override fun injectScheduled() {
-        style.appendText(scheduledRules.joinToString("\n"))
+        getCurrentStyleElement(scheduledRules.size).appendText(scheduledRules.joinToString("\n"))
         scheduledRules.clear()
     }
 
     override fun clear() {
+        super.clear()
         scheduledRules.clear()
     }
 }

--- a/kotlin-styled-next/src/main/kotlin/styled/sheets/Sheet.kt
+++ b/kotlin-styled-next/src/main/kotlin/styled/sheets/Sheet.kt
@@ -2,6 +2,8 @@ package styled.sheets
 
 import kotlinx.browser.window
 import org.w3c.dom.HTMLStyleElement
+import org.w3c.dom.asList
+import org.w3c.dom.css.CSSStyleSheet
 
 internal typealias GroupId = Int
 
@@ -19,20 +21,64 @@ internal interface Sheet {
     fun injectScheduled()
 }
 
-internal abstract class AbstractSheet(private val ruleType: RuleType) : Sheet {
+internal const val DEFAULT_MAX_RULES_PER_SHEET = 50
+
+/**
+ * @param maxRulesPerSheet If style sheet contains more than [maxRulesPerSheet] rules, then new styles
+ * are inserted to new style sheet to avoid possibly slow style recalculation. If [maxRulesPerSheet] is null,
+ * then all styles are inserted to the single style sheet.
+ */
+internal abstract class AbstractSheet(
+    private val ruleType: RuleType,
+    protected val maxRulesPerSheet: Int? = DEFAULT_MAX_RULES_PER_SHEET
+) : Sheet {
+    protected val usedStyleElements = mutableListOf<HTMLStyleElement>()
     private val id: String
         get() = when (ruleType) {
             RuleType.REGULAR -> styleId
             RuleType.IMPORT -> importStyleId
         }
 
-    fun appendStyleElement(): HTMLStyleElement {
+    private var currentStyleElement: HTMLStyleElement? = null
+    private var partitionCounter = 0
+    private fun createStyleElement(): HTMLStyleElement {
+        val id = when (maxRulesPerSheet) {
+            null -> id
+            else -> "${id}_${partitionCounter++}"
+        }
         val style = window.document.head!!.appendChild(window.document.createElement("style")) as HTMLStyleElement
         style.setAttribute("id", id)
+        usedStyleElements += style
         return style
     }
 
-    fun removeStyleElement() = window.document.getElementById(id)?.remove()
+    protected fun getCurrentStyleElement(rulesToAdd: Int): HTMLStyleElement {
+        val element = currentStyleElement?.takeIf {
+            it.parentNode != null && (maxRulesPerSheet == null || it.cssSheet.cssRules.length + rulesToAdd <= maxRulesPerSheet)
+        } ?: createStyleElement().also {
+            currentStyleElement = it
+        }
+        return element
+    }
 
-    internal abstract fun clear()
+    protected val HTMLStyleElement.cssSheet: CSSStyleSheet get() = sheet as CSSStyleSheet
+
+    protected fun HTMLStyleElement.removeAndCleanUp() {
+        remove()
+        usedStyleElements.remove(this)
+        if (currentStyleElement == this) {
+            currentStyleElement = null
+        }
+    }
+
+    internal open fun clear() {
+        usedStyleElements.toList().forEach {
+            it.removeAndCleanUp()
+        }
+        window.document.querySelectorAll(styleElementsSelector(id)).asList().forEach {
+            (it as HTMLStyleElement).remove()
+        }
+    }
 }
+
+internal fun styleElementsSelector(id: String) = "[id^='${id}_'],[id='$id']"

--- a/kotlin-styled-next/src/test/kotlin/benchmark/BenchmarkBase.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/BenchmarkBase.kt
@@ -29,7 +29,7 @@ open class BenchmarkBase {
     }
 
     protected fun TestScope.assertCssNotEmpty() {
-        assertTrue(getRules().length > 0)
+        assertTrue(getRules().isNotEmpty())
     }
 
     /**

--- a/kotlin-styled-next/src/test/kotlin/benchmark/InjectCssNPlusOne.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/InjectCssNPlusOne.kt
@@ -1,0 +1,118 @@
+package benchmark
+
+import TestScope
+import addCss
+import kotlinx.browser.window
+import kotlinx.css.CssBuilder
+import kotlinx.css.height
+import kotlinx.css.px
+import kotlinx.css.width
+import react.Props
+import react.fc
+import styled.GlobalStyles
+import styled.css
+import styled.sheets.CSSOMSheet
+import styled.sheets.RemoveMode
+import styled.sheets.RuleType
+import styled.styledDiv
+import waitForAnimationFrame
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
+
+@OptIn(ExperimentalTime::class)
+class InjectCssNPlusOne : BenchmarkBase() {
+
+    private suspend fun TestScope.preloadElements(n: Int) {
+        val component = fc<Props> {
+            val random = Random(152)
+            (1..n).forEach {
+                styledDiv {
+                    css {
+                        height = 100.px
+                        width = 100.px
+                    }
+
+                    addCss(it, random)
+                }
+            }
+        }
+        renderComponent(component)
+        waitForAnimationFrame()
+
+        assertChildrenCount(n)
+        assertCssNotEmpty()
+    }
+
+    /**
+     * Measure performance of style recalculation caused by CSS injection.
+     * This metric becomes more important for pages with big and complex DOM and CSSOM.
+     */
+    private suspend fun TestScope.injectRulesOneByOne(): Duration {
+        val duration = measureTime {
+            repeat(100) {
+                GlobalStyles.scheduleToInject(".dummy_rule$it", CssBuilder().apply {
+                    height = 0.px
+                })
+                GlobalStyles.injectScheduled()
+                window.document.body!!.scrollTop += 1
+            }
+        }
+        clear()
+        return duration
+    }
+
+    private fun disableSheetPartitioning() {
+        GlobalStyles.sheet = CSSOMSheet(RuleType.REGULAR, RemoveMode.Instantly, maxRulesPerSheet = null)
+    }
+
+    @Test
+    fun injectRulesOneByOne500Elements() = runBenchmark("injectRulesOneByOne500Elements") {
+        preloadElements(500)
+
+        injectRulesOneByOne()
+    }
+
+    @Test
+    fun injectRulesOneByOne1000Elements() = runBenchmark("injectRulesOneByOne1000Elements") {
+        preloadElements(1000)
+
+        injectRulesOneByOne()
+    }
+
+    @Test
+    fun injectRulesOneByOne2000Elements() = runBenchmark("injectRulesOneByOne2000Elements") {
+        preloadElements(2000)
+
+        injectRulesOneByOne()
+    }
+
+    @Test
+    fun injectRulesOneByOne500Elements_partitioningDisabled() =
+        runBenchmark("injectRulesOneByOne500Elements_partitioningDisabled") {
+            disableSheetPartitioning()
+            preloadElements(500)
+
+            injectRulesOneByOne()
+        }
+
+    @Test
+    fun injectRulesOneByOne1000Elements_partitioningDisabled() =
+        runBenchmark("injectRulesOneByOne1000Elements_partitioningDisabled") {
+            disableSheetPartitioning()
+            preloadElements(1000)
+
+            injectRulesOneByOne()
+        }
+
+    @Test
+    fun injectRulesOneByOne2000Elements_partitioningDisabled() =
+        runBenchmark("injectRulesOneByOne2000Elements_partitioningDisabled") {
+            disableSheetPartitioning()
+            preloadElements(2000)
+
+            injectRulesOneByOne()
+        }
+}

--- a/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/ElementTest.kt
@@ -4,7 +4,6 @@ import TestScope
 import kotlinx.css.*
 import kotlinx.css.properties.*
 import kotlinx.html.classes
-import org.w3c.dom.css.get
 import org.w3c.dom.get
 import react.Props
 import react.dom.attrs
@@ -76,7 +75,7 @@ class ElementTest : TestBase() {
         assertEquals(firstColor.toString(), element.getStyle().backgroundColor)
         val rule = getRules()[0]
         assertNotNull(rule)
-        assertTrue(rule.cssText.contains("${element.className}:first-child:first-child"))
+        assertTrue(rule.contains("${element.className}:first-child:first-child"))
     }
 
     @Test
@@ -86,10 +85,10 @@ class ElementTest : TestBase() {
                 addRotation()
             }
         }
-        val rules = getStylesheet().cssRules
+        val rules = getRules()
         assertEquals(1, sheet.scheduledGroups.size)
         assertEquals(2, sheet.scheduledGroups.values.first().toList().size)
-        assertEquals(0, rules.length)
+        assertEquals(0, rules.size)
     }
 
     /**
@@ -120,9 +119,9 @@ class ElementTest : TestBase() {
         }
         val firstElement = clearAndInject(first)
         val secondElement = inject(second)
-        val rules = getStylesheet().cssRules
+        val rules = getRules()
         assertEquals(firstElement.className, secondElement.className)
-        assertEquals(1, rules.length)
+        assertEquals(1, rules.size)
     }
 
     /**
@@ -245,12 +244,11 @@ class ElementTest : TestBase() {
             }
         }
         val classname = clearAndInject(styledComponent).className
-        val rules = getStylesheet().cssRules
-        val keyframeIdx = (0 until rules.length).first { i ->
-            val rule = rules[i]
-            rule != null && rule.cssText.contains("@keyframes")
+        val rules = getRules()
+        val keyframeIdx = rules.indexOfFirst {
+            it.contains("@keyframes")
         }
-        val keyframeName = rules[keyframeIdx]!!.cssText.substringAfter("@keyframes ").substringBefore("{").trim()
+        val keyframeName = rules[keyframeIdx].substringAfter("@keyframes ").substringBefore("{").trim()
         assertCssInjected(
             classname,
             "animation" to "5s linear 3s infinite reverse forwards running $keyframeName",
@@ -326,7 +324,7 @@ class ElementTest : TestBase() {
     }
 
     private fun TestScope.assertRulesContain(substring: String) {
-        val rule = getRules().find { it.cssText.contains(substring) }
+        val rule = getRules().find { it.contains(substring) }
         assertNotNull(rule)
     }
 
@@ -373,11 +371,11 @@ class ElementTest : TestBase() {
         }
         val element = clearAndInject(styledComponent)
         val linearClassName = ".${element.className}".repeat(3)
-        val linearCss = getRules().find { it.cssText.contains(linearClassName) }
+        val linearCss = getRules().find { it.contains(linearClassName) }
         assertNotNull(linearCss)
 
         val exponentialClassName = ".${element.className}".repeat(4)
-        val exponentialCss = getRules().find { it.cssText.contains(exponentialClassName) }
+        val exponentialCss = getRules().find { it.contains(exponentialClassName) }
         assertNull(exponentialCss)
 
         assertCssInjected(linearClassName, "color" to thirdColor.toString())

--- a/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/RemoveCssTest.kt
@@ -63,10 +63,10 @@ class RemoveCssTest : TestBase() {
             }
         }
         clearAndInject(styledComponent)
-        assertEquals(1, getRules().length)
+        assertEquals(1, getRules().size)
         clear()
 
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 
     @Test
@@ -77,10 +77,10 @@ class RemoveCssTest : TestBase() {
             styledSpan { css { paddingLeft = 0.px } }
         }
         clearAndInject(styledComponent)
-        assertEquals(3, getRules().length)
+        assertEquals(3, getRules().size)
         clear()
 
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 
     @Test
@@ -99,7 +99,7 @@ class RemoveCssTest : TestBase() {
         assertEquals(firstColor.toString(), element2.color())
         clear()
 
-        assertEquals(1, getRules().length)
+        assertEquals(1, getRules().size)
         assertEquals(firstColor.toString(), element2.color())
     }
 
@@ -117,14 +117,14 @@ class RemoveCssTest : TestBase() {
         }
         clearAndInject(styledComponent)
         injectAdditional(styledComponent2)
-        assertEquals(5, getRules().length)
+        assertEquals(5, getRules().size)
         injectAdditional(styledComponent, thirdRoot)
         clear()
-        assertEquals(5, getRules().length)
+        assertEquals(5, getRules().size)
         unmount(thirdRoot)
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
         unmount(secondRoot)
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 
     @Test
@@ -143,15 +143,15 @@ class RemoveCssTest : TestBase() {
         injectAdditional(styledComponent2)
 
         clear()
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
         clearAndInject(styledComponent)
-        assertEquals(5, getRules().length)
+        assertEquals(5, getRules().size)
         unmount(secondRoot)
-        assertEquals(4, getRules().length)
+        assertEquals(4, getRules().size)
         clear()
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
         injectAdditional(styledComponent2)
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
     }
 
     @Test
@@ -168,11 +168,11 @@ class RemoveCssTest : TestBase() {
         }
         clearAndInject(styledComponent)
         injectAdditional(styledComponent2)
-        assertEquals(5, getRules().length)
+        assertEquals(5, getRules().size)
 
         clear()
 
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
         assertEquals(firstColor.toString(), secondRoot.childAt(0).color())
         assertEquals(thirdColor.toString(), secondRoot.childAt(1).color())
     }
@@ -190,10 +190,10 @@ class RemoveCssTest : TestBase() {
             }
         }
         clearAndInject(styledComponent)
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
 
         clear()
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 
     @Test
@@ -204,11 +204,11 @@ class RemoveCssTest : TestBase() {
             }
         }
         clearAndInject(styledComponent)
-        assertEquals(3, getRules().length)
+        assertEquals(3, getRules().size)
 
         clear()
         // 2 rules remaining are keyframes, which we do not remove
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
     }
 
     @Test
@@ -220,11 +220,11 @@ class RemoveCssTest : TestBase() {
             }
         }
         clearAndInject(styledComponent)
-        assertEquals(3, getRules().length)
+        assertEquals(3, getRules().size)
 
         clear()
         // 2 rules remaining are keyframes, which we do not remove
-        assertEquals(2, getRules().length)
+        assertEquals(2, getRules().size)
     }
 
     @Test
@@ -237,7 +237,7 @@ class RemoveCssTest : TestBase() {
         }
         clearAndInject(styledComponent)
         clearAndInject(styledComponent)
-        assertEquals(3, getRules().length)
+        assertEquals(3, getRules().size)
     }
 
     @Test
@@ -246,9 +246,9 @@ class RemoveCssTest : TestBase() {
             styledDiv { css { +staticStyleSheet.property1 } }
         }
         clearAndInject(styledComponent)
-        assertEquals(1, getRules().length)
+        assertEquals(1, getRules().size)
         removeInjectedStyleSheet()
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 
     @Test
@@ -257,9 +257,11 @@ class RemoveCssTest : TestBase() {
             styledDiv { css { +staticStyleSheet.property1 } }
         }
         clearAndInject(styledComponent)
-        assertEquals(1, getRules().length)
+        assertEquals(1, getRules().size)
+        println("hi1")
         removeInjectedStyleSheet()
-        assertEquals(0, getRules().length)
+        println("hi2")
+        assertEquals(0, getRules().size)
 
         val styledComponent2 = fc<Props> {
             styledDiv {
@@ -269,10 +271,13 @@ class RemoveCssTest : TestBase() {
                 }
             }
         }
+        println("hi3")
         clearAndInject(styledComponent)
+        println("hi4")
         injectAdditional(styledComponent2)
-        assertEquals(2, getRules().length)
+        println("hi5")
+        assertEquals(2, getRules().size)
         removeInjectedStyleSheet()
-        assertEquals(0, getRules().length)
+        assertEquals(0, getRules().size)
     }
 }

--- a/kotlin-styled-next/src/test/kotlin/test/SheetPartitioningTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/SheetPartitioningTest.kt
@@ -1,0 +1,141 @@
+package test
+
+import Component
+import TestScope
+import createDOMElement
+import kotlinx.css.height
+import kotlinx.css.px
+import org.w3c.dom.Element
+import org.w3c.dom.HTMLElement
+import react.FC
+import react.Props
+import react.fc
+import runTest
+import styled.GlobalStyles
+import styled.css
+import styled.sheets.CSSOMSheet
+import styled.sheets.RemoveMode
+import styled.sheets.RuleType
+import styled.styledDiv
+import unmount
+import waitForAnimationFrame
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SheetPartitioningTest : TestBase() {
+    private val secondRoot by lazy { createDOMElement() }
+    private val thirdRoot by lazy { createDOMElement() }
+
+    private suspend fun TestScope.injectAdditional(component: Component, root: HTMLElement = secondRoot): Element {
+        renderComponent(component, root)
+        val element = root.firstElementChild
+        assertNotNull(element)
+        waitForAnimationFrame()
+        return element
+    }
+
+    @BeforeTest
+    override fun before() = runTest {
+        clearStyles()
+        GlobalStyles.sheet = CSSOMSheet(RuleType.REGULAR, RemoveMode.Instantly, maxRulesPerSheet = 100)
+    }
+
+    @Test
+    fun rulesAddedToOneSheetInOneBatch() = runTest {
+        val styledComponent = getFC(1..250)
+        inject(styledComponent)
+        assertEquals(250, getRules().size)
+        assertEquals(listOf(250), getStylesheets().map { it.cssRules.length })
+    }
+
+    @Test
+    fun rulesAddedToNewStyleSheets() = runTest {
+        val styledComponent1 = getFC(1..100)
+        val styledComponent2 = getFC(101..200)
+        val styledComponent3 = getFC(201..250)
+
+        inject(styledComponent1)
+        assertEquals(100, getRules().size)
+        assertEquals(listOf(100), getStylesheets().map { it.cssRules.length })
+
+        injectAdditional(styledComponent2, secondRoot)
+        injectAdditional(styledComponent3, thirdRoot)
+
+        assertEquals(250, getRules().size)
+        assertEquals(listOf(100, 100, 50), getStylesheets().map { it.cssRules.length })
+    }
+
+    @Test
+    fun rulesAddedToOldAndNewStyleSheets() = runTest {
+        val styledComponent1 = getFC(1..50)
+        val styledComponent2 = getFC(51..150)
+        val styledComponent3 = getFC(151..250)
+
+        inject(styledComponent1)
+        assertEquals(50, getRules().size)
+        assertEquals(listOf(50), getStylesheets().map { it.cssRules.length })
+
+        injectAdditional(styledComponent2, secondRoot)
+        injectAdditional(styledComponent3, thirdRoot)
+
+        assertEquals(250, getRules().size)
+        assertEquals(listOf(50, 100, 100), getStylesheets().map { it.cssRules.length })
+    }
+
+    @Test
+    fun compressSheetsAfterRulesDeletion() = runTest {
+        val styleRanges = listOf(
+            0 until 25,
+            25 until 100,
+            100 until 125,
+            125 until 200,
+            200 until 300,
+            300 until 350,
+            350 until 400,
+            400 until 450
+        )
+        val roots = styleRanges.map {
+            createDOMElement()
+        }
+        val components = styleRanges.map {
+            getFC(it)
+        }
+        components.zip(roots).forEach { (component, root) ->
+            injectAdditional(component, root)
+        }
+        assertEquals(450, getRules().size)
+        assertEquals(listOf(100, 100, 100, 100, 50), getStylesheets().map { it.cssRules.length })
+        val rules = getRules()
+
+        unmount(roots[1])
+        unmount(roots[3])
+
+        assertEquals(300, getRules().size)
+        assertEquals(listOf(50, 100, 100, 50), getStylesheets().map { it.cssRules.length })
+        val rules1 = rules - rules.slice(styleRanges[1]).toSet() - rules.slice(styleRanges[3]).toSet()
+        assertEquals(rules1, getRules())
+
+        unmount(roots[5])
+
+        assertEquals(250, getRules().size)
+        assertEquals(listOf(50, 100, 100), getStylesheets().map { it.cssRules.length })
+        val rules2 = rules1 - rules.slice(styleRanges[5]).toSet()
+        assertEquals(rules2, getRules())
+    }
+
+    private fun getFC(range: IntRange): FC<Props> {
+        return fc {
+            styledDiv {
+                css {
+                    range.forEach {
+                        descendants("k$it") {
+                            height = 0.px
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/StyleSheetTest.kt
@@ -3,7 +3,7 @@ package test
 import kotlinx.browser.document
 import kotlinx.css.*
 import org.w3c.dom.HTMLStyleElement
-import org.w3c.dom.css.CSSRuleList
+import org.w3c.dom.asList
 import org.w3c.dom.css.CSSStyleSheet
 import react.Props
 import react.fc
@@ -11,6 +11,7 @@ import runTest
 import styleSheets.*
 import styled.*
 import styled.sheets.importStyleId
+import styled.sheets.styleElementsSelector
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -24,9 +25,12 @@ class StyleSheetTest : TestBase() {
     private lateinit var importUrlSheet: StyleSheet
     private lateinit var importFileSheet: StyleSheet
 
-    private fun getImportRules(): CSSRuleList {
-        val styles = document.getElementById(importStyleId) as HTMLStyleElement
-        return (styles.sheet as CSSStyleSheet).cssRules
+    private fun getImportRules(): List<String> {
+        return document.querySelectorAll(styleElementsSelector(importStyleId)).asList().flatMap { node ->
+            node.unsafeCast<HTMLStyleElement>().sheet.unsafeCast<CSSStyleSheet>().cssRules.asList().map {
+                it.cssText
+            }
+        }
     }
 
     @BeforeTest
@@ -45,9 +49,9 @@ class StyleSheetTest : TestBase() {
         CssBuilder().apply {
             +staticStyleSheet.property1
         }
-        val rules = getStylesheet().cssRules
+        val rules = getRules()
         assertEquals(1, sheet.scheduledGroups.size)
-        assertEquals(0, rules.length)
+        assertEquals(0, rules.size)
     }
 
     object SheetWithMarker : StyleSheet("SheetWithMarker", isStatic = true) {
@@ -177,7 +181,7 @@ class StyleSheetTest : TestBase() {
         }
         clearAndInject(styledComponent)
         inject(styledComponent)
-        assertEquals(4, getImportRules().length)
+        assertEquals(4, getImportRules().size)
     }
 
     @Test

--- a/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
+++ b/kotlin-styled-next/src/test/kotlin/test/TestBase.kt
@@ -8,7 +8,6 @@ import kotlinx.css.properties.rotate
 import kotlinx.css.properties.transform
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLInputElement
-import org.w3c.dom.css.CSSRuleList
 import org.w3c.dom.get
 import runTest
 import kotlin.test.*
@@ -31,13 +30,12 @@ open class TestBase {
     protected fun TestScope.assertCssInjected(
         selector: String,
         strings: Iterable<String>,
-        rules: CSSRuleList = getRules(),
+        rules: List<String> = getRules(),
     ) {
         val checkedCss = StringBuilder()
-        for (i in 0 until rules.length) {
-            val css = rules.item(i)?.cssText
+        for (css in rules) {
             checkedCss.appendLine(css)
-            if (css == null || selector !in css)
+            if (selector !in css)
                 continue
             css.let {
                 strings.forEach {


### PR DESCRIPTION
It should make style recalculation cheaper when new CSS is injected