### PR TITLE
CSSType. Numeric `flex` support [generated]

### DIFF
--- a/kotlin-csstype/src/main/generated/csstype/Number.kt
+++ b/kotlin-csstype/src/main/generated/csstype/Number.kt
@@ -8,6 +8,7 @@ package csstype
 
 sealed external interface NumberType :
     AnimationIterationCount,
+    Flex,
     FlexGrow,
     FlexShrink,
     LineHeight,


### PR DESCRIPTION
Fix #1423

cc @aerialist7 