### PR TITLE
CSSType. Support `@font-face` rule [generated]

### DIFF
--- a/kotlin-csstype/src/main/generated/csstype/RuleBuilder.kt
+++ b/kotlin-csstype/src/main/generated/csstype/RuleBuilder.kt
@@ -9,6 +9,12 @@ package csstype
 import kotlinx.js.jso
 
 interface RuleBuilder<T : Any> {
+    inline fun fontFace(
+        block: FontFace.() -> Unit,
+    ) {
+        this@RuleBuilder.unsafeCast<Rules>()[Selector("@font-face")] = jso(block)
+    }
+
     inline operator fun Selector.invoke(
         block: T.() -> Unit,
     ) {

--- a/kotlin-csstype/src/main/generated/csstype/Rules.kt
+++ b/kotlin-csstype/src/main/generated/csstype/Rules.kt
@@ -4,4 +4,4 @@ package csstype
 
 import kotlinx.js.Record
 
-typealias Rules = Record<Selector, Properties>
+typealias Rules = Record<Selector, Any>


### PR DESCRIPTION
[Related discussion](https://kotlinlang.slack.com/archives/C5ZTZ6ER0/p1648812884243099)

[Multiple `@font-face`](https://github.com/emotion-js/emotion/issues/1395)