### PR TITLE
Enable `kotlin.time` in one place

### DIFF
--- a/kotlin-styled-next/build.gradle.kts
+++ b/kotlin-styled-next/build.gradle.kts
@@ -15,6 +15,10 @@ kotlin.js {
     }
 }
 
+kotlin.sourceSets.test {
+    languageSettings.optIn("kotlin.time.ExperimentalTime")
+}
+
 dependencies {
     api(project(":kotlin-extensions"))
     api(project(":kotlin-css"))

--- a/kotlin-styled-next/src/test/kotlin/benchmark/AddDuplicateCss.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/AddDuplicateCss.kt
@@ -9,10 +9,8 @@ import waitForAnimationFrame
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class AddDuplicateCss : BenchmarkBase() {
     /**
      * Measure the time elapsed to inject [repeatCount] styled components with the same CSS [n] times into the DOM

--- a/kotlin-styled-next/src/test/kotlin/benchmark/AddStyledElements.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/AddStyledElements.kt
@@ -8,16 +8,12 @@ import styled.UsedCssInfo
 import waitForAnimationFrame
 import kotlin.test.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-
-@OptIn(ExperimentalTime::class)
 class AddStyledElements : BenchmarkBase() {
     /**
      * [LinkedHashMap] implementation which holds total duration of all [get] and [put] operations
      */
-    @OptIn(ExperimentalTime::class)
     private class TimedLinkedHashMap<K, V> : LinkedHashMap<K, V>() {
         var getOperationsDuration: Duration = Duration.ZERO
         var putOperationsDuration: Duration = Duration.ZERO

--- a/kotlin-styled-next/src/test/kotlin/benchmark/BenchmarkBase.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/BenchmarkBase.kt
@@ -10,9 +10,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalTime::class)
 open class BenchmarkBase {
     protected val additionalMeasurements = mutableMapOf<String, MutableList<Duration>>()
     private fun flowRepeat(count: Int, calculate: suspend () -> Duration): Flow<Duration> {

--- a/kotlin-styled-next/src/test/kotlin/benchmark/ConvertToStyled.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/ConvertToStyled.kt
@@ -5,10 +5,8 @@ import waitFlowCoroutine
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class ConvertToStyled : BenchmarkBase() {
     private suspend fun convertNCssBuilders(n: Int): Duration {
         val builders = getCssBuilders(n)

--- a/kotlin-styled-next/src/test/kotlin/benchmark/CssBuildersInject.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/CssBuildersInject.kt
@@ -6,10 +6,8 @@ import kotlinx.css.CssBuilder
 import waitForAnimationFrame
 import kotlin.test.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class CssBuildersInject : BenchmarkBase() {
     /**
      * Measure the time elapsed to inject [n] [CssBuilder] CSS rules into the DOM

--- a/kotlin-styled-next/src/test/kotlin/benchmark/DataTypeOperations.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/DataTypeOperations.kt
@@ -8,10 +8,8 @@ import waitForAnimationFrame
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class DataTypeOperations : BenchmarkBase() {
     /**
      * Measures [LinkedHashMap.put] operation for [GlobalStyles.styledClasses] data structure [n] times

--- a/kotlin-styled-next/src/test/kotlin/benchmark/InjectCssNPlusOne.kt
+++ b/kotlin-styled-next/src/test/kotlin/benchmark/InjectCssNPlusOne.kt
@@ -19,10 +19,8 @@ import waitForAnimationFrame
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class InjectCssNPlusOne : BenchmarkBase() {
 
     private suspend fun TestScope.preloadElements(n: Int) {


### PR DESCRIPTION
Preparing to Kotlin `1.6.20`

cc @sgrishchenko @aerialist7 