### PR TITLE
remove kotlin-history from settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,9 +58,6 @@ include("kotlin-emotion")
 // Kotlin/JS: various helpers
 include("kotlin-extensions")
 
-// Kotlin/JS: History wrappers
-include("kotlin-history")
-
 // Kotlin/JS: APIs missing from the standard library
 include("kotlin-js")
 


### PR DESCRIPTION
kotlin-history was removed in [e3911204bc241ba9cf8e9518f6c7f0cd0d97db58](https://github.com/JetBrains/kotlin-wrappers/commit/e3911204bc241ba9cf8e9518f6c7f0cd0d97db58)