### PR TITLE
Declare .editorconfig as root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 charset = utf-8
 end_of_line = lf


### PR DESCRIPTION
Without the `root = true` implementations search further up until the filesystem root is reached.
Usually you want to stop in the root of your project.
