### PR TITLE
Add GitHub Action to publish Dokka docs to GitHub Pages

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -1,0 +1,69 @@
+name: Publish GitHub Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout-ref:
+        description: "The branch, tag or SHA to checkout. See actions/checkout 'ref'."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      checkout-ref:
+        description: "The branch, tag or SHA to checkout. See actions/checkout 'ref'."
+        required: false
+        type: string
+  release:
+    types: [ published ]
+
+concurrency:
+  group: "Publish Site: ${{ github.workflow }}"
+  cancel-in-progress: false
+
+jobs:
+
+  build-site:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Build site
+        run: |
+          ./gradlew :docs:dokkatooGeneratePublicationHtml
+
+      - name: Upload Dokkatoo to Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build/docs/dokka/html/
+
+  deploy:
+    needs:
+      - build-site
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Automatically publish the Dokka API docs to GitHub Pages.

GitHub pages might require some configuration in https://github.com/JetBrains/kotlin-wrappers/settings/pages

Hopefully this is the last step!

Fix https://github.com/JetBrains/kotlin-wrappers/issues/2228