### PR TITLE
Build. Enable parallel configuration caching

### DIFF
--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.jvmargs=-Xms2g -Xmx4g
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.parallel=true
 
 kotlin.js.yarn=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@ wrappers.version=2025.5.7
 
 org.gradle.jvmargs=-Xms2g -Xmx4g
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.parallel=true
 
 kotlin.js.yarn=false


### PR DESCRIPTION
Speeds up the build process by skipping the same tasks configuration phase

Relies on #2784