### PR TITLE
Allow Object.entries to work on Record<String, Any?>

### DIFF
--- a/kotlin-js/src/jsMain/kotlin/js/objects/Object.kt
+++ b/kotlin-js/src/jsMain/kotlin/js/objects/Object.kt
@@ -17,7 +17,7 @@ external class Object internal constructor() {
         fun <T : Any> create(o: T?, properties: PropertyDescriptorMap = definedExternally): T
         fun <T : Any> defineProperties(o: T, properties: PropertyDescriptorMap): T
         fun <T : Any, P> defineProperty(o: T, p: PropertyKey, attributes: TypedPropertyDescriptor<P>): T
-        fun <T : Any?> entries(o: ReadonlyRecord<String, T>): ReadonlyArray<JsTuple2<String, T>>
+        fun <T> entries(o: ReadonlyRecord<String, T>): ReadonlyArray<JsTuple2<String, T>>
         fun entries(o: Any): ReadonlyArray<JsTuple2<String, Any?>>
         fun <R, T : R> freeze(o: T): R
         fun <T> fromEntries(entries: JsIterable<JsTuple2<String, T>>): ReadonlyRecord<String, T>

--- a/kotlin-js/src/jsMain/kotlin/js/objects/Object.kt
+++ b/kotlin-js/src/jsMain/kotlin/js/objects/Object.kt
@@ -17,7 +17,7 @@ external class Object internal constructor() {
         fun <T : Any> create(o: T?, properties: PropertyDescriptorMap = definedExternally): T
         fun <T : Any> defineProperties(o: T, properties: PropertyDescriptorMap): T
         fun <T : Any, P> defineProperty(o: T, p: PropertyKey, attributes: TypedPropertyDescriptor<P>): T
-        fun <T : Any> entries(o: ReadonlyRecord<String, T>): ReadonlyArray<JsTuple2<String, T>>
+        fun <T : Any?> entries(o: ReadonlyRecord<String, T>): ReadonlyArray<JsTuple2<String, T>>
         fun entries(o: Any): ReadonlyArray<JsTuple2<String, Any?>>
         fun <R, T : R> freeze(o: T): R
         fun <T> fromEntries(entries: JsIterable<JsTuple2<String, T>>): ReadonlyRecord<String, T>


### PR DESCRIPTION
I'm not 100% sure because my IDE is still in K2 Alpha mode. I think narrowing down the generic type to T: Any prevents T from working with nullable values in this case, barring you from using it on a Record<String, Any?> 

Please confirm before merging, if this is the correct way to go about it.