### PR TITLE
Node. Fix `EventEmitter` hierarchy [generated]

### DIFF
--- a/kotlin-node/src/main/generated/node/events/EventEmitter.kt
+++ b/kotlin-node/src/main/generated/node/events/EventEmitter.kt
@@ -9,7 +9,7 @@ import kotlinx.js.ReadonlyArray
 import kotlinx.js.Symbol
 import kotlin.js.Promise
 
-external class EventEmitter {
+abstract external class EventEmitter : IEventEmitter {
     constructor(options: EventEmitterOptions = definedExternally)
 
     companion object {


### PR DESCRIPTION
Part of #1681 