### PR TITLE
Re-enable `-Xir-generate-inline-anonymous-functions`

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -55,9 +55,6 @@ tasks.withType<Kotlin2JsCompile>().configureEach {
 
         freeCompilerArgs.addAll(
             "-Xdont-warn-on-error-suppression",
-        )
-
-        freeCompilerArgs.addAll(
             "-Xir-generate-inline-anonymous-functions",
         )
     }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -57,12 +57,8 @@ tasks.withType<Kotlin2JsCompile>().configureEach {
             "-Xdont-warn-on-error-suppression",
         )
 
-        // TODO: Enable after resolving
-        //  https://youtrack.jetbrains.com/issue/KT-67355
-        /*
         freeCompilerArgs.addAll(
             "-Xir-generate-inline-anonymous-functions",
         )
-        */
     }
 }


### PR DESCRIPTION
According to the YouTrack issue the reason was fixed in 2.0.20 and 2.0.20 is used already.
Thus this PR re-enables the option.
