### PR TITLE
JS. WASM-compatible union declarations for the Temporal API Units (#2449)

### DIFF
--- a/kotlin-js/src/commonMain/kotlin/js/temporal/DateUnit.kt
+++ b/kotlin-js/src/commonMain/kotlin/js/temporal/DateUnit.kt
@@ -4,26 +4,26 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DateUnit<out T : DateUnit<T>> :
     DateTimeUnit<T> {
-    companion object {
-        @JsValue("year")
-        val year: year
-
-        @JsValue("month")
-        val month: month
-
-        @JsValue("week")
-        val week: week
-
-        @JsValue("day")
-        val day: day
-    }
-
     sealed interface year : DateUnit<year>
     sealed interface month : DateUnit<month>
     sealed interface week : DateUnit<week>
     sealed interface day : DateUnit<day>
+
+    companion object
 }
+
+inline val DateUnit.Companion.year: DateUnit.year
+    get() = unsafeCast("year")
+
+inline val DateUnit.Companion.month: DateUnit.month
+    get() = unsafeCast("month")
+
+inline val DateUnit.Companion.week: DateUnit.week
+    get() = unsafeCast("week")
+
+inline val DateUnit.Companion.day: DateUnit.day
+    get() = unsafeCast("day")

--- a/kotlin-js/src/commonMain/kotlin/js/temporal/PluralUnit.kt
+++ b/kotlin-js/src/commonMain/kotlin/js/temporal/PluralUnit.kt
@@ -4,7 +4,7 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 /**
  * When the name of a unit is provided to a Temporal API as a string, it is
@@ -15,36 +15,35 @@ sealed external interface PluralUnit<T : DateTimeUnit<T>> :
     LargestUnit<T>,
     SmallestUnit<T>,
     TotalUnit<T> {
-    companion object {
-
-        @JsValue("years")
-        val years: PluralUnit<DateUnit.year>
-
-        @JsValue("months")
-        val months: PluralUnit<DateUnit.month>
-
-        @JsValue("weeks")
-        val weeks: PluralUnit<DateUnit.week>
-
-        @JsValue("days")
-        val days: PluralUnit<DateUnit.day>
-
-        @JsValue("hours")
-        val hours: PluralUnit<TimeUnit.hour>
-
-        @JsValue("minutes")
-        val minutes: PluralUnit<TimeUnit.minute>
-
-        @JsValue("seconds")
-        val seconds: PluralUnit<TimeUnit.second>
-
-        @JsValue("milliseconds")
-        val milliseconds: PluralUnit<TimeUnit.millisecond>
-
-        @JsValue("microseconds")
-        val microseconds: PluralUnit<TimeUnit.microsecond>
-
-        @JsValue("nanoseconds")
-        val nanoseconds: PluralUnit<TimeUnit.nanosecond>
-    }
+    companion object
 }
+
+inline val PluralUnit.Companion.years: PluralUnit<DateUnit.year>
+    get() = unsafeCast("years")
+
+inline val PluralUnit.Companion.months: PluralUnit<DateUnit.month>
+    get() = unsafeCast("months")
+
+inline val PluralUnit.Companion.weeks: PluralUnit<DateUnit.week>
+    get() = unsafeCast("weeks")
+
+inline val PluralUnit.Companion.days: PluralUnit<DateUnit.day>
+    get() = unsafeCast("days")
+
+inline val PluralUnit.Companion.hours: PluralUnit<TimeUnit.hour>
+    get() = unsafeCast("hours")
+
+inline val PluralUnit.Companion.minutes: PluralUnit<TimeUnit.minute>
+    get() = unsafeCast("minutes")
+
+inline val PluralUnit.Companion.seconds: PluralUnit<TimeUnit.second>
+    get() = unsafeCast("seconds")
+
+inline val PluralUnit.Companion.milliseconds: PluralUnit<TimeUnit.millisecond>
+    get() = unsafeCast("milliseconds")
+
+inline val PluralUnit.Companion.microseconds: PluralUnit<TimeUnit.microsecond>
+    get() = unsafeCast("microseconds")
+
+inline val PluralUnit.Companion.nanoseconds: PluralUnit<TimeUnit.nanosecond>
+    get() = unsafeCast("nanoseconds")

--- a/kotlin-js/src/commonMain/kotlin/js/temporal/TimeUnit.kt
+++ b/kotlin-js/src/commonMain/kotlin/js/temporal/TimeUnit.kt
@@ -4,34 +4,34 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TimeUnit<out T : TimeUnit<T>> :
     DateTimeUnit<T> {
-    companion object {
-        @JsValue("hour")
-        val hour: hour
-
-        @JsValue("minute")
-        val minute: minute
-
-        @JsValue("second")
-        val second: second
-
-        @JsValue("millisecond")
-        val millisecond: millisecond
-
-        @JsValue("microsecond")
-        val microsecond: microsecond
-
-        @JsValue("nanosecond")
-        val nanosecond: nanosecond
-    }
-
     sealed interface hour : TimeUnit<hour>
     sealed interface minute : TimeUnit<minute>
     sealed interface second : TimeUnit<second>
     sealed interface millisecond : TimeUnit<millisecond>
     sealed interface microsecond : TimeUnit<microsecond>
     sealed interface nanosecond : TimeUnit<nanosecond>
+
+    companion object
 }
+
+inline val TimeUnit.Companion.hour: TimeUnit.hour
+    get() = unsafeCast("hour")
+
+inline val TimeUnit.Companion.minute: TimeUnit.minute
+    get() = unsafeCast("minute")
+
+inline val TimeUnit.Companion.second: TimeUnit.second
+    get() = unsafeCast("second")
+
+inline val TimeUnit.Companion.millisecond: TimeUnit.millisecond
+    get() = unsafeCast("millisecond")
+
+inline val TimeUnit.Companion.microsecond: TimeUnit.microsecond
+    get() = unsafeCast("microsecond")
+
+inline val TimeUnit.Companion.nanosecond: TimeUnit.nanosecond
+    get() = unsafeCast("nanosecond")


### PR DESCRIPTION
Manually inline tricky sealed interfaces in the `js.temporal` like `DateUnit`, `TimeUnit`, `PluralUnit`.

See [this issue](https://github.com/JetBrains/kotlin-wrappers/issues/2449).