### PR TITLE
enable Gradle Build Cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ version.build=pre.742
 
 org.gradle.jvmargs=-Xms2g -Xmx4g
 org.gradle.parallel=true
+org.gradle.caching=true
 
 kotlin.incremental.js.klib=false
 


### PR DESCRIPTION
[Gradle Build Cache](https://docs.gradle.org/current/userguide/build_cache.html) is a quick and easy way to improve build performance. 