### PR TITLE
Tidy Publishing Configuration

### DIFF
--- a/buildSrc/src/main/kotlin/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/Kotlin.kt
@@ -1,4 +1,0 @@
-import org.gradle.api.Project
-
-internal val Project.isKotlinMultiplatformProject: Boolean
-    get() = plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")

--- a/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
@@ -51,8 +51,14 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
 }
 
 pluginManager.withPlugin("java-platform") {
-    publishing.publications.create<MavenPublication>("bom") {
+    publishing.publications.register<MavenPublication>("maven") {
         from(components["javaPlatform"])
+    }
+}
+
+pluginManager.withPlugin("version-catalog") {
+    publishing.publications.register<MavenPublication>("maven") {
+        from(components["versionCatalog"])
     }
 }
 

--- a/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
@@ -3,72 +3,56 @@ plugins {
     signing
 }
 
-val publicationType = when {
-    isKotlinMultiplatformProject -> PublicationType.LIBRARY
-    project.name == "kotlin-wrappers-bom" -> PublicationType.BOM
-    project.name == "kotlin-wrappers-catalog" -> PublicationType.VERSION_CATALOG
-
-    else -> throw IllegalStateException("Unable to calculate publication type for project ${project.path}")
-}
-
 val publishVersion = publishVersion()
 project.version = publishVersion
 
-val javadocJar = if (publicationType == PublicationType.LIBRARY) {
-    tasks.register("emptyJavadocJar", Jar::class) {
-        archiveClassifier.set("javadoc")
+val emptyJavadocJar by tasks.registering(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Empty javadoc artifact (required by Maven Central)"
+    archiveClassifier = "javadoc"
+    from(
+        resources.text.fromString(
+            """
+            |This Javadoc JAR is intentionally empty.
+            |
+            |For documentation, see https://github.com/JetBrains/kotlin-wrappers/ or the sources JAR.
+            |
+            """.trimMargin()
+        )
+    ) {
+        rename { "readme.txt" }
     }
-} else null
+}
 
-configure<PublishingExtension> {
+publishing {
     publications {
-        when (publicationType) {
-            PublicationType.LIBRARY ->
-                withType<MavenPublication>().configureEach {
-                    val artifactName = when (name) {
-                        "kotlinMultiplatform" -> ""
-                        else -> "-$name"
-                    }
-
-                    groupId = project.group.toString()
-                    artifactId = "${project.name}$artifactName"
-                    version = publishVersion
-
-                    if (name == "jvm") {
-                        artifact(javadocJar!!.get())
-                    }
-
-                    configurePom(project)
-                }
-
-            else ->
-                create<MavenPublication>("maven") {
-                    when (publicationType) {
-                        PublicationType.LIBRARY,
-                        -> throw UnsupportedOperationException()
-
-                        PublicationType.BOM,
-                        -> from(components["javaPlatform"])
-
-                        PublicationType.VERSION_CATALOG,
-                        -> from(components["versionCatalog"])
-                    }
-
-                    groupId = project.group.toString()
-                    artifactId = project.name
-                    version = publishVersion
-
-                    configurePom(project)
-                }
+        withType<MavenPublication>().configureEach {
+            configurePom(project)
         }
     }
 
     repositories {
-        maven {
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers") {
             name = "kotlinSpace"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers")
             credentials(org.gradle.api.artifacts.repositories.PasswordCredentials::class)
         }
+        // Create a local repo for testing publishing.
+        // Run `./gradlew publishToLocalBuildRepo` and check `$rootDir/build/local-repo`
+        maven(rootDir.resolve("build/local-repo")) {
+            name = "LocalBuildRepo"
+        }
+    }
+}
+
+pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+    publishing.publications.withType<MavenPublication>().configureEach {
+        artifact(emptyJavadocJar)
+    }
+}
+
+pluginManager.withPlugin("java-platform") {
+    publishing.publications.create<MavenPublication>("bom") {
+        from(components["javaPlatform"])
     }
 }
 


### PR DESCRIPTION
- Add `readme.txt` to Javadoc JAR to explain why it's empty.
- Avoid conditional build config - always register the Javadoc JAR task, and avoid 'peeking' into KMP internals to conditionally add it. Always adding it is more robust.
- Use pluginsManager to lazily 'react' to plugins.
- Allow Gradle to set the project's group/artifactId/version in the POM. Manually setting these values is discouraged.
- Add a local-repo - very helpful for debugging.