### PR TITLE
MUI `5.16.12`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -94,19 +94,19 @@ js.version=1.0.0
 js-core.version=1.0.0
 
 # https://www.npmjs.com/package/@mui/material
-mui-material.npm.version=5.16.7
+mui-material.npm.version=5.16.12
 
 # https://www.npmjs.com/package/@mui/base
-mui-base.npm.version=^5.0.0-beta.52
+mui-base.npm.version=^5.0.0-beta.40-0
 
 # https://www.npmjs.com/package/@mui/icons-material
-mui-icons-material.npm.version=5.16.7
+mui-icons-material.npm.version=5.16.12
 
 # https://www.npmjs.com/package/@mui/system
-mui-system.npm.version=^5.16.7
+mui-system.npm.version=^5.16.12
 
 # https://www.npmjs.com/package/@mui/lab
-mui-lab.npm.version=5.0.0-alpha.173
+mui-lab.npm.version=5.0.0-alpha.175
 
 # https://www.npmjs.com/package/@mui/x-date-pickers
 muix-date-pickers.npm.version=5.0.20

--- a/kotlin-mui-base/src/jsMain/generated/mui/base/useList.types.kt
+++ b/kotlin-mui-base/src/jsMain/generated/mui/base/useList.types.kt
@@ -52,7 +52,7 @@ external interface UseListParameters<ItemValue, State, CustomAction, CustomActio
      *
      * @param item List item to get the DOM element for.
      */
-    var getItemDomElement: ((itemValue: ItemValue) -> HTMLElement?)?
+    var getItemDomElement: ((itemValue: ItemValue) -> HTMLElement)?
 
     /**
      * A function that returns the id of an item.

--- a/kotlin-mui-base/src/jsMain/generated/mui/base/useTab.types.kt
+++ b/kotlin-mui-base/src/jsMain/generated/mui/base/useTab.types.kt
@@ -13,7 +13,7 @@ external interface UseTabParameters {
     var value: dynamic
 
     /**
-     * Callback invoked when new value is being set.
+     * If `true`, the tab will be disabled.
      */
     var onChange: ((event: react.dom.events.SyntheticEvent<*, *>, value: Any /* Number | String */) -> Unit)?
 

--- a/kotlin-mui-material/src/jsMain/generated/mui/material/Tab.kt
+++ b/kotlin-mui-material/src/jsMain/generated/mui/material/Tab.kt
@@ -45,7 +45,7 @@ external interface TabOwnProps :
     /**
      * The icon to display.
      */
-    var icon: react.ReactNode?
+    var icon: react.ReactElement<*>?
 
     /**
      * The position of the icon relative to the label.

--- a/kotlin-mui-system/src/jsMain/generated/mui/system/createSpacing.ext.kt
+++ b/kotlin-mui-system/src/jsMain/generated/mui/system/createSpacing.ext.kt
@@ -36,7 +36,6 @@ inline fun SpacingOptions(
 typealias SpacingArgument = Int /* web.cssom.Auto */
 
 sealed external interface Spacing {
-
     @JsNative
     operator fun invoke(): web.cssom.Length
 
@@ -47,11 +46,7 @@ sealed external interface Spacing {
     operator fun invoke(topBottom: SpacingArgument, rightLeft: SpacingArgument): web.cssom.Length
 
     @JsNative
-    operator fun invoke(
-        top: SpacingArgument,
-        rightLeft: SpacingArgument,
-        bottom: SpacingArgument,
-    ): web.cssom.Length
+    operator fun invoke(top: SpacingArgument, rightLeft: SpacingArgument, bottom: SpacingArgument): web.cssom.Length
 
     @JsNative
     operator fun invoke(


### PR DESCRIPTION
Material UI v5 is now compatible with React 19
https://github.com/mui/material-ui/releases/tag/v5.16.12

Build on CI is currently failed because it needed to update the `package-lock.json` by dependabot.