### PR TITLE
React. Remove deprecated `children()` helper

### DIFF
--- a/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
+++ b/kotlin-react/src/main/kotlin/react/ChildrenBuilder.kt
@@ -75,12 +75,6 @@ sealed interface ChildrenBuilder {
             block()
         }
     }
-
-    @Deprecated("Use +props.children instead.")
-    fun PropsWithChildren.children() {
-        Children.toArray(children)
-            .forEach(::child)
-    }
 }
 
 @JsName("createChildrenBuilder")


### PR DESCRIPTION
cc @aerialist7 