### PR TITLE
Fixed generation 0.pct generation to 0%

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleDimensions.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleDimensions.kt
@@ -49,7 +49,7 @@ open class LinearDimension(override val value: String) : CssValue(value) {
 }
 
 class NumericLinearDimension(val number: Number, val unit: String) :
-    LinearDimension(if (number == 0) ZERO else number.toString() + unit)
+    LinearDimension(if (number == 0 && unit != "%") ZERO else number.toString() + unit)
 
 val Number.ch: LinearDimension get() = NumericLinearDimension(this, "ch")           // Width of "0" glyph
 val Number.cm: LinearDimension get() = NumericLinearDimension(this, "cm")           // Centimeter

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestFlex.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestFlex.kt
@@ -1,0 +1,24 @@
+package kotlinx.css
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestFlex {
+    @Test
+    fun testFlexCorrectBasis() {
+        val cssBuilder = CssBuilder()
+
+        ruleSet {
+            flex(1.0, 1.0, 0.pct)
+        }.invoke(cssBuilder)
+
+        assertEquals(
+            """
+                flex: 1 1 0%;
+
+            """.trimIndent(),
+            cssBuilder.toString(),
+            "Unexpected generated CSS block"
+        )
+    }
+}


### PR DESCRIPTION
When using `flex` property, right now we can't set default `flex: 1`, which will be `flex-grow: 1`, `flex-shrink: 1` and `flex-basis: 0%`. That's how most browsers transform `flex: 1` property.
In `kotlin-css` any zero value transforms into `"0"`, which in the browser fallbacks to `0px`. So the `flex(1.0, 1.0, 0.pct)` call will be transformed to `flex: 1 1 0px`. Pixels and percentages have different behavior, so I suggest to keep unit if someone puts `.pct` for zero value too.
I don't know if it's important to keep unit for them, so I made a fix only for percentages.

cc @Leonya 