### PR TITLE
Add `buildSrc/settings.gradle.kts`

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "buildSrc"


### PR DESCRIPTION
Prevents Gradle warning: 

> Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.
