### PR TITLE
React Query. Fix `UseBaseMutationResult` signature

### DIFF
--- a/kotlin-react-query/src/main/generated/react/query/mutationCache.core.kt
+++ b/kotlin-react-query/src/main/generated/react/query/mutationCache.core.kt
@@ -20,7 +20,8 @@ external interface MutationCacheConfig {
 
 typealias MutationCacheListener = (mutation: Mutation<*, *, *, *>?) -> Unit
 
-open external class MutationCache(config: MutationCacheConfig = definedExternally) : Subscribable<MutationCacheListener> {
+open external class MutationCache(config: MutationCacheConfig = definedExternally) :
+    Subscribable<MutationCacheListener> {
     open var config: MutationCacheConfig
     open fun <TData, TError, TVariables, TContext> build(
         client: QueryClient,

--- a/kotlin-react-query/src/main/generated/react/query/mutationCache.core.kt
+++ b/kotlin-react-query/src/main/generated/react/query/mutationCache.core.kt
@@ -20,8 +20,7 @@ external interface MutationCacheConfig {
 
 typealias MutationCacheListener = (mutation: Mutation<*, *, *, *>?) -> Unit
 
-open external class MutationCache(config: MutationCacheConfig = definedExternally) :
-    Subscribable<MutationCacheListener> {
+open external class MutationCache(config: MutationCacheConfig = definedExternally) : Subscribable<MutationCacheListener> {
     open var config: MutationCacheConfig
     open fun <TData, TError, TVariables, TContext> build(
         client: QueryClient,

--- a/kotlin-react-query/src/main/generated/react/query/types.kt
+++ b/kotlin-react-query/src/main/generated/react/query/types.kt
@@ -28,6 +28,10 @@ typealias UseMutateFunction<TData, TError, TVariables, TContext> = Function<Unit
 
 typealias UseMutateAsyncFunction<TData, TError, TVariables, TContext> = MutateFunction<TData, TError, TVariables, TContext>
 
-typealias UseBaseMutationResult<TData, TError, TVariables, TContext> = MutationObserverResult<TData, TError, TVariables, TContext>
+external interface UseBaseMutationResult<TData, TError, TVariables, TContext> :
+    MutationObserverResult<TData, TError, TVariables, TContext> {
+    // override val mutate: UseMutateFunction<TData, TError, TVariables, TContext>
+    val mutateAsync: UseMutateAsyncFunction<TData, TError, TVariables, TContext>
+}
 
 typealias UseMutationResult<TData, TError, TVariables, TContext> = UseBaseMutationResult<TData, TError, TVariables, TContext>


### PR DESCRIPTION
Closes #1548

cc @turansky 