### PR TITLE
React Router: hardcode is removed

### DIFF
--- a/kotlin-remix-run-router/README.md
+++ b/kotlin-remix-run-router/README.md
@@ -6,20 +6,17 @@ Kotlin wrapper for [React Router](https://remix.run/docs/en/v1/other-api/react-r
 
 ### TODO:
 
-1) Do not hardcode params for functions:
-    * `matchPath`
-    * `generatePath`
-2) Support union type hierarchy:
+1) Support union type hierarchy:
     * `AgnosticDataRouteObject`
     * `AgnosticRouteObject`
     * `DataResult`
-3) Support string unions:
+2) Support string unions:
     * `FormEncType`
     * `FormMethod`
-4) Improve typing coverage for types:
+3) Improve typing coverage for types:
     * `DeferredData`
     * `ShouldRevalidateFunctionArgs`
-5) Support indexed type signatures:
+4) Support indexed type signatures:
     * `RouteData`
-6) Remove redundant `?` automatically
+5) Remove redundant `?` automatically
 

--- a/kotlin-remix-run-router/karakum/convertGeneratePath.js
+++ b/kotlin-remix-run-router/karakum/convertGeneratePath.js
@@ -1,4 +1,5 @@
 const ts = require("typescript");
+const karakum = require("karakum");
 
 module.exports = function (node, context, render) {
     if (
@@ -9,9 +10,19 @@ module.exports = function (node, context, render) {
 
         const returnType = render(node.type)
 
-        return `
-external fun ${name}(path: String, params: Record<String, String> = definedExternally): ${returnType}
-        `
+        const signatures = karakum.prepareParameters(node, context)
+
+        return signatures
+            .map(signature => {
+                const parameters = signature
+                    .map(({parameter, type, nullable}) => {
+                        return karakum.convertParameterDeclarationWithFixedType(parameter, type, nullable, context, render);
+                    })
+                    .join(", ")
+
+                return `external fun ${name}(${parameters}): ${returnType}`
+            })
+            .join("\n\n")
     }
     return null
 }

--- a/kotlin-remix-run-router/karakum/convertGeneratePathParams.js
+++ b/kotlin-remix-run-router/karakum/convertGeneratePathParams.js
@@ -1,0 +1,13 @@
+const ts = require("typescript");
+
+module.exports = function (node) {
+    if (
+        ts.isMappedTypeNode(node)
+        && ts.isParameter(node.parent)
+        && ts.isFunctionDeclaration(node.parent.parent)
+        && node.parent.parent.name.text === "generatePath"
+    ) {
+        return "Record<String, String>"
+    }
+    return null
+}

--- a/kotlin-remix-run-router/karakum/convertMatchPath.js
+++ b/kotlin-remix-run-router/karakum/convertMatchPath.js
@@ -1,4 +1,5 @@
 const ts = require("typescript");
+const karakum = require("karakum");
 
 module.exports = function (node, context, render) {
     if (
@@ -9,11 +10,19 @@ module.exports = function (node, context, render) {
 
         const returnType = render(node.type)
 
-        return `
-external fun ${name}(pattern: String, pathname: String): ${returnType}
+        const signatures = karakum.prepareParameters(node, context)
 
-external fun ${name}(pattern: PathPattern, pathname: String): ${returnType}
-        `
+        return signatures
+            .map(signature => {
+                const parameters = signature
+                    .map(({parameter, type, nullable}) => {
+                        return karakum.convertParameterDeclarationWithFixedType(parameter, type, nullable, context, render);
+                    })
+                    .join(", ")
+
+                return `external fun ${name}(${parameters}): ${returnType}`
+            })
+            .join("\n\n")
     }
     return null
 }

--- a/kotlin-remix-run-router/karakum/convertPathParam.js
+++ b/kotlin-remix-run-router/karakum/convertPathParam.js
@@ -1,0 +1,21 @@
+const ts = require("typescript");
+
+module.exports = function (node) {
+    const isGeneratePath = node.parent?.parent !== undefined
+        && ts.isFunctionDeclaration(node.parent.parent)
+        && node.parent.parent.name.text === "generatePath"
+
+    const isMatchPath = node.parent?.parent?.parent !== undefined
+        && ts.isFunctionDeclaration(node.parent.parent.parent)
+        && node.parent.parent.parent.name.text === "matchPath"
+
+    if (
+        ts.isTypeReferenceNode(node)
+        && ts.isIdentifier(node.typeName)
+        && node.typeName.text === "Path"
+        && (isGeneratePath || isMatchPath)
+    ) {
+        return "String"
+    }
+    return null
+}

--- a/kotlin-remix-run-router/src/main/generated/remix/run/router/generatePath.kt
+++ b/kotlin-remix-run-router/src/main/generated/remix/run/router/generatePath.kt
@@ -14,6 +14,4 @@ import js.core.Record
  *
  * @see https://reactrouter.com/docs/en/v6/utils/generate-path
  */
-
 external fun generatePath(path: String, params: Record<String, String> = definedExternally): String
-

--- a/kotlin-remix-run-router/src/main/generated/remix/run/router/matchPath.kt
+++ b/kotlin-remix-run-router/src/main/generated/remix/run/router/matchPath.kt
@@ -14,8 +14,6 @@ package remix.run.router
  *
  * @see https://reactrouter.com/docs/en/v6/utils/match-path
  */
-
-external fun matchPath(pattern: String, pathname: String): PathMatch?
-
 external fun matchPath(pattern: PathPattern, pathname: String): PathMatch?
 
+external fun matchPath(pattern: String, pathname: String): PathMatch?


### PR DESCRIPTION
Hardcode for `matchPath` and `generatePath` params is removed.