### PR TITLE
React. `ForwardRef` factory method

### DIFF
--- a/examples/src/main/kotlin/example/ForwardingRefs.kt
+++ b/examples/src/main/kotlin/example/ForwardingRefs.kt
@@ -19,7 +19,7 @@ private class SimpleFocusable(
 
 typealias FancyInputProps = PropsWithRef<Focusable>
 
-val FancyInput = rawForwardRef<Focusable, FancyInputProps> { _, forwardedRef ->
+val FancyInput = ForwardRef<Focusable, FancyInputProps> { _, forwardedRef ->
     val inputRef = useRef<HTMLInputElement>()
 
     useImperativeHandle(forwardedRef, inputRef) {

--- a/kotlin-react/src/main/kotlin/react/ForwardRef.kt
+++ b/kotlin-react/src/main/kotlin/react/ForwardRef.kt
@@ -1,0 +1,11 @@
+package react
+
+fun <T : Any, P : PropsWithRef<T>> ForwardRef(
+    block: ChildrenBuilder.(
+        props: P,
+        forwardedRef: Ref<T>?,
+    ) -> Unit,
+): ForwardRefExoticComponent<P> =
+    rawForwardRef { props, ref ->
+        createElementOrNull { block(props, ref) }
+    }


### PR DESCRIPTION
Fix #1347