### PR TITLE
React Router: declarations improvements

### DIFF
--- a/kotlin-react-router/karakum/plugins/convertRouteObjects.js
+++ b/kotlin-react-router/karakum/plugins/convertRouteObjects.js
@@ -1,0 +1,28 @@
+const ts = require("typescript");
+const karakum = require("karakum");
+
+module.exports = function (node, context, render) {
+    if (
+        ts.isInterfaceDeclaration(node)
+        && node.name.text.endsWith("RouteObject")
+    ) {
+        const name = render(node.name)
+
+        const heritageClauses = node.heritageClauses
+            ?.map(heritageClause => render(heritageClause))
+            ?.join(", ")
+
+        let members = node.members
+            .map(member => render(member))
+            .join("\n")
+
+        const parentType = "RouteObject"
+
+        return `
+external interface ${name} : ${parentType}${karakum.ifPresent(heritageClauses, it => `, ${it}`)} {
+${members}
+}
+        `
+    }
+    return null
+}

--- a/kotlin-react-router/src/jsMain/generated/react/router/IndexRouteObject.kt
+++ b/kotlin-react-router/src/jsMain/generated/react/router/IndexRouteObject.kt
@@ -12,7 +12,7 @@ import remix.run.router.LoaderFunction
 import remix.run.router.ShouldRevalidateFunction
 
 
-external interface IndexRouteObject {
+external interface IndexRouteObject : RouteObject {
     var caseSensitive: Boolean?
     var path: String?
     var id: String?

--- a/kotlin-react-router/src/jsMain/generated/react/router/NonIndexRouteObject.kt
+++ b/kotlin-react-router/src/jsMain/generated/react/router/NonIndexRouteObject.kt
@@ -12,7 +12,7 @@ import remix.run.router.LoaderFunction
 import remix.run.router.ShouldRevalidateFunction
 
 
-external interface NonIndexRouteObject {
+external interface NonIndexRouteObject : RouteObject {
     var caseSensitive: Boolean?
     var path: String?
     var id: String?

--- a/kotlin-react-router/src/jsMain/kotlin/react/router/IndexRouteObject.ext.kt
+++ b/kotlin-react-router/src/jsMain/kotlin/react/router/IndexRouteObject.ext.kt
@@ -1,0 +1,14 @@
+@file:Suppress(
+    "CANNOT_CHECK_FOR_EXTERNAL_INTERFACE",
+)
+
+package react.router
+
+import kotlin.contracts.contract
+
+fun isIndexRouteObject(routeObject: RouteObject): Boolean {
+    contract {
+        returns(true) implies (routeObject is IndexRouteObject)
+    }
+    return routeObject.asDynamic().index == true
+}

--- a/kotlin-react-router/src/jsMain/kotlin/react/router/NonIndexRouteObject.ext.kt
+++ b/kotlin-react-router/src/jsMain/kotlin/react/router/NonIndexRouteObject.ext.kt
@@ -1,0 +1,14 @@
+@file:Suppress(
+    "CANNOT_CHECK_FOR_EXTERNAL_INTERFACE",
+)
+
+package react.router
+
+import kotlin.contracts.contract
+
+fun isNonIndexRouteObject(routeObject: RouteObject): Boolean {
+    contract {
+        returns(true) implies (routeObject is NonIndexRouteObject)
+    }
+    return routeObject.asDynamic().index != true
+}

--- a/kotlin-react-router/src/jsMain/kotlin/react/router/Route.ext.kt
+++ b/kotlin-react-router/src/jsMain/kotlin/react/router/Route.ext.kt
@@ -1,0 +1,12 @@
+@file:JsModule("react-router")
+
+package react.router
+
+@JsName("Route")
+external val PathRoute: react.FC<PathRouteProps>
+
+@JsName("Route")
+external val LayoutRoute: react.FC<LayoutRouteProps>
+
+@JsName("Route")
+external val IndexRoute: react.FC<IndexRouteProps>

--- a/kotlin-react-router/src/jsMain/kotlin/react/router/useRoutes.ext.kt
+++ b/kotlin-react-router/src/jsMain/kotlin/react/router/useRoutes.ext.kt
@@ -1,10 +1,7 @@
-@file:Suppress(
-    "NOTHING_TO_INLINE",
-)
+@file:JsModule("react-router")
 
 package react.router
 
 import js.core.ReadonlyArray
 
-inline fun useRoutes(routes: ReadonlyArray<RouteObject>): react.ReactElement<*>? =
-    useRoutes(routes, undefined.unsafeCast<String>())
+external fun useRoutes(routes: ReadonlyArray<RouteObject>): react.ReactElement<*>?

--- a/kotlin-react-router/src/jsMain/kotlin/react/router/useRoutes.ext.kt
+++ b/kotlin-react-router/src/jsMain/kotlin/react/router/useRoutes.ext.kt
@@ -1,0 +1,10 @@
+@file:Suppress(
+    "NOTHING_TO_INLINE",
+)
+
+package react.router
+
+import js.core.ReadonlyArray
+
+inline fun useRoutes(routes: ReadonlyArray<RouteObject>): react.ReactElement<*>? =
+    useRoutes(routes, undefined.unsafeCast<String>())


### PR DESCRIPTION
Fixes for #1916:
1.  Invalid `RouteObject` - ~~single type expected in result~~ checkers with contracts are added
2.  Duplicated `useRoutes` - inline function with single parameter is added