### PR TITLE
React. Deprecate `children()` extension

### DIFF
--- a/examples/src/main/kotlin/example/Main.kt
+++ b/examples/src/main/kotlin/example/Main.kt
@@ -29,7 +29,7 @@ enum class Theme(
 
 val ThemeContext = createContext(Theme.LIGHT)
 
-val MainApp = FC<PropsWithChildren> {
+val MainApp = FC<PropsWithChildren> { props ->
     ThemeContext.Provider(Theme.DARK) {
         div {
             ThemeContext.Consumer {
@@ -61,7 +61,7 @@ val MainApp = FC<PropsWithChildren> {
             Object.assign(this, jso<HTMLAttributes<HTMLDivElement>> { tabIndex = 0 })
 
             // Appending children from props
-            children()
+            +props.children
 
             // Form elements https://facebook.github.io/react/docs/forms.html
 

--- a/examples/src/main/kotlin/example/Product.kt
+++ b/examples/src/main/kotlin/example/Product.kt
@@ -25,12 +25,12 @@ import react.useState
  * Date: Nov 24, 2017
  */
 
-val RawProductCategory = FC<PropsWithChildren> {
+val RawProductCategory = FC<PropsWithChildren> { props ->
     tr {
         th {
             colSpan = 2
 
-            children()
+            +props.children
         }
     }
 }

--- a/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
@@ -65,6 +65,7 @@ sealed interface ChildrenBuilder {
         }
     }
 
+    @Deprecated("Use +props.children instead.")
     fun PropsWithChildren.children() {
         Children.toArray(children)
             .forEach(::child)


### PR DESCRIPTION
Related - #614