### PR TITLE
Create Gradle BuildService for easier aggregation of kotlin-wrappers subprojects

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-wrappers-subprojects-service.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-wrappers-subprojects-service.gradle.kts
@@ -1,0 +1,26 @@
+/**
+ * Create a service for collecting the coordinates of all kotlin-wrappers
+ * artifacts that should be included in `kotlin-wrappers-bom`.
+ */
+abstract class SubprojectsManagerService : BuildService<BuildServiceParameters.None> {
+    /** [Project.path]s of subprojects to include in `kotlin-wrappers-bom`. */
+    abstract val bomDependencies: SetProperty<String>
+
+    /** [Project.path]s of subprojects to include in the aggregated Dokka docs. */
+    abstract val dokkaDependencies: SetProperty<String>
+}
+
+val kotlinWrapperSubprojects: SubprojectsManagerService =
+    gradle.sharedServices.registerIfAbsent("SubprojectsManagerService", SubprojectsManagerService::class).get()
+
+extensions.add("kotlinWrapperSubprojects", kotlinWrapperSubprojects)
+
+/** Controls whether the current subproject will be included in `kotlin-wrappers-bom`. */
+val includeInKotlinWrappersBom: Property<Boolean> =
+    objects.property<Boolean>().convention(project.path != ":kotlin-wrappers-bom")
+extensions.add<Property<Boolean>>("includeInKotlinWrappersBom", includeInKotlinWrappersBom)
+
+kotlinWrapperSubprojects.bomDependencies
+    .addAll(provider { project.path }.zip(includeInKotlinWrappersBom) { path, enabled ->
+        if (enabled) listOf(path) else emptyList()
+    })

--- a/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-conventions.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `maven-publish`
     signing
+    id("kotlin-wrappers-subprojects-service")
 }
 
 val publicationType = when {

--- a/kotlin-wrappers-bom/build.gradle.kts
+++ b/kotlin-wrappers-bom/build.gradle.kts
@@ -3,10 +3,14 @@ plugins {
     `publish-conventions`
 }
 
-dependencies {
-    constraints {
-        for (library in getLibraryProjects(rootProject)) {
-            api(project(library.path))
+configurations.api.configure {
+    // lazily add enabled subprojects to the BOM
+    dependencyConstraints.addAllLater(
+        kotlinWrapperSubprojects.bomDependencies.map { subproject ->
+            logger.info("[$path] adding ${subproject.size} subprojects to BOM: $subproject")
+            subproject.sorted().map { coord ->
+                project.dependencies.constraints.create(project(coord))
+            }
         }
-    }
+    )
 }


### PR DESCRIPTION
The recent change to automatically aggregate subprojects is nice, but in upcoming Gradle versions they are looking at disabling cross-project configuration, as it harms build configuration performance (https://docs.gradle.org/current/userguide/isolated_projects.html).

Using a BuildService will help with Gradle build performance, and is more future-proof.