### PR TITLE
MUI: Correct Palette and PaletteOptions types

### DIFF
--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -91,10 +91,15 @@ external interface PaletteAugmentColorOptions {
     var name: dynamic
 }
 
+enum class PaletteMode {
+    light,
+    dark
+}
+
 external interface Palette {
     var common: CommonColors
 
-    var mode: dynamic
+    // var mode: PaletteMode is declared as an extension var below.
 
     var contrastThreshold: Number
 
@@ -126,6 +131,10 @@ external interface Palette {
 
     var augmentColor: (options: PaletteAugmentColorOptions) -> PaletteColor
 }
+
+var Palette.mode: PaletteType
+    get() = PaletteType.valueOf(asDynamic()["mode"] as String)
+    set(value) { asDynamic()["mode"] = value.name }
 
 external interface PaletteOptions {
     var primary: dynamic

--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -69,6 +69,7 @@ external interface PaletteColor {
     var contrastText: csstype.Color
 }
 
+// This is related to PaletteMode, unclear how you access one from the other, though.
 external interface TypeObject {
     var text: dynamic
 

--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -137,6 +137,21 @@ var Palette.mode: PaletteType
     get() = PaletteType.valueOf(asDynamic()["mode"] as String)
     set(value) { asDynamic()["mode"] = value.name }
 
+fun Palette.augmentColor(
+    color: Color? = null,
+    name: String? = null,
+    mainShade: Number? = null,
+    lightShade: Number? = null,
+    darkShade: Number? = null
+): PaletteColor =
+    augmentColor(jso {
+        this.color = color
+        this.name = name
+        this.mainShade = mainShade
+        this.lightShade = lightShade
+        this.darkShade = darkShade
+    })
+
 external interface PaletteOptions {
     var primary: dynamic
 

--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -133,8 +133,8 @@ external interface Palette {
     var augmentColor: (options: PaletteAugmentColorOptions) -> PaletteColor
 }
 
-var Palette.mode: PaletteType
-    get() = PaletteType.valueOf(asDynamic()["mode"] as String)
+var Palette.mode: PaletteMode
+    get() = PaletteMode.valueOf(asDynamic()["mode"] as String)
     set(value) { asDynamic()["mode"] = value.name }
 
 fun Palette.augmentColor(
@@ -152,6 +152,12 @@ fun Palette.augmentColor(
         this.darkShade = darkShade
     })
 
+external interface CommonColorsOptions {
+    var black: csstype.Color?
+
+    var white: csstype.Color?
+}
+
 external interface PaletteOptions {
     var primary: SimplePaletteColorOptions?
 
@@ -165,13 +171,13 @@ external interface PaletteOptions {
 
     var success: SimplePaletteColorOptions?
 
-    var mode: dynamic
+    var mode: PaletteMode?
 
     var tonalOffset: Number?
 
     var contrastThreshold: Number?
 
-    var common: dynamic
+    var common: CommonColorsOptions?
 
     var grey: dynamic
 

--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -12,31 +12,31 @@ external interface CommonColors {
 }
 
 external interface TypeText {
-    var primary: String
+    var primary: csstype.Color
 
-    var secondary: String
+    var secondary: csstype.Color
 
-    var disabled: String
+    var disabled: csstype.Color
 }
 
 external interface TypeAction {
-    var active: String
+    var active: csstype.Color
 
-    var hover: String
+    var hover: csstype.Color
 
     var hoverOpacity: Number
 
-    var selected: String
+    var selected: csstype.Color
 
     var selectedOpacity: Number
 
-    var disabled: String
+    var disabled: csstype.Color
 
     var disabledOpacity: Number
 
-    var disabledBackground: String
+    var disabledBackground: csstype.Color
 
-    var focus: String
+    var focus: csstype.Color
 
     var focusOpacity: Number
 
@@ -50,13 +50,13 @@ external interface TypeBackground {
 }
 
 external interface SimplePaletteColorOptions {
-    var light: String?
+    var light: csstype.Color?
 
-    var main: String
+    var main: csstype.Color
 
-    var dark: String?
+    var dark: csstype.Color?
 
-    var contrastText: String?
+    var contrastText: csstype.Color?
 }
 
 external interface PaletteColor {
@@ -80,7 +80,7 @@ external interface TypeObject {
 }
 
 external interface PaletteAugmentColorOptions {
-    var color: dynamic
+    var color: csstype.Color
 
     var mainShade: dynamic
 
@@ -92,13 +92,13 @@ external interface PaletteAugmentColorOptions {
 }
 
 external interface Palette {
-    var common: dynamic
+    var common: CommonColors
 
     var mode: dynamic
 
     var contrastThreshold: Number
 
-    var tonalOffset: dynamic
+    var tonalOffset: Number
 
     var primary: PaletteColor
 
@@ -114,13 +114,13 @@ external interface Palette {
 
     var grey: dynamic
 
-    var text: dynamic
+    var text: TypeText
 
-    var divider: dynamic
+    var divider: csstype.Color
 
-    var action: dynamic
+    var action: TypeAction
 
-    var background: dynamic
+    var background: TypeBackground
 
     var getContrastText: (background: String) -> String
 

--- a/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
+++ b/kotlin-mui/src/main/generated/mui/material/styles/createPalette.kt
@@ -153,21 +153,21 @@ fun Palette.augmentColor(
     })
 
 external interface PaletteOptions {
-    var primary: dynamic
+    var primary: SimplePaletteColorOptions?
 
-    var secondary: dynamic
+    var secondary: SimplePaletteColorOptions?
 
-    var error: dynamic
+    var error: SimplePaletteColorOptions?
 
-    var warning: dynamic
+    var warning: SimplePaletteColorOptions?
 
-    var info: dynamic
+    var info: SimplePaletteColorOptions?
 
-    var success: dynamic
+    var success: SimplePaletteColorOptions?
 
     var mode: dynamic
 
-    var tonalOffset: dynamic
+    var tonalOffset: Number?
 
     var contrastThreshold: Number?
 


### PR DESCRIPTION
Added types for most of the remaining `Palette` and `PaletteOptions` fields.

@turansky — I realize these files are generated, not hand-edited, so this PR won't be directly acceptable, but I figured this was the easiest way to convey suggested changes to [mui-kotlin](https://github.com/karakum-team/mui-kotlin).

Thank you!