### PR TITLE
Use explicit NPM versions

### DIFF
--- a/buildSrc/src/main/kotlin/NpmDependencies.kt
+++ b/buildSrc/src/main/kotlin/NpmDependencies.kt
@@ -4,14 +4,6 @@ import org.jetbrains.kotlin.gradle.targets.js.npm.DevNpmDependencyExtension
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependency
 import org.jetbrains.kotlin.gradle.targets.js.npm.NpmDependencyExtension
 
-private val STRICT_VERSION_REQUIRED = setOf(
-    "@mui/material",
-    "@mui/icons-material",
-    "@mui/lab",
-    "@mui/x-date-pickers",
-    "@mui/x-tree-view",
-)
-
 private val NAME_ALIASES = mapOf(
     "@mui/x-date-pickers" to "muix-date-pickers",
     "@mui/x-tree-view" to "muix-tree-view",
@@ -27,12 +19,7 @@ private fun Project.npmVersion(name: String): String {
             .removePrefix("@")
             .replace("/", "-")
 
-    val version = version(finalName)
-    if (name in STRICT_VERSION_REQUIRED) {
-        return version
-    }
-
-    return "^$version"
+    return version(finalName)
 }
 
 fun Project.npmv(name: String): NpmDependency {

--- a/buildSrc/src/main/kotlin/NpmDependencies.kt
+++ b/buildSrc/src/main/kotlin/NpmDependencies.kt
@@ -12,8 +12,22 @@ private val STRICT_VERSION_REQUIRED = setOf(
     "@mui/x-tree-view",
 )
 
+private val NAME_ALIASES = mapOf(
+    "@mui/x-date-pickers" to "muix-date-pickers",
+    "@mui/x-tree-view" to "muix-tree-view",
+
+    "@popperjs/core" to "popper",
+
+    "@types/node" to "node",
+)
+
 private fun Project.npmVersion(name: String): String {
-    val version = version(name)
+    val finalName = NAME_ALIASES[name]
+        ?: name
+            .removePrefix("@")
+            .replace("/", "-")
+
+    val version = version(finalName)
     if (name in STRICT_VERSION_REQUIRED) {
         return version
     }

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -2,32 +2,27 @@ import org.gradle.api.Project
 
 private val TARGET_ALIASES = mapOf(
     "react-core" to "react",
-    "react-dom" to "react",
-    "react-dom-legacy" to "react",
-    "react-dom-test-utils" to "react",
+    "react-dom-legacy" to "react-dom",
+    "react-dom-test-utils" to "react-dom",
     "react-legacy" to "react",
 
     "emotion" to "emotion-react",
-
-    "@mui/x-date-pickers" to "muix-date-pickers",
-    "@mui/x-tree-view" to "muix-tree-view",
-
-    "@popperjs/core" to "popper",
-
-    "@types/node" to "node",
 )
 
 fun Project.version(target: String): String {
-    val finalTarget = TARGET_ALIASES[target]
-        ?: target.removePrefix("@")
-            .replace("/", "-")
-
-    return prop("$finalTarget.version")
+    return prop("$target.version")
 }
 
 internal fun Project.publishVersion(): String {
+    val target = name.removePrefix("kotlin-")
+    val finalTarget = TARGET_ALIASES[target] ?: target
+
     val build = prop("version.build")
         .let { if (it.isNotEmpty()) "-$it" else "" }
 
-    return version(name.removePrefix("kotlin-")) + build
+    val version = version(finalTarget)
+        .removePrefix("^")
+        .removePrefix("~")
+
+    return version + build
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,43 +26,43 @@ karakum.version=1.0.0-alpha.46
 seskar.version=3.6.0
 
 # https://www.npmjs.com/package/@actions/artifact
-actions-artifact.version=2.1.8
+actions-artifact.version=^2.1.8
 
 # https://www.npmjs.com/package/@actions/cache
-actions-cache.version=3.2.4
+actions-cache.version=^3.2.4
 
 # https://www.npmjs.com/package/@actions/core
-actions-core.version=1.10.1
+actions-core.version=^1.10.1
 
 # https://www.npmjs.com/package/@actions/exec
-actions-exec.version=1.1.1
+actions-exec.version=^1.1.1
 
 # https://www.npmjs.com/package/@actions/github
-actions-github.version=6.0.0
+actions-github.version=^6.0.0
 
 # https://www.npmjs.com/package/@actions/glob
-actions-glob.version=0.4.0
+actions-glob.version=^0.4.0
 
 # https://www.npmjs.com/package/@actions/http-client
-actions-http-client.version=2.2.1
+actions-http-client.version=^2.2.1
 
 # https://www.npmjs.com/package/@actions/io
-actions-io.version=1.1.3
+actions-io.version=^1.1.3
 
 # https://www.npmjs.com/package/@actions/tool-cache
-actions-tool-cache.version=2.0.1
+actions-tool-cache.version=^2.0.1
 
 # The version of `kotlin-actions-toolkit` does not follow any external dependency
-actions-toolkit.version=1.0.0
+actions-toolkit.version=^1.0.0
 
 # https://www.npmjs.com/package/@types/web
 browser.version=1.0.0
 
 # https://www.npmjs.com/package/@cesium/engine
-cesium-engine.version=10.1.0
+cesium-engine.version=^10.1.0
 
 # https://www.npmjs.com/package/@cesium/widgets
-cesium-widgets.version=7.1.0
+cesium-widgets.version=^7.1.0
 
 # The version of kotlin-css does not follow any external dependency
 css.version=1.0.0
@@ -71,22 +71,22 @@ css.version=1.0.0
 cssom-core.version=0.0.1
 
 # https://www.npmjs.com/package/csstype
-csstype.version=3.1.3
+csstype.version=^3.1.3
 
 # https://www.npmjs.com/package/electron
-electron.version=29.2.0
+electron.version=^29.2.0
 
 # https://www.npmjs.com/package/@emotion/cache
-emotion-cache.version=11.13.1
+emotion-cache.version=^11.13.1
 
 # https://www.npmjs.com/package/@emotion/css
-emotion-css.version=11.13.0
+emotion-css.version=^11.13.0
 
 # https://www.npmjs.com/package/@emotion/react
-emotion-react.version=11.13.0
+emotion-react.version=^11.13.0
 
 # https://www.npmjs.com/package/@emotion/styled
-emotion-styled.version=11.13.0
+emotion-styled.version=^11.13.0
 
 # The version of kotlin-extensions does not follow any external dependency
 extensions.version=1.0.1
@@ -98,13 +98,13 @@ js.version=1.0.0
 mui-material.version=5.16.5
 
 # https://www.npmjs.com/package/@mui/base
-mui-base.version=5.0.0-beta.52
+mui-base.version=^5.0.0-beta.52
 
 # https://www.npmjs.com/package/@mui/icons-material
 mui-icons-material.version=5.16.5
 
 # https://www.npmjs.com/package/@mui/system
-mui-system.version=5.16.5
+mui-system.version=^5.16.5
 
 # https://www.npmjs.com/package/@mui/lab
 mui-lab.version=5.0.0-alpha.173
@@ -116,70 +116,70 @@ muix-date-pickers.version=5.0.20
 muix-tree-view.version=7.11.1
 
 # https://www.npmjs.com/package/@types/node
-node.version=20.14.10
+node.version=^20.14.10
 
 # https://www.npmjs.com/package/@popperjs/core
-popper.version=2.11.8
+popper.version=^2.11.8
 
 # https://www.npmjs.com/package/@preact/signals-core
-preact-signals-core.version=1.6.0
+preact-signals-core.version=^1.6.0
 
 # https://www.npmjs.com/package/@preact/signals-react
-preact-signals-react.version=2.0.1
+preact-signals-react.version=^2.0.1
 
 # https://www.npmjs.com/package/react
-react.version=18.3.1
+react.version=^18.3.1
 
 # https://www.npmjs.com/package/react-dom
-react-dom.version=18.3.1
+react-dom.version=^18.3.1
 
 # https://www.npmjs.com/package/react-beautiful-dnd
-react-beautiful-dnd.version=13.1.1
+react-beautiful-dnd.version=^13.1.1
 
 # https://www.npmjs.com/package/react-popper
-react-popper.version=2.3.0
+react-popper.version=^2.3.0
 
 # https://www.npmjs.com/package/react-router
-react-router.version=6.26.0
+react-router.version=^6.26.0
 
 # https://www.npmjs.com/package/react-router-dom
-react-router-dom.version=6.26.0
+react-router-dom.version=^6.26.0
 
 # https://www.npmjs.com/package/react-select
-react-select.version=5.8.0
+react-select.version=^5.8.0
 
 # https://www.npmjs.com/package/react-use
-react-use.version=17.4.0
+react-use.version=^17.4.0
 
 # https://www.npmjs.com/package/@remix-run/router
-remix-run-router.version=1.19.0
+remix-run-router.version=^1.19.0
 
 # The version of kotlin-styled-next does not follow any external dependency
 styled-next.version=1.2.4
 
 # https://www.npmjs.com/package/@tanstack/query-core
-tanstack-query-core.version=5.51.17
+tanstack-query-core.version=^5.51.17
 
 # https://www.npmjs.com/package/@tanstack/react-query
-tanstack-react-query.version=5.51.18
+tanstack-react-query.version=^5.51.18
 
 # https://www.npmjs.com/package/@tanstack/react-query-devtools
-tanstack-react-query-devtools.version=5.51.18
+tanstack-react-query-devtools.version=^5.51.18
 
 # https://www.npmjs.com/package/@tanstack/react-table
-tanstack-react-table.version=8.19.3
+tanstack-react-table.version=^8.19.3
 
 # https://www.npmjs.com/package/@tanstack/react-virtual
-tanstack-react-virtual.version=3.8.4
+tanstack-react-virtual.version=^3.8.4
 
 # https://www.npmjs.com/package/@tanstack/table-core
-tanstack-table-core.version=8.19.3
+tanstack-table-core.version=^8.19.3
 
 # https://www.npmjs.com/package/@tanstack/virtual-core
-tanstack-virtual-core.version=3.8.4
+tanstack-virtual-core.version=^3.8.4
 
 # https://www.npmjs.com/package/typescript
-typescript.version=5.4.5
+typescript.version=^5.4.5
 
 # https://www.npmjs.com/package/@types/web
 web.version=1.0.0
@@ -188,7 +188,7 @@ web.version=1.0.0
 wrappers-bom.version=1.0.0
 
 # https://www.npmjs.com/package/inline-style-prefixer
-inline-style-prefixer.version=7.0.1
+inline-style-prefixer.version=^7.0.1
 
 # https://www.npmjs.com/package/puppeteer
-puppeteer.version=22.15.0
+puppeteer.version=^22.15.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,7 @@ actions-io.version=^1.1.3
 actions-tool-cache.version=^2.0.1
 
 # The version of `kotlin-actions-toolkit` does not follow any external dependency
-actions-toolkit.version=^1.0.0
+actions-toolkit.version=1.0.0
 
 # https://www.npmjs.com/package/@types/web
 browser.version=1.0.0
@@ -149,7 +149,7 @@ react-router-dom.version=^6.26.0
 react-select.version=^5.8.0
 
 # https://www.npmjs.com/package/react-use
-react-use.version=^17.4.0
+react-use.version=17.4.0
 
 # https://www.npmjs.com/package/@remix-run/router
 remix-run-router.version=^1.19.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -130,6 +130,9 @@ preact-signals-react.version=2.0.1
 # https://www.npmjs.com/package/react
 react.version=18.3.1
 
+# https://www.npmjs.com/package/react-dom
+react-dom.version=18.3.1
+
 # https://www.npmjs.com/package/react-beautiful-dnd
 react-beautiful-dnd.version=13.1.1
 


### PR DESCRIPTION
In this PR:

* I tried to split two helper functions:
  * `npmVersion`: npm library name -> dependency version
  * `publishVersion`: kotlin wrapper subproject name -> version of published wrapper
* I used the results of refactoring to declare NPM version ranges explicitly in `gradle.properties`

Next possible steps: 

* use `versionCatalogs` to manage NPM dependencies