### PR TITLE
useScrollTrigger

### DIFF
--- a/kotlin-mui/src/jsMain/kotlin/mui/material/useScrollTrigger.kt
+++ b/kotlin-mui/src/jsMain/kotlin/mui/material/useScrollTrigger.kt
@@ -1,0 +1,16 @@
+@file:JsModule("@mui/material/useScrollTrigger")
+@file:JsNonModule
+
+package mui.material
+
+@JsName("useScrollTrigger")
+internal external fun useScrollTrigger(options: ScrollTriggerOptions = definedExternally): Boolean
+
+internal external interface ScrollTriggerOptions {
+    /** Defaults to false. Disable the hysteresis. Ignore the scroll direction when determining the trigger value. */
+    var disableHysteresis: Boolean
+    /** Defaults to window. */
+    var target: dynamic
+    /** Defaults to 100. Change the trigger value when the vertical scroll strictly crosses this threshold (exclusive). */
+    var threshold: Number
+}

--- a/kotlin-mui/src/jsMain/kotlin/mui/material/useScrollTrigger.kt
+++ b/kotlin-mui/src/jsMain/kotlin/mui/material/useScrollTrigger.kt
@@ -3,10 +3,10 @@
 
 package mui.material
 
-@JsName("useScrollTrigger")
-internal external fun useScrollTrigger(options: ScrollTriggerOptions = definedExternally): Boolean
+@JsName("default")
+external fun useScrollTrigger(options: ScrollTriggerOptions = definedExternally): Boolean
 
-internal external interface ScrollTriggerOptions {
+external interface ScrollTriggerOptions {
     /** Defaults to false. Disable the hysteresis. Ignore the scroll direction when determining the trigger value. */
     var disableHysteresis: Boolean
     /** Defaults to window. */


### PR DESCRIPTION
Just a small first PR to introduce a function that is available in the MUI Material and commonly used to hide or show `AppBar`, `Fab`, etc

#### Usage example in React JS

```jsx
import useScrollTrigger from '@mui/material/useScrollTrigger';

function HideOnScroll(props) {
  const trigger = useScrollTrigger();
  return (
    <Slide in={!trigger}>
      <div>Hello</div>
    </Slide>
  );
}
```

#### Equivalent in Kotlin

```kotlin
import mui.material.useScrollTrigger

val HideOnScroll: FC<Props> = FC {
    val trigger = useScrollTrigger()
    Slide {
        `in` = !trigger
        div {
            +"Hello"
        }
    }
}
```

### Reference

https://mui.com/material-ui/react-app-bar/#usescrolltrigger-options-trigger