### PR TITLE
Wrappers Build. Avoid using `project.extensions` in task configuration

### DIFF
--- a/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
-private val TEST_SOURCE_SETS = listOf(
+val TEST_SOURCE_SETS = listOf(
     "jsTest",
     "commonTest",
 )
 
-private val JS_TEST_TASK_NAME = "jsTestPackageJson"
+val JS_TEST_TASK_NAME = "jsTestPackageJson"
 
 afterEvaluate {
     val kotlin = project.extensions.getByName<KotlinProjectExtension>("kotlin")

--- a/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
@@ -1,19 +1,23 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
-val TEST_SOURCE_SETS = listOf(
+private val TEST_SOURCE_SETS = listOf(
     "jsTest",
     "commonTest",
 )
 
-afterEvaluate {
-    tasks.named("jsTestPackageJson") {
-        onlyIf {
-            val kotlin = project.extensions.getByName<KotlinProjectExtension>("kotlin")
+private val JS_TEST_TASK_NAME = "jsTestPackageJson"
 
-            TEST_SOURCE_SETS.asSequence()
-                .map { kotlin.sourceSets.getByName(it) }
-                .flatMap { it.kotlin.sourceDirectories }
-                .any { it.exists() }
+afterEvaluate {
+    val kotlin = project.extensions.getByName<KotlinProjectExtension>("kotlin")
+
+    val hasSupportedTestSourceSet = TEST_SOURCE_SETS
+        .mapNotNull { name -> kotlin.sourceSets.findByName(name) }
+        .flatMap { it.kotlin.sourceDirectories }
+        .any { it.exists() }
+
+    tasks.named(JS_TEST_TASK_NAME) {
+        onlyIf {
+            hasSupportedTestSourceSet
         }
     }
 }

--- a/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
@@ -14,8 +14,6 @@ afterEvaluate {
         .any { it.exists() }
 
     tasks.named("jsTestPackageJson") {
-        onlyIf {
-            hasSupportedTestSourceSet
-        }
+        enabled = hasSupportedTestSourceSet
     }
 }

--- a/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
@@ -5,8 +5,6 @@ val TEST_SOURCE_SETS = listOf(
     "commonTest",
 )
 
-val JS_TEST_TASK_NAME = "jsTestPackageJson"
-
 afterEvaluate {
     val kotlin = project.extensions.getByName<KotlinProjectExtension>("kotlin")
 
@@ -15,7 +13,7 @@ afterEvaluate {
         .flatMap { it.kotlin.sourceDirectories }
         .any { it.exists() }
 
-    tasks.named(JS_TEST_TASK_NAME) {
+    tasks.named("jsTestPackageJson") {
         onlyIf {
             hasSupportedTestSourceSet
         }

--- a/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/wrappersbuild.kotlin-test-conventions.gradle.kts
@@ -8,12 +8,12 @@ val TEST_SOURCE_SETS = listOf(
 afterEvaluate {
     val kotlin = project.extensions.getByName<KotlinProjectExtension>("kotlin")
 
-    val hasSupportedTestSourceSet = TEST_SOURCE_SETS
+    val hasTestSources = TEST_SOURCE_SETS
         .mapNotNull { name -> kotlin.sourceSets.findByName(name) }
         .flatMap { it.kotlin.sourceDirectories }
         .any { it.exists() }
 
     tasks.named("jsTestPackageJson") {
-        enabled = hasSupportedTestSourceSet
+        enabled = hasTestSources
     }
 }


### PR DESCRIPTION
Required for Gradle configuration caches to be enabled