### PR TITLE
mui: update Portal.kt JsName

### DIFF
--- a/kotlin-mui/src/jsMain/generated/mui/base/Portal.kt
+++ b/kotlin-mui/src/jsMain/generated/mui/base/Portal.kt
@@ -16,5 +16,5 @@ package mui.base
  *
  * - [Portal API](https://mui.com/base-ui/react-portal/components-api/#portal)
  */
-@JsName("default")
+@JsName("Portal")
 external val Portal: react.FC<PortalProps>


### PR DESCRIPTION
No symbol at `default`, should be `Portal`.