### PR TITLE
CSSType. Fix `GridLine` type [generated]

### DIFF
--- a/kotlin-csstype/src/main/generated/csstype/AutoType.kt
+++ b/kotlin-csstype/src/main/generated/csstype/AutoType.kt
@@ -26,6 +26,7 @@ sealed external interface AutoType :
     FontOpticalSizing,
     FontSmooth,
     ForcedColorAdjust,
+    GridLine,
     HyphenateCharacter,
     Hyphens,
     ImageRendering,

--- a/kotlin-csstype/src/main/generated/csstype/GridLine.kt
+++ b/kotlin-csstype/src/main/generated/csstype/GridLine.kt
@@ -2,5 +2,4 @@
 
 package csstype
 
-// "auto" | (string & {}) | (number & {})
 sealed external interface GridLine : GridLineProperty


### PR DESCRIPTION
cc @turansky 