### PR TITLE
Allow converting Uint8Array-s to Kotlin's types

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -13,6 +13,7 @@ tasks.withType<KotlinCompile<*>>().configureEach {
 
         freeCompilerArgs += listOf(
             "-opt-in=kotlin.ExperimentalStdlibApi",
+            "-opt-in=kotlin.ExperimentalUnsignedTypes",
             "-opt-in=kotlin.contracts.ExperimentalContracts",
         )
     }

--- a/kotlin-js/src/jsMain/kotlin/js/typedarrays/Uint8Array.kt
+++ b/kotlin-js/src/jsMain/kotlin/js/typedarrays/Uint8Array.kt
@@ -1,5 +1,9 @@
 @file:Suppress(
     "EXTERNAL_CLASS_CONSTRUCTOR_PROPERTY_PARAMETER",
+    "INLINE_EXTERNAL_DECLARATION",
+    "INLINE_CLASS_IN_EXTERNAL_DECLARATION_WARNING",
+    "WRONG_BODY_OF_EXTERNAL_DECLARATION",
+    "NOTHING_TO_INLINE",
 )
 
 package js.typedarrays
@@ -17,6 +21,12 @@ open external class Uint8Array(
     constructor(length: Int)
     constructor(elements: JsIterable<Byte>)
     constructor(elements: ReadonlyArray<Byte>)
+
+    inline fun toByteArray(): ByteArray =
+        Int8Array(buffer, byteOffset, length).asByteArray()
+
+    inline fun toUByteArray(): UByteArray =
+        toByteArray().asUByteArray()
 
     companion object : TypedArrayCompanion<Uint8Array, Byte>
 }


### PR DESCRIPTION
Not sure if `as-` is the correct way to express what's happening here.  
A new instance is created, so maybe `to-` is better. But then it's not aligned with `Int8Array`.

Edit: on a second thought, while a new instance is created, no copying is performed, the new `Int8Array` is only a view over the buffer, so maybe `as-` is totally ok.