### PR TITLE
Promise. Non-sealed `PromiseLike` (fix #2518)

### DIFF
--- a/kotlin-js/src/jsMain/kotlin/js/promise/PromiseLike.kt
+++ b/kotlin-js/src/jsMain/kotlin/js/promise/PromiseLike.kt
@@ -13,7 +13,7 @@ import js.promise.internal.awaitPromiseLike
 import js.promise.internal.thenToContinuation
 import kotlin.coroutines.Continuation
 
-sealed external interface PromiseLike<out T> :
+external interface PromiseLike<out T> :
     PromiseResult<T> {
     fun <R> then(
         onFulfilled: (T) -> R,


### PR DESCRIPTION
https://github.com/JetBrains/kotlin-wrappers/issues/2518