### PR TITLE
React. Fix `value`, `min`, `max` types [generated]

### DIFF
--- a/kotlin-react-dom/src/main/generated/react/dom/events/KeyboardEvent.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/events/KeyboardEvent.kt
@@ -32,4 +32,5 @@ external interface KeyboardEvent<out T : Element> : UIEvent<T, NativeKeyboardEve
 
     @Deprecated("Will be removed soon!")
     val which: Int
+    override val target: T
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/ButtonHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/ButtonHTMLAttributes.kt
@@ -15,5 +15,5 @@ external interface ButtonHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var formTarget: String?
     var name: String?
     var type: ButtonType?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/DataHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/DataHTMLAttributes.kt
@@ -5,5 +5,5 @@ package react.dom.html
 import org.w3c.dom.Element
 
 external interface DataHTMLAttributes<T : Element> : HTMLAttributes<T> {
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/HTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/HTMLAttributes.kt
@@ -14,7 +14,7 @@ external interface HTMLAttributes<T : Element> :
     react.PropsWithStyle {
     // React-specific Attributes
     var defaultChecked: Boolean?
-    var defaultValue: String?
+    var defaultValue: Any? /* string | number | ReadonlyArray<string> */
     var suppressContentEditableWarning: Boolean?
     var suppressHydrationWarning: Boolean?
 

--- a/kotlin-react-dom/src/main/generated/react/dom/html/InputHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/InputHTMLAttributes.kt
@@ -23,9 +23,9 @@ external interface InputHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var formTarget: String?
     var height: Double?
     var list: String?
-    var max: Double?
+    var max: Any? /* number | Date */
     var maxLength: Int?
-    var min: Double?
+    var min: Any? /* number | Date */
     var minLength: Int?
     var multiple: Boolean?
     var name: String?
@@ -37,7 +37,7 @@ external interface InputHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var src: String?
     var step: Double?
     var type: InputType?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
     var width: Double?
     var onChange: ChangeEventHandler<T>?
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/LiHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/LiHTMLAttributes.kt
@@ -5,5 +5,5 @@ package react.dom.html
 import org.w3c.dom.Element
 
 external interface LiHTMLAttributes<T : Element> : HTMLAttributes<T> {
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/MeterHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/MeterHTMLAttributes.kt
@@ -11,5 +11,5 @@ external interface MeterHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var max: Double?
     var min: Double?
     var optimum: Double?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/OptionHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/OptionHTMLAttributes.kt
@@ -8,5 +8,5 @@ external interface OptionHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var disabled: Boolean?
     var label: String?
     var selected: Boolean?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/ParamHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/ParamHTMLAttributes.kt
@@ -6,5 +6,5 @@ import org.w3c.dom.Element
 
 external interface ParamHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var name: String?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/ProgressHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/ProgressHTMLAttributes.kt
@@ -6,5 +6,5 @@ import org.w3c.dom.Element
 
 external interface ProgressHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var max: Double?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/SelectHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/SelectHTMLAttributes.kt
@@ -14,6 +14,6 @@ external interface SelectHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var name: String?
     var required: Boolean?
     var size: Int?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
     var onChange: ChangeEventHandler<T>?
 }

--- a/kotlin-react-dom/src/main/generated/react/dom/html/TextareaHTMLAttributes.kt
+++ b/kotlin-react-dom/src/main/generated/react/dom/html/TextareaHTMLAttributes.kt
@@ -19,7 +19,7 @@ external interface TextareaHTMLAttributes<T : Element> : HTMLAttributes<T> {
     var readOnly: Boolean?
     var required: Boolean?
     var rows: Int?
-    var value: String?
+    var value: Any? /* string | ReadonlyArray<string> | number */
     var wrap: String?
     var onChange: ChangeEventHandler<T>?
 }


### PR DESCRIPTION
Fix ##1649

cc @sgrishchenko @aerialist7 