### PR TITLE
Browser. Wasm-compatible union generation (#2449)

### DIFF
--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/DOMException.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/DOMException.kt
@@ -24,8 +24,8 @@ internal fun domExceptionErrorNames(): String =
             /**
               * $description
               */
-            @JsValue("$name")
-            val $name: JsErrorName
+            inline val DOMException.Companion.${name}: JsErrorName
+                get() = unsafeCast("$name")
             """.trimIndent()
         }
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Decorators.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Decorators.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.objectUnionBody
+import karakum.common.CommonUnionConverter.objectUnionBody
 import karakum.common.unionConstant
 import karakum.common.unionName
 import karakum.common.withDefaultLineBreaks

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Form.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Form.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.unionBody
+import karakum.common.CommonUnionConverter.unionBody
 
 internal const val VALIDATION_TARGET = "ValidationTarget"
 internal const val FORM_CONTROL = "FormControl"

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
@@ -1382,21 +1382,11 @@ internal fun convertInterface(
     val companion = if (staticSource != null) {
         val companionContent = getCompanion(name, staticSource)
         when {
-            name == DOM_EXCEPTION -> {
-                companionContent
-                    .splitToSequence("\n")
-                    .filter { !it.endsWith(": Short") }
-                    .joinToString("\n")
-                    .replaceFirst("\n}", domExceptionErrorNames() + "\n}")
-            }
+            name == DOM_EXCEPTION -> "companion object" // leave it empty, add extensions below
 
             idDeclaration != null -> {
                 require(companionContent.isEmpty())
-                """
-                companion object {
-                    $idDeclaration
-                }
-                """.trimIndent()
+                "companion object"
             }
 
             else -> companionContent
@@ -1420,6 +1410,12 @@ internal fun convertInterface(
         ?.joinToString("\n") { "sealed interface $it" }
         ?: ""
 
+    val extensions = when {
+        name == DOM_EXCEPTION -> domExceptionErrorNames()
+        idDeclaration != null -> idDeclaration
+        else -> ""
+    }
+
     var body = sequenceOf(
         typeGuard,
         annotations,
@@ -1428,6 +1424,7 @@ internal fun convertInterface(
         companion,
         additionalAliases,
         "}",
+        extensions
     ).filter { it.isNotEmpty() }
         .joinToString("\n")
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/HtmlUnions.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/HtmlUnions.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.sealedUnionBody
+import karakum.common.CommonUnionConverter.sealedUnionBody
 
 internal const val AUTO_CAPITALIZE = "AutoCapitalize"
 internal const val BLOCKING = "Blocking"

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Intl.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Intl.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.sealedUnionBody
+import karakum.common.CommonUnionConverter.sealedUnionBody
 import karakum.common.withDefaultLineBreaks
 import java.io.File
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/JsUnions.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/JsUnions.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.unionBody
+import karakum.common.CommonUnionConverter.unionBody
 
 // Remaining interfaces annotated with @JsValue
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Keyboard.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Keyboard.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.unionBody
+import karakum.common.CommonUnionConverter.unionBody
 
 internal const val KEY_CODE = "KeyCode"
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Popover.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Popover.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.unionBody
+import karakum.common.CommonUnionConverter.unionBody
 
 internal const val POPOVER = "Popover"
 internal const val POPOVER_TARGET_ACTION = "PopoverTargetAction"

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/RenderingContextRegistry.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/RenderingContextRegistry.kt
@@ -40,8 +40,8 @@ internal object RenderingContextRegistry {
             ?: return null
 
         return """
-        @JsValue("${data.id}")
-        val ID: $RENDERING_CONTEXT_ID<${data.type}, ${data.options}>
+        inline val $name.Companion.ID: $RENDERING_CONTEXT_ID<${data.type}, ${data.options}>
+            get() = unsafeCast("${data.id}")
         """.trimIndent()
     }
 }

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Types.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Types.kt
@@ -1,7 +1,7 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.objectUnionBody
-import karakum.common.JsUnionConverter.sealedUnionBody
+import karakum.common.CommonUnionConverter.objectUnionBody
+import karakum.common.CommonUnionConverter.sealedUnionBody
 import karakum.common.unionConstant
 
 private val PKG_MAP = mapOf(

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/WebAssembly.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/WebAssembly.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.unionBodyByConstants
+import karakum.common.CommonUnionConverter.unionBodyByConstants
 import karakum.common.UnionConstant
 import karakum.common.withDefaultLineBreaks
 

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/WebGL.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/WebGL.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.objectUnionBody
+import karakum.common.CommonUnionConverter.objectUnionBody
 import karakum.common.unionConstant
 
 private val CONVERTED_WEBGL_TYPES = listOf(
@@ -33,13 +33,13 @@ private val CLASSES = setOf(
 internal fun webglDeclarations(
     content: String,
 ): Sequence<ConversionResult> {
-    val interfaces = Regex("""interface ((ANGLE_|EXT_|KHR_|OES_|OVR_|WEBGL_|WebGL).+?) \{[\s\S]+?\}""")
+    val interfaces = Regex("""interface ((ANGLE_|EXT_|KHR_|OES_|OVR_|WEBGL_|WebGL).+?) \{[\s\S]+?}""")
         .findAll(content)
         .map { it.value }
         .mapNotNull { convertInterface(it) }
         .toList()
 
-    val classes = Regex("""declare var WebGL.+?: \{[\s\S]+?\}""")
+    val classes = Regex("""declare var WebGL.+?: \{[\s\S]+?}""")
         .findAll(content)
         .map { it.value }
         .mapNotNull { convertCompanion(it) }
@@ -97,7 +97,9 @@ private fun convertInterface(
         } else "$declaration\nprivate constructor()"
     }
 
-    val body = "$modifier external $declaration {\n$members\n}"
+    val idDeclaration = RenderingContextRegistry.getIdDeclaration(name) ?: ""
+
+    val body = "$modifier external $declaration {\n$members\n}\n$idDeclaration"
 
     return ConversionResult(
         name = name,
@@ -144,18 +146,16 @@ private fun convertCompanion(
         .joinToString("\n")
 
     val body = if (memberSource.isNotEmpty()) {
-        var companionMembers = memberSource.replace("readonly ", "val ")
+        val companionMembers = memberSource.replace("readonly ", "val ")
             .replace(Regex("""_BIT: 0x\S+"""), "_BIT: GLbitfield")
             .replace(Regex(""": 0x\S+"""), ": GLenum")
-            .replace(Regex(""": \-?\d"""), ": GLenum")
+            .replace(Regex(""": -?\d"""), ": GLenum")
 
-        val idDeclaration = RenderingContextRegistry.getIdDeclaration(name)
-        if (idDeclaration != null)
-            companionMembers += "\n\n$idDeclaration"
-
-        "companion object {\n" +
-                companionMembers +
-                "\n}"
+        """
+        companion object {
+            $companionMembers
+        }
+        """.trimIndent()
     } else ""
 
     return ConversionResult(

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Window.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Window.kt
@@ -1,6 +1,6 @@
 package karakum.browser
 
-import karakum.common.JsUnionConverter.sealedUnionBody
+import karakum.common.CommonUnionConverter.sealedUnionBody
 
 private val WINDOW_TARGET_VALUES = listOf(
     "_self",

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/common/UnionConverter.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/common/UnionConverter.kt
@@ -117,6 +117,110 @@ internal object JsUnionConverter : UnionConverter {
     }
 }
 
+// Helpers converting TS unions to sealed external interfaces with companion extensions
+// Generated interfaces support in the WASM target.
+internal object CommonUnionConverter : UnionConverter {
+
+    override fun unionBodyByConstants(
+        name: String,
+        constants: List<UnionConstant>,
+    ): String {
+        val interfaceName = name.substringBefore('<')
+        val hasGenerics = interfaceName != name
+
+        val extensions = constants
+            .joinToString("\n\n") {
+                require(!hasGenerics || it.type != null) {
+                    "You should specify types for all generic unions. Wrong constant: $it."
+                }
+
+                """
+                inline val $interfaceName.Companion.${it.name}: ${it.type ?: name}
+                    get() = unsafeCast("${it.value}")
+                """.trimIndent()
+            }
+
+        return """
+               sealed external interface $name {
+                  companion object
+               }
+
+               $extensions
+               """.trimIndent()
+    }
+
+    override fun sealedUnionBody(
+        name: String,
+        values: List<String>,
+    ): String {
+        val constants = values.map(::unionConstant)
+
+        val extensions = constants.joinToString("\n\n") {
+            """
+            inline val $name.Companion.${it.name}: $name
+                get() = unsafeCast("${it.value}")
+            """.trimIndent()
+        }
+
+        return """
+                sealed external interface $name {
+            companion object
+        }
+
+        $extensions
+    """.trimIndent()
+    }
+
+    override fun sealedUnionBody(
+        name: String,
+        parentType: String,
+        values: List<String>,
+    ): String {
+        val constants = values.map(::unionConstant)
+
+        val extensions = constants.joinToString("\n") {
+            """
+            inline val $name.Companion.${it.name}: $parentType.${it.name.replaceFirstChar(Char::uppercase)}
+                get() = unsafeCast("${it.value}")
+            """.trimIndent()
+        }
+
+        return """
+        sealed external interface $name : $parentType {
+            companion object
+        }
+
+        $extensions
+        """.trimIndent()
+    }
+
+    override fun objectUnionBody(
+        name: String,
+        constants: List<UnionConstant>,
+    ): String {
+        val extensions = constants.joinToString("\n\n") {
+            """
+            inline val $name.Companion.${it.name}: $name.${it.name}
+                get() = unsafeCast("${it.value}")
+            """.trimIndent()
+        }
+
+        val constantTypes = constants.joinToString("\n") {
+            "sealed interface ${it.name} : $name"
+        }
+
+        return """
+           sealed external interface $name {
+              $constantTypes
+
+              companion object
+           }
+
+           $extensions
+    """.trimIndent()
+    }
+}
+
 internal data class UnionConstant(
     val name: String,
     val value: String,

--- a/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useCreateUser.kt
+++ b/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useCreateUser.kt
@@ -4,6 +4,7 @@ import example.entities.CreateUserOptions
 import example.entities.User
 import js.json.stringify
 import web.http.BodyInit
+import web.http.POST
 import web.http.RequestInit
 import web.http.RequestMethod
 

--- a/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useDeleteUser.kt
+++ b/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useDeleteUser.kt
@@ -1,6 +1,7 @@
 package example.hooks
 
 import example.entities.User
+import web.http.DELETE
 import web.http.RequestInit
 import web.http.RequestMethod
 

--- a/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useUpdateUser.kt
+++ b/examples/tanstack-react-table/src/jsMain/kotlin/example/hooks/useUpdateUser.kt
@@ -3,6 +3,7 @@ package example.hooks
 import example.entities.User
 import js.json.stringify
 import web.http.BodyInit
+import web.http.PUT
 import web.http.RequestInit
 import web.http.RequestMethod
 

--- a/examples/tanstack-table-common/src/jsMain/kotlin/example/table/selection/SelectionCheckbox.kt
+++ b/examples/tanstack-table-common/src/jsMain/kotlin/example/table/selection/SelectionCheckbox.kt
@@ -7,7 +7,8 @@ import react.PropsWithValue
 import react.dom.events.ChangeEvent
 import react.dom.html.ReactHTML.input
 import web.html.HTMLInputElement
-import web.html.InputType.Companion.checkbox
+import web.html.InputType
+import web.html.checkbox
 
 internal external interface SelectionCheckboxProps : PropsWithValue<ReadonlySignal<Boolean>> {
     var onChange: (event: ChangeEvent<HTMLInputElement>) -> Unit
@@ -19,7 +20,7 @@ internal val SelectionCheckbox: FC<SelectionCheckboxProps> = FC { props ->
     val isChecked = props.value
 
     input {
-        type = checkbox
+        type = InputType.checkbox
         checked = isChecked.value
         onChange = props.onChange
     }

--- a/kotlin-browser/src/commonMain/generated/web/animations/AnimationPlayState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/AnimationPlayState.kt
@@ -6,20 +6,20 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AnimationPlayState {
-    companion object {
-        @JsValue("finished")
-        val finished: AnimationPlayState
-
-        @JsValue("idle")
-        val idle: AnimationPlayState
-
-        @JsValue("paused")
-        val paused: AnimationPlayState
-
-        @JsValue("running")
-        val running: AnimationPlayState
-    }
+    companion object
 }
+
+inline val AnimationPlayState.Companion.finished: AnimationPlayState
+    get() = unsafeCast("finished")
+
+inline val AnimationPlayState.Companion.idle: AnimationPlayState
+    get() = unsafeCast("idle")
+
+inline val AnimationPlayState.Companion.paused: AnimationPlayState
+    get() = unsafeCast("paused")
+
+inline val AnimationPlayState.Companion.running: AnimationPlayState
+    get() = unsafeCast("running")

--- a/kotlin-browser/src/commonMain/generated/web/animations/AnimationReplaceState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/AnimationReplaceState.kt
@@ -6,17 +6,17 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AnimationReplaceState {
-    companion object {
-        @JsValue("active")
-        val active: AnimationReplaceState
-
-        @JsValue("persisted")
-        val persisted: AnimationReplaceState
-
-        @JsValue("removed")
-        val removed: AnimationReplaceState
-    }
+    companion object
 }
+
+inline val AnimationReplaceState.Companion.active: AnimationReplaceState
+    get() = unsafeCast("active")
+
+inline val AnimationReplaceState.Companion.persisted: AnimationReplaceState
+    get() = unsafeCast("persisted")
+
+inline val AnimationReplaceState.Companion.removed: AnimationReplaceState
+    get() = unsafeCast("removed")

--- a/kotlin-browser/src/commonMain/generated/web/animations/CompositeOperation.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/CompositeOperation.kt
@@ -6,17 +6,17 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CompositeOperation {
-    companion object {
-        @JsValue("accumulate")
-        val accumulate: CompositeOperation
-
-        @JsValue("add")
-        val add: CompositeOperation
-
-        @JsValue("replace")
-        val replace: CompositeOperation
-    }
+    companion object
 }
+
+inline val CompositeOperation.Companion.accumulate: CompositeOperation
+    get() = unsafeCast("accumulate")
+
+inline val CompositeOperation.Companion.add: CompositeOperation
+    get() = unsafeCast("add")
+
+inline val CompositeOperation.Companion.replace: CompositeOperation
+    get() = unsafeCast("replace")

--- a/kotlin-browser/src/commonMain/generated/web/animations/CompositeOperationOrAuto.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/CompositeOperationOrAuto.kt
@@ -6,20 +6,20 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CompositeOperationOrAuto {
-    companion object {
-        @JsValue("accumulate")
-        val accumulate: CompositeOperationOrAuto
-
-        @JsValue("add")
-        val add: CompositeOperationOrAuto
-
-        @JsValue("auto")
-        val auto: CompositeOperationOrAuto
-
-        @JsValue("replace")
-        val replace: CompositeOperationOrAuto
-    }
+    companion object
 }
+
+inline val CompositeOperationOrAuto.Companion.accumulate: CompositeOperationOrAuto
+    get() = unsafeCast("accumulate")
+
+inline val CompositeOperationOrAuto.Companion.add: CompositeOperationOrAuto
+    get() = unsafeCast("add")
+
+inline val CompositeOperationOrAuto.Companion.auto: CompositeOperationOrAuto
+    get() = unsafeCast("auto")
+
+inline val CompositeOperationOrAuto.Companion.replace: CompositeOperationOrAuto
+    get() = unsafeCast("replace")

--- a/kotlin-browser/src/commonMain/generated/web/animations/FillMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/FillMode.kt
@@ -6,23 +6,23 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FillMode {
-    companion object {
-        @JsValue("auto")
-        val auto: FillMode
-
-        @JsValue("backwards")
-        val backwards: FillMode
-
-        @JsValue("both")
-        val both: FillMode
-
-        @JsValue("forwards")
-        val forwards: FillMode
-
-        @JsValue("none")
-        val none: FillMode
-    }
+    companion object
 }
+
+inline val FillMode.Companion.auto: FillMode
+    get() = unsafeCast("auto")
+
+inline val FillMode.Companion.backwards: FillMode
+    get() = unsafeCast("backwards")
+
+inline val FillMode.Companion.both: FillMode
+    get() = unsafeCast("both")
+
+inline val FillMode.Companion.forwards: FillMode
+    get() = unsafeCast("forwards")
+
+inline val FillMode.Companion.none: FillMode
+    get() = unsafeCast("none")

--- a/kotlin-browser/src/commonMain/generated/web/animations/IterationCompositeOperation.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/IterationCompositeOperation.kt
@@ -6,14 +6,14 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface IterationCompositeOperation {
-    companion object {
-        @JsValue("accumulate")
-        val accumulate: IterationCompositeOperation
-
-        @JsValue("replace")
-        val replace: IterationCompositeOperation
-    }
+    companion object
 }
+
+inline val IterationCompositeOperation.Companion.accumulate: IterationCompositeOperation
+    get() = unsafeCast("accumulate")
+
+inline val IterationCompositeOperation.Companion.replace: IterationCompositeOperation
+    get() = unsafeCast("replace")

--- a/kotlin-browser/src/commonMain/generated/web/animations/PlaybackDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/animations/PlaybackDirection.kt
@@ -6,20 +6,20 @@
 
 package web.animations
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PlaybackDirection {
-    companion object {
-        @JsValue("alternate")
-        val alternate: PlaybackDirection
-
-        @JsValue("alternate-reverse")
-        val alternateReverse: PlaybackDirection
-
-        @JsValue("normal")
-        val normal: PlaybackDirection
-
-        @JsValue("reverse")
-        val reverse: PlaybackDirection
-    }
+    companion object
 }
+
+inline val PlaybackDirection.Companion.alternate: PlaybackDirection
+    get() = unsafeCast("alternate")
+
+inline val PlaybackDirection.Companion.alternateReverse: PlaybackDirection
+    get() = unsafeCast("alternate-reverse")
+
+inline val PlaybackDirection.Companion.normal: PlaybackDirection
+    get() = unsafeCast("normal")
+
+inline val PlaybackDirection.Companion.reverse: PlaybackDirection
+    get() = unsafeCast("reverse")

--- a/kotlin-browser/src/commonMain/generated/web/audio/AudioContextLatencyCategory.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/AudioContextLatencyCategory.kt
@@ -6,17 +6,17 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AudioContextLatencyCategory {
-    companion object {
-        @JsValue("balanced")
-        val balanced: AudioContextLatencyCategory
-
-        @JsValue("interactive")
-        val interactive: AudioContextLatencyCategory
-
-        @JsValue("playback")
-        val playback: AudioContextLatencyCategory
-    }
+    companion object
 }
+
+inline val AudioContextLatencyCategory.Companion.balanced: AudioContextLatencyCategory
+    get() = unsafeCast("balanced")
+
+inline val AudioContextLatencyCategory.Companion.interactive: AudioContextLatencyCategory
+    get() = unsafeCast("interactive")
+
+inline val AudioContextLatencyCategory.Companion.playback: AudioContextLatencyCategory
+    get() = unsafeCast("playback")

--- a/kotlin-browser/src/commonMain/generated/web/audio/AudioContextState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/AudioContextState.kt
@@ -6,20 +6,20 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AudioContextState {
-    companion object {
-        @JsValue("closed")
-        val closed: AudioContextState
-
-        @JsValue("interrupted")
-        val interrupted: AudioContextState
-
-        @JsValue("running")
-        val running: AudioContextState
-
-        @JsValue("suspended")
-        val suspended: AudioContextState
-    }
+    companion object
 }
+
+inline val AudioContextState.Companion.closed: AudioContextState
+    get() = unsafeCast("closed")
+
+inline val AudioContextState.Companion.interrupted: AudioContextState
+    get() = unsafeCast("interrupted")
+
+inline val AudioContextState.Companion.running: AudioContextState
+    get() = unsafeCast("running")
+
+inline val AudioContextState.Companion.suspended: AudioContextState
+    get() = unsafeCast("suspended")

--- a/kotlin-browser/src/commonMain/generated/web/audio/AutomationRate.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/AutomationRate.kt
@@ -6,14 +6,14 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutomationRate {
-    companion object {
-        @JsValue("a-rate")
-        val aRate: AutomationRate
-
-        @JsValue("k-rate")
-        val kRate: AutomationRate
-    }
+    companion object
 }
+
+inline val AutomationRate.Companion.aRate: AutomationRate
+    get() = unsafeCast("a-rate")
+
+inline val AutomationRate.Companion.kRate: AutomationRate
+    get() = unsafeCast("k-rate")

--- a/kotlin-browser/src/commonMain/generated/web/audio/BiquadFilterType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/BiquadFilterType.kt
@@ -6,32 +6,32 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface BiquadFilterType {
-    companion object {
-        @JsValue("allpass")
-        val allpass: BiquadFilterType
-
-        @JsValue("bandpass")
-        val bandpass: BiquadFilterType
-
-        @JsValue("highpass")
-        val highpass: BiquadFilterType
-
-        @JsValue("highshelf")
-        val highshelf: BiquadFilterType
-
-        @JsValue("lowpass")
-        val lowpass: BiquadFilterType
-
-        @JsValue("lowshelf")
-        val lowshelf: BiquadFilterType
-
-        @JsValue("notch")
-        val notch: BiquadFilterType
-
-        @JsValue("peaking")
-        val peaking: BiquadFilterType
-    }
+    companion object
 }
+
+inline val BiquadFilterType.Companion.allpass: BiquadFilterType
+    get() = unsafeCast("allpass")
+
+inline val BiquadFilterType.Companion.bandpass: BiquadFilterType
+    get() = unsafeCast("bandpass")
+
+inline val BiquadFilterType.Companion.highpass: BiquadFilterType
+    get() = unsafeCast("highpass")
+
+inline val BiquadFilterType.Companion.highshelf: BiquadFilterType
+    get() = unsafeCast("highshelf")
+
+inline val BiquadFilterType.Companion.lowpass: BiquadFilterType
+    get() = unsafeCast("lowpass")
+
+inline val BiquadFilterType.Companion.lowshelf: BiquadFilterType
+    get() = unsafeCast("lowshelf")
+
+inline val BiquadFilterType.Companion.notch: BiquadFilterType
+    get() = unsafeCast("notch")
+
+inline val BiquadFilterType.Companion.peaking: BiquadFilterType
+    get() = unsafeCast("peaking")

--- a/kotlin-browser/src/commonMain/generated/web/audio/ChannelCountMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/ChannelCountMode.kt
@@ -6,17 +6,17 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ChannelCountMode {
-    companion object {
-        @JsValue("clamped-max")
-        val clampedMax: ChannelCountMode
-
-        @JsValue("explicit")
-        val explicit: ChannelCountMode
-
-        @JsValue("max")
-        val max: ChannelCountMode
-    }
+    companion object
 }
+
+inline val ChannelCountMode.Companion.clampedMax: ChannelCountMode
+    get() = unsafeCast("clamped-max")
+
+inline val ChannelCountMode.Companion.explicit: ChannelCountMode
+    get() = unsafeCast("explicit")
+
+inline val ChannelCountMode.Companion.max: ChannelCountMode
+    get() = unsafeCast("max")

--- a/kotlin-browser/src/commonMain/generated/web/audio/ChannelInterpretation.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/ChannelInterpretation.kt
@@ -6,14 +6,14 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ChannelInterpretation {
-    companion object {
-        @JsValue("discrete")
-        val discrete: ChannelInterpretation
-
-        @JsValue("speakers")
-        val speakers: ChannelInterpretation
-    }
+    companion object
 }
+
+inline val ChannelInterpretation.Companion.discrete: ChannelInterpretation
+    get() = unsafeCast("discrete")
+
+inline val ChannelInterpretation.Companion.speakers: ChannelInterpretation
+    get() = unsafeCast("speakers")

--- a/kotlin-browser/src/commonMain/generated/web/audio/DistanceModelType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/DistanceModelType.kt
@@ -6,17 +6,17 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DistanceModelType {
-    companion object {
-        @JsValue("exponential")
-        val exponential: DistanceModelType
-
-        @JsValue("inverse")
-        val inverse: DistanceModelType
-
-        @JsValue("linear")
-        val linear: DistanceModelType
-    }
+    companion object
 }
+
+inline val DistanceModelType.Companion.exponential: DistanceModelType
+    get() = unsafeCast("exponential")
+
+inline val DistanceModelType.Companion.inverse: DistanceModelType
+    get() = unsafeCast("inverse")
+
+inline val DistanceModelType.Companion.linear: DistanceModelType
+    get() = unsafeCast("linear")

--- a/kotlin-browser/src/commonMain/generated/web/audio/OscillatorType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/OscillatorType.kt
@@ -6,23 +6,23 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface OscillatorType {
-    companion object {
-        @JsValue("custom")
-        val custom: OscillatorType
-
-        @JsValue("sawtooth")
-        val sawtooth: OscillatorType
-
-        @JsValue("sine")
-        val sine: OscillatorType
-
-        @JsValue("square")
-        val square: OscillatorType
-
-        @JsValue("triangle")
-        val triangle: OscillatorType
-    }
+    companion object
 }
+
+inline val OscillatorType.Companion.custom: OscillatorType
+    get() = unsafeCast("custom")
+
+inline val OscillatorType.Companion.sawtooth: OscillatorType
+    get() = unsafeCast("sawtooth")
+
+inline val OscillatorType.Companion.sine: OscillatorType
+    get() = unsafeCast("sine")
+
+inline val OscillatorType.Companion.square: OscillatorType
+    get() = unsafeCast("square")
+
+inline val OscillatorType.Companion.triangle: OscillatorType
+    get() = unsafeCast("triangle")

--- a/kotlin-browser/src/commonMain/generated/web/audio/OverSampleType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/OverSampleType.kt
@@ -6,17 +6,17 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface OverSampleType {
-    companion object {
-        @JsValue("2x")
-        val x2: OverSampleType
-
-        @JsValue("4x")
-        val x4: OverSampleType
-
-        @JsValue("none")
-        val none: OverSampleType
-    }
+    companion object
 }
+
+inline val OverSampleType.Companion.x2: OverSampleType
+    get() = unsafeCast("2x")
+
+inline val OverSampleType.Companion.x4: OverSampleType
+    get() = unsafeCast("4x")
+
+inline val OverSampleType.Companion.none: OverSampleType
+    get() = unsafeCast("none")

--- a/kotlin-browser/src/commonMain/generated/web/audio/PanningModelType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/PanningModelType.kt
@@ -6,14 +6,14 @@
 
 package web.audio
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PanningModelType {
-    companion object {
-        @JsValue("HRTF")
-        val HRTF: PanningModelType
-
-        @JsValue("equalpower")
-        val equalpower: PanningModelType
-    }
+    companion object
 }
+
+inline val PanningModelType.Companion.HRTF: PanningModelType
+    get() = unsafeCast("HRTF")
+
+inline val PanningModelType.Companion.equalpower: PanningModelType
+    get() = unsafeCast("equalpower")

--- a/kotlin-browser/src/commonMain/generated/web/authn/AttestationConveyancePreference.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/AttestationConveyancePreference.kt
@@ -6,20 +6,20 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AttestationConveyancePreference {
-    companion object {
-        @JsValue("direct")
-        val direct: AttestationConveyancePreference
-
-        @JsValue("enterprise")
-        val enterprise: AttestationConveyancePreference
-
-        @JsValue("indirect")
-        val indirect: AttestationConveyancePreference
-
-        @JsValue("none")
-        val none: AttestationConveyancePreference
-    }
+    companion object
 }
+
+inline val AttestationConveyancePreference.Companion.direct: AttestationConveyancePreference
+    get() = unsafeCast("direct")
+
+inline val AttestationConveyancePreference.Companion.enterprise: AttestationConveyancePreference
+    get() = unsafeCast("enterprise")
+
+inline val AttestationConveyancePreference.Companion.indirect: AttestationConveyancePreference
+    get() = unsafeCast("indirect")
+
+inline val AttestationConveyancePreference.Companion.none: AttestationConveyancePreference
+    get() = unsafeCast("none")

--- a/kotlin-browser/src/commonMain/generated/web/authn/AuthenticatorAttachment.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/AuthenticatorAttachment.kt
@@ -6,14 +6,14 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AuthenticatorAttachment {
-    companion object {
-        @JsValue("cross-platform")
-        val crossPlatform: AuthenticatorAttachment
-
-        @JsValue("platform")
-        val platform: AuthenticatorAttachment
-    }
+    companion object
 }
+
+inline val AuthenticatorAttachment.Companion.crossPlatform: AuthenticatorAttachment
+    get() = unsafeCast("cross-platform")
+
+inline val AuthenticatorAttachment.Companion.platform: AuthenticatorAttachment
+    get() = unsafeCast("platform")

--- a/kotlin-browser/src/commonMain/generated/web/authn/AuthenticatorTransport.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/AuthenticatorTransport.kt
@@ -6,23 +6,23 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AuthenticatorTransport {
-    companion object {
-        @JsValue("ble")
-        val ble: AuthenticatorTransport
-
-        @JsValue("hybrid")
-        val hybrid: AuthenticatorTransport
-
-        @JsValue("internal")
-        val internal: AuthenticatorTransport
-
-        @JsValue("nfc")
-        val nfc: AuthenticatorTransport
-
-        @JsValue("usb")
-        val usb: AuthenticatorTransport
-    }
+    companion object
 }
+
+inline val AuthenticatorTransport.Companion.ble: AuthenticatorTransport
+    get() = unsafeCast("ble")
+
+inline val AuthenticatorTransport.Companion.hybrid: AuthenticatorTransport
+    get() = unsafeCast("hybrid")
+
+inline val AuthenticatorTransport.Companion.internal: AuthenticatorTransport
+    get() = unsafeCast("internal")
+
+inline val AuthenticatorTransport.Companion.nfc: AuthenticatorTransport
+    get() = unsafeCast("nfc")
+
+inline val AuthenticatorTransport.Companion.usb: AuthenticatorTransport
+    get() = unsafeCast("usb")

--- a/kotlin-browser/src/commonMain/generated/web/authn/PublicKeyCredentialType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/PublicKeyCredentialType.kt
@@ -6,11 +6,11 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PublicKeyCredentialType {
-    companion object {
-        @JsValue("public-key")
-        val publicKey: PublicKeyCredentialType
-    }
+    companion object
 }
+
+inline val PublicKeyCredentialType.Companion.publicKey: PublicKeyCredentialType
+    get() = unsafeCast("public-key")

--- a/kotlin-browser/src/commonMain/generated/web/authn/ResidentKeyRequirement.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/ResidentKeyRequirement.kt
@@ -6,17 +6,17 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ResidentKeyRequirement {
-    companion object {
-        @JsValue("discouraged")
-        val discouraged: ResidentKeyRequirement
-
-        @JsValue("preferred")
-        val preferred: ResidentKeyRequirement
-
-        @JsValue("required")
-        val required: ResidentKeyRequirement
-    }
+    companion object
 }
+
+inline val ResidentKeyRequirement.Companion.discouraged: ResidentKeyRequirement
+    get() = unsafeCast("discouraged")
+
+inline val ResidentKeyRequirement.Companion.preferred: ResidentKeyRequirement
+    get() = unsafeCast("preferred")
+
+inline val ResidentKeyRequirement.Companion.required: ResidentKeyRequirement
+    get() = unsafeCast("required")

--- a/kotlin-browser/src/commonMain/generated/web/authn/UserVerificationRequirement.kt
+++ b/kotlin-browser/src/commonMain/generated/web/authn/UserVerificationRequirement.kt
@@ -6,17 +6,17 @@
 
 package web.authn
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface UserVerificationRequirement {
-    companion object {
-        @JsValue("discouraged")
-        val discouraged: UserVerificationRequirement
-
-        @JsValue("preferred")
-        val preferred: UserVerificationRequirement
-
-        @JsValue("required")
-        val required: UserVerificationRequirement
-    }
+    companion object
 }
+
+inline val UserVerificationRequirement.Companion.discouraged: UserVerificationRequirement
+    get() = unsafeCast("discouraged")
+
+inline val UserVerificationRequirement.Companion.preferred: UserVerificationRequirement
+    get() = unsafeCast("preferred")
+
+inline val UserVerificationRequirement.Companion.required: UserVerificationRequirement
+    get() = unsafeCast("required")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillAddressKind.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillAddressKind.kt
@@ -6,14 +6,14 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillAddressKind {
-    companion object {
-        @JsValue("billing")
-        val billing: AutoFillAddressKind
-
-        @JsValue("shipping")
-        val shipping: AutoFillAddressKind
-    }
+    companion object
 }
+
+inline val AutoFillAddressKind.Companion.billing: AutoFillAddressKind
+    get() = unsafeCast("billing")
+
+inline val AutoFillAddressKind.Companion.shipping: AutoFillAddressKind
+    get() = unsafeCast("shipping")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillBase.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillBase.kt
@@ -6,18 +6,18 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillBase :
     AutoFill {
-    companion object {
-        @JsValue("")
-        val none: AutoFillBase
-
-        @JsValue("off")
-        val off: AutoFillBase
-
-        @JsValue("on")
-        val on: AutoFillBase
-    }
+    companion object
 }
+
+inline val AutoFillBase.Companion.none: AutoFillBase
+    get() = unsafeCast("")
+
+inline val AutoFillBase.Companion.off: AutoFillBase
+    get() = unsafeCast("off")
+
+inline val AutoFillBase.Companion.on: AutoFillBase
+    get() = unsafeCast("on")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillContactField.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillContactField.kt
@@ -6,36 +6,36 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillContactField :
     AutoFillField {
-    companion object {
-        @JsValue("email")
-        val email: AutoFillContactField
-
-        @JsValue("tel")
-        val tel: AutoFillContactField
-
-        @JsValue("tel-area-code")
-        val telAreaCode: AutoFillContactField
-
-        @JsValue("tel-country-code")
-        val telCountryCode: AutoFillContactField
-
-        @JsValue("tel-extension")
-        val telExtension: AutoFillContactField
-
-        @JsValue("tel-local")
-        val telLocal: AutoFillContactField
-
-        @JsValue("tel-local-prefix")
-        val telLocalPrefix: AutoFillContactField
-
-        @JsValue("tel-local-suffix")
-        val telLocalSuffix: AutoFillContactField
-
-        @JsValue("tel-national")
-        val telNational: AutoFillContactField
-    }
+    companion object
 }
+
+inline val AutoFillContactField.Companion.email: AutoFillContactField
+    get() = unsafeCast("email")
+
+inline val AutoFillContactField.Companion.tel: AutoFillContactField
+    get() = unsafeCast("tel")
+
+inline val AutoFillContactField.Companion.telAreaCode: AutoFillContactField
+    get() = unsafeCast("tel-area-code")
+
+inline val AutoFillContactField.Companion.telCountryCode: AutoFillContactField
+    get() = unsafeCast("tel-country-code")
+
+inline val AutoFillContactField.Companion.telExtension: AutoFillContactField
+    get() = unsafeCast("tel-extension")
+
+inline val AutoFillContactField.Companion.telLocal: AutoFillContactField
+    get() = unsafeCast("tel-local")
+
+inline val AutoFillContactField.Companion.telLocalPrefix: AutoFillContactField
+    get() = unsafeCast("tel-local-prefix")
+
+inline val AutoFillContactField.Companion.telLocalSuffix: AutoFillContactField
+    get() = unsafeCast("tel-local-suffix")
+
+inline val AutoFillContactField.Companion.telNational: AutoFillContactField
+    get() = unsafeCast("tel-national")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillContactKind.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillContactKind.kt
@@ -6,17 +6,17 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillContactKind {
-    companion object {
-        @JsValue("home")
-        val home: AutoFillContactKind
-
-        @JsValue("mobile")
-        val mobile: AutoFillContactKind
-
-        @JsValue("work")
-        val work: AutoFillContactKind
-    }
+    companion object
 }
+
+inline val AutoFillContactKind.Companion.home: AutoFillContactKind
+    get() = unsafeCast("home")
+
+inline val AutoFillContactKind.Companion.mobile: AutoFillContactKind
+    get() = unsafeCast("mobile")
+
+inline val AutoFillContactKind.Companion.work: AutoFillContactKind
+    get() = unsafeCast("work")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillCredentialField.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillCredentialField.kt
@@ -6,11 +6,11 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillCredentialField {
-    companion object {
-        @JsValue("webauthn")
-        val webauthn: AutoFillCredentialField
-    }
+    companion object
 }
+
+inline val AutoFillCredentialField.Companion.webauthn: AutoFillCredentialField
+    get() = unsafeCast("webauthn")

--- a/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillNormalField.kt
+++ b/kotlin-browser/src/commonMain/generated/web/autofill/AutoFillNormalField.kt
@@ -6,117 +6,117 @@
 
 package web.autofill
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoFillNormalField :
     AutoFillField {
-    companion object {
-        @JsValue("additional-name")
-        val additionalName: AutoFillNormalField
-
-        @JsValue("address-level1")
-        val addressLevel1: AutoFillNormalField
-
-        @JsValue("address-level2")
-        val addressLevel2: AutoFillNormalField
-
-        @JsValue("address-level3")
-        val addressLevel3: AutoFillNormalField
-
-        @JsValue("address-level4")
-        val addressLevel4: AutoFillNormalField
-
-        @JsValue("address-line1")
-        val addressLine1: AutoFillNormalField
-
-        @JsValue("address-line2")
-        val addressLine2: AutoFillNormalField
-
-        @JsValue("address-line3")
-        val addressLine3: AutoFillNormalField
-
-        @JsValue("bday-day")
-        val bdayDay: AutoFillNormalField
-
-        @JsValue("bday-month")
-        val bdayMonth: AutoFillNormalField
-
-        @JsValue("bday-year")
-        val bdayYear: AutoFillNormalField
-
-        @JsValue("cc-csc")
-        val ccCsc: AutoFillNormalField
-
-        @JsValue("cc-exp")
-        val ccExp: AutoFillNormalField
-
-        @JsValue("cc-exp-month")
-        val ccExpMonth: AutoFillNormalField
-
-        @JsValue("cc-exp-year")
-        val ccExpYear: AutoFillNormalField
-
-        @JsValue("cc-family-name")
-        val ccFamilyName: AutoFillNormalField
-
-        @JsValue("cc-given-name")
-        val ccGivenName: AutoFillNormalField
-
-        @JsValue("cc-name")
-        val ccName: AutoFillNormalField
-
-        @JsValue("cc-number")
-        val ccNumber: AutoFillNormalField
-
-        @JsValue("cc-type")
-        val ccType: AutoFillNormalField
-
-        @JsValue("country")
-        val country: AutoFillNormalField
-
-        @JsValue("country-name")
-        val countryName: AutoFillNormalField
-
-        @JsValue("current-password")
-        val currentPassword: AutoFillNormalField
-
-        @JsValue("family-name")
-        val familyName: AutoFillNormalField
-
-        @JsValue("given-name")
-        val givenName: AutoFillNormalField
-
-        @JsValue("honorific-prefix")
-        val honorificPrefix: AutoFillNormalField
-
-        @JsValue("honorific-suffix")
-        val honorificSuffix: AutoFillNormalField
-
-        @JsValue("name")
-        val name: AutoFillNormalField
-
-        @JsValue("new-password")
-        val newPassword: AutoFillNormalField
-
-        @JsValue("one-time-code")
-        val oneTimeCode: AutoFillNormalField
-
-        @JsValue("organization")
-        val organization: AutoFillNormalField
-
-        @JsValue("postal-code")
-        val postalCode: AutoFillNormalField
-
-        @JsValue("street-address")
-        val streetAddress: AutoFillNormalField
-
-        @JsValue("transaction-amount")
-        val transactionAmount: AutoFillNormalField
-
-        @JsValue("transaction-currency")
-        val transactionCurrency: AutoFillNormalField
-
-        @JsValue("username")
-        val username: AutoFillNormalField
-    }
+    companion object
 }
+
+inline val AutoFillNormalField.Companion.additionalName: AutoFillNormalField
+    get() = unsafeCast("additional-name")
+
+inline val AutoFillNormalField.Companion.addressLevel1: AutoFillNormalField
+    get() = unsafeCast("address-level1")
+
+inline val AutoFillNormalField.Companion.addressLevel2: AutoFillNormalField
+    get() = unsafeCast("address-level2")
+
+inline val AutoFillNormalField.Companion.addressLevel3: AutoFillNormalField
+    get() = unsafeCast("address-level3")
+
+inline val AutoFillNormalField.Companion.addressLevel4: AutoFillNormalField
+    get() = unsafeCast("address-level4")
+
+inline val AutoFillNormalField.Companion.addressLine1: AutoFillNormalField
+    get() = unsafeCast("address-line1")
+
+inline val AutoFillNormalField.Companion.addressLine2: AutoFillNormalField
+    get() = unsafeCast("address-line2")
+
+inline val AutoFillNormalField.Companion.addressLine3: AutoFillNormalField
+    get() = unsafeCast("address-line3")
+
+inline val AutoFillNormalField.Companion.bdayDay: AutoFillNormalField
+    get() = unsafeCast("bday-day")
+
+inline val AutoFillNormalField.Companion.bdayMonth: AutoFillNormalField
+    get() = unsafeCast("bday-month")
+
+inline val AutoFillNormalField.Companion.bdayYear: AutoFillNormalField
+    get() = unsafeCast("bday-year")
+
+inline val AutoFillNormalField.Companion.ccCsc: AutoFillNormalField
+    get() = unsafeCast("cc-csc")
+
+inline val AutoFillNormalField.Companion.ccExp: AutoFillNormalField
+    get() = unsafeCast("cc-exp")
+
+inline val AutoFillNormalField.Companion.ccExpMonth: AutoFillNormalField
+    get() = unsafeCast("cc-exp-month")
+
+inline val AutoFillNormalField.Companion.ccExpYear: AutoFillNormalField
+    get() = unsafeCast("cc-exp-year")
+
+inline val AutoFillNormalField.Companion.ccFamilyName: AutoFillNormalField
+    get() = unsafeCast("cc-family-name")
+
+inline val AutoFillNormalField.Companion.ccGivenName: AutoFillNormalField
+    get() = unsafeCast("cc-given-name")
+
+inline val AutoFillNormalField.Companion.ccName: AutoFillNormalField
+    get() = unsafeCast("cc-name")
+
+inline val AutoFillNormalField.Companion.ccNumber: AutoFillNormalField
+    get() = unsafeCast("cc-number")
+
+inline val AutoFillNormalField.Companion.ccType: AutoFillNormalField
+    get() = unsafeCast("cc-type")
+
+inline val AutoFillNormalField.Companion.country: AutoFillNormalField
+    get() = unsafeCast("country")
+
+inline val AutoFillNormalField.Companion.countryName: AutoFillNormalField
+    get() = unsafeCast("country-name")
+
+inline val AutoFillNormalField.Companion.currentPassword: AutoFillNormalField
+    get() = unsafeCast("current-password")
+
+inline val AutoFillNormalField.Companion.familyName: AutoFillNormalField
+    get() = unsafeCast("family-name")
+
+inline val AutoFillNormalField.Companion.givenName: AutoFillNormalField
+    get() = unsafeCast("given-name")
+
+inline val AutoFillNormalField.Companion.honorificPrefix: AutoFillNormalField
+    get() = unsafeCast("honorific-prefix")
+
+inline val AutoFillNormalField.Companion.honorificSuffix: AutoFillNormalField
+    get() = unsafeCast("honorific-suffix")
+
+inline val AutoFillNormalField.Companion.name: AutoFillNormalField
+    get() = unsafeCast("name")
+
+inline val AutoFillNormalField.Companion.newPassword: AutoFillNormalField
+    get() = unsafeCast("new-password")
+
+inline val AutoFillNormalField.Companion.oneTimeCode: AutoFillNormalField
+    get() = unsafeCast("one-time-code")
+
+inline val AutoFillNormalField.Companion.organization: AutoFillNormalField
+    get() = unsafeCast("organization")
+
+inline val AutoFillNormalField.Companion.postalCode: AutoFillNormalField
+    get() = unsafeCast("postal-code")
+
+inline val AutoFillNormalField.Companion.streetAddress: AutoFillNormalField
+    get() = unsafeCast("street-address")
+
+inline val AutoFillNormalField.Companion.transactionAmount: AutoFillNormalField
+    get() = unsafeCast("transaction-amount")
+
+inline val AutoFillNormalField.Companion.transactionCurrency: AutoFillNormalField
+    get() = unsafeCast("transaction-currency")
+
+inline val AutoFillNormalField.Companion.username: AutoFillNormalField
+    get() = unsafeCast("username")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasDirection.kt
@@ -6,17 +6,17 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasDirection {
-    companion object {
-        @JsValue("inherit")
-        val inherit: CanvasDirection
-
-        @JsValue("ltr")
-        val ltr: CanvasDirection
-
-        @JsValue("rtl")
-        val rtl: CanvasDirection
-    }
+    companion object
 }
+
+inline val CanvasDirection.Companion.inherit: CanvasDirection
+    get() = unsafeCast("inherit")
+
+inline val CanvasDirection.Companion.ltr: CanvasDirection
+    get() = unsafeCast("ltr")
+
+inline val CanvasDirection.Companion.rtl: CanvasDirection
+    get() = unsafeCast("rtl")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFillRule.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFillRule.kt
@@ -6,14 +6,14 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasFillRule {
-    companion object {
-        @JsValue("evenodd")
-        val evenodd: CanvasFillRule
-
-        @JsValue("nonzero")
-        val nonzero: CanvasFillRule
-    }
+    companion object
 }
+
+inline val CanvasFillRule.Companion.evenodd: CanvasFillRule
+    get() = unsafeCast("evenodd")
+
+inline val CanvasFillRule.Companion.nonzero: CanvasFillRule
+    get() = unsafeCast("nonzero")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontKerning.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontKerning.kt
@@ -6,17 +6,17 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasFontKerning {
-    companion object {
-        @JsValue("auto")
-        val auto: CanvasFontKerning
-
-        @JsValue("none")
-        val none: CanvasFontKerning
-
-        @JsValue("normal")
-        val normal: CanvasFontKerning
-    }
+    companion object
 }
+
+inline val CanvasFontKerning.Companion.auto: CanvasFontKerning
+    get() = unsafeCast("auto")
+
+inline val CanvasFontKerning.Companion.none: CanvasFontKerning
+    get() = unsafeCast("none")
+
+inline val CanvasFontKerning.Companion.normal: CanvasFontKerning
+    get() = unsafeCast("normal")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontStretch.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontStretch.kt
@@ -6,35 +6,35 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasFontStretch {
-    companion object {
-        @JsValue("condensed")
-        val condensed: CanvasFontStretch
-
-        @JsValue("expanded")
-        val expanded: CanvasFontStretch
-
-        @JsValue("extra-condensed")
-        val extraCondensed: CanvasFontStretch
-
-        @JsValue("extra-expanded")
-        val extraExpanded: CanvasFontStretch
-
-        @JsValue("normal")
-        val normal: CanvasFontStretch
-
-        @JsValue("semi-condensed")
-        val semiCondensed: CanvasFontStretch
-
-        @JsValue("semi-expanded")
-        val semiExpanded: CanvasFontStretch
-
-        @JsValue("ultra-condensed")
-        val ultraCondensed: CanvasFontStretch
-
-        @JsValue("ultra-expanded")
-        val ultraExpanded: CanvasFontStretch
-    }
+    companion object
 }
+
+inline val CanvasFontStretch.Companion.condensed: CanvasFontStretch
+    get() = unsafeCast("condensed")
+
+inline val CanvasFontStretch.Companion.expanded: CanvasFontStretch
+    get() = unsafeCast("expanded")
+
+inline val CanvasFontStretch.Companion.extraCondensed: CanvasFontStretch
+    get() = unsafeCast("extra-condensed")
+
+inline val CanvasFontStretch.Companion.extraExpanded: CanvasFontStretch
+    get() = unsafeCast("extra-expanded")
+
+inline val CanvasFontStretch.Companion.normal: CanvasFontStretch
+    get() = unsafeCast("normal")
+
+inline val CanvasFontStretch.Companion.semiCondensed: CanvasFontStretch
+    get() = unsafeCast("semi-condensed")
+
+inline val CanvasFontStretch.Companion.semiExpanded: CanvasFontStretch
+    get() = unsafeCast("semi-expanded")
+
+inline val CanvasFontStretch.Companion.ultraCondensed: CanvasFontStretch
+    get() = unsafeCast("ultra-condensed")
+
+inline val CanvasFontStretch.Companion.ultraExpanded: CanvasFontStretch
+    get() = unsafeCast("ultra-expanded")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontVariantCaps.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasFontVariantCaps.kt
@@ -6,29 +6,29 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasFontVariantCaps {
-    companion object {
-        @JsValue("all-petite-caps")
-        val allPetiteCaps: CanvasFontVariantCaps
-
-        @JsValue("all-small-caps")
-        val allSmallCaps: CanvasFontVariantCaps
-
-        @JsValue("normal")
-        val normal: CanvasFontVariantCaps
-
-        @JsValue("petite-caps")
-        val petiteCaps: CanvasFontVariantCaps
-
-        @JsValue("small-caps")
-        val smallCaps: CanvasFontVariantCaps
-
-        @JsValue("titling-caps")
-        val titlingCaps: CanvasFontVariantCaps
-
-        @JsValue("unicase")
-        val unicase: CanvasFontVariantCaps
-    }
+    companion object
 }
+
+inline val CanvasFontVariantCaps.Companion.allPetiteCaps: CanvasFontVariantCaps
+    get() = unsafeCast("all-petite-caps")
+
+inline val CanvasFontVariantCaps.Companion.allSmallCaps: CanvasFontVariantCaps
+    get() = unsafeCast("all-small-caps")
+
+inline val CanvasFontVariantCaps.Companion.normal: CanvasFontVariantCaps
+    get() = unsafeCast("normal")
+
+inline val CanvasFontVariantCaps.Companion.petiteCaps: CanvasFontVariantCaps
+    get() = unsafeCast("petite-caps")
+
+inline val CanvasFontVariantCaps.Companion.smallCaps: CanvasFontVariantCaps
+    get() = unsafeCast("small-caps")
+
+inline val CanvasFontVariantCaps.Companion.titlingCaps: CanvasFontVariantCaps
+    get() = unsafeCast("titling-caps")
+
+inline val CanvasFontVariantCaps.Companion.unicase: CanvasFontVariantCaps
+    get() = unsafeCast("unicase")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasLineCap.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasLineCap.kt
@@ -6,17 +6,17 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasLineCap {
-    companion object {
-        @JsValue("butt")
-        val butt: CanvasLineCap
-
-        @JsValue("round")
-        val round: CanvasLineCap
-
-        @JsValue("square")
-        val square: CanvasLineCap
-    }
+    companion object
 }
+
+inline val CanvasLineCap.Companion.butt: CanvasLineCap
+    get() = unsafeCast("butt")
+
+inline val CanvasLineCap.Companion.round: CanvasLineCap
+    get() = unsafeCast("round")
+
+inline val CanvasLineCap.Companion.square: CanvasLineCap
+    get() = unsafeCast("square")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasLineJoin.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasLineJoin.kt
@@ -6,17 +6,17 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasLineJoin {
-    companion object {
-        @JsValue("bevel")
-        val bevel: CanvasLineJoin
-
-        @JsValue("miter")
-        val miter: CanvasLineJoin
-
-        @JsValue("round")
-        val round: CanvasLineJoin
-    }
+    companion object
 }
+
+inline val CanvasLineJoin.Companion.bevel: CanvasLineJoin
+    get() = unsafeCast("bevel")
+
+inline val CanvasLineJoin.Companion.miter: CanvasLineJoin
+    get() = unsafeCast("miter")
+
+inline val CanvasLineJoin.Companion.round: CanvasLineJoin
+    get() = unsafeCast("round")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasRenderingContext2D.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasRenderingContext2D.kt
@@ -2,7 +2,7 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.html.HTMLCanvasElement
 import web.rendering.RenderingContext
 import web.rendering.RenderingContextId
@@ -40,8 +40,8 @@ protected /* private */ constructor() :
      */
     val canvas: HTMLCanvasElement
 
-    companion object {
-        @JsValue("2d")
-        val ID: RenderingContextId<CanvasRenderingContext2D, CanvasRenderingContext2DSettings>
-    }
+    companion object
 }
+
+inline val CanvasRenderingContext2D.Companion.ID: RenderingContextId<CanvasRenderingContext2D, CanvasRenderingContext2DSettings>
+    get() = unsafeCast("2d")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextAlign.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextAlign.kt
@@ -6,23 +6,23 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasTextAlign {
-    companion object {
-        @JsValue("center")
-        val center: CanvasTextAlign
-
-        @JsValue("end")
-        val end: CanvasTextAlign
-
-        @JsValue("left")
-        val left: CanvasTextAlign
-
-        @JsValue("right")
-        val right: CanvasTextAlign
-
-        @JsValue("start")
-        val start: CanvasTextAlign
-    }
+    companion object
 }
+
+inline val CanvasTextAlign.Companion.center: CanvasTextAlign
+    get() = unsafeCast("center")
+
+inline val CanvasTextAlign.Companion.end: CanvasTextAlign
+    get() = unsafeCast("end")
+
+inline val CanvasTextAlign.Companion.left: CanvasTextAlign
+    get() = unsafeCast("left")
+
+inline val CanvasTextAlign.Companion.right: CanvasTextAlign
+    get() = unsafeCast("right")
+
+inline val CanvasTextAlign.Companion.start: CanvasTextAlign
+    get() = unsafeCast("start")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextBaseline.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextBaseline.kt
@@ -6,26 +6,26 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasTextBaseline {
-    companion object {
-        @JsValue("alphabetic")
-        val alphabetic: CanvasTextBaseline
-
-        @JsValue("bottom")
-        val bottom: CanvasTextBaseline
-
-        @JsValue("hanging")
-        val hanging: CanvasTextBaseline
-
-        @JsValue("ideographic")
-        val ideographic: CanvasTextBaseline
-
-        @JsValue("middle")
-        val middle: CanvasTextBaseline
-
-        @JsValue("top")
-        val top: CanvasTextBaseline
-    }
+    companion object
 }
+
+inline val CanvasTextBaseline.Companion.alphabetic: CanvasTextBaseline
+    get() = unsafeCast("alphabetic")
+
+inline val CanvasTextBaseline.Companion.bottom: CanvasTextBaseline
+    get() = unsafeCast("bottom")
+
+inline val CanvasTextBaseline.Companion.hanging: CanvasTextBaseline
+    get() = unsafeCast("hanging")
+
+inline val CanvasTextBaseline.Companion.ideographic: CanvasTextBaseline
+    get() = unsafeCast("ideographic")
+
+inline val CanvasTextBaseline.Companion.middle: CanvasTextBaseline
+    get() = unsafeCast("middle")
+
+inline val CanvasTextBaseline.Companion.top: CanvasTextBaseline
+    get() = unsafeCast("top")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextRendering.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/CanvasTextRendering.kt
@@ -6,20 +6,20 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanvasTextRendering {
-    companion object {
-        @JsValue("auto")
-        val auto: CanvasTextRendering
-
-        @JsValue("geometricPrecision")
-        val geometricPrecision: CanvasTextRendering
-
-        @JsValue("optimizeLegibility")
-        val optimizeLegibility: CanvasTextRendering
-
-        @JsValue("optimizeSpeed")
-        val optimizeSpeed: CanvasTextRendering
-    }
+    companion object
 }
+
+inline val CanvasTextRendering.Companion.auto: CanvasTextRendering
+    get() = unsafeCast("auto")
+
+inline val CanvasTextRendering.Companion.geometricPrecision: CanvasTextRendering
+    get() = unsafeCast("geometricPrecision")
+
+inline val CanvasTextRendering.Companion.optimizeLegibility: CanvasTextRendering
+    get() = unsafeCast("optimizeLegibility")
+
+inline val CanvasTextRendering.Companion.optimizeSpeed: CanvasTextRendering
+    get() = unsafeCast("optimizeSpeed")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/GlobalCompositeOperation.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/GlobalCompositeOperation.kt
@@ -6,86 +6,86 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GlobalCompositeOperation {
-    companion object {
-        @JsValue("color")
-        val color: GlobalCompositeOperation
-
-        @JsValue("color-burn")
-        val colorBurn: GlobalCompositeOperation
-
-        @JsValue("color-dodge")
-        val colorDodge: GlobalCompositeOperation
-
-        @JsValue("copy")
-        val copy: GlobalCompositeOperation
-
-        @JsValue("darken")
-        val darken: GlobalCompositeOperation
-
-        @JsValue("destination-atop")
-        val destinationAtop: GlobalCompositeOperation
-
-        @JsValue("destination-in")
-        val destinationIn: GlobalCompositeOperation
-
-        @JsValue("destination-out")
-        val destinationOut: GlobalCompositeOperation
-
-        @JsValue("destination-over")
-        val destinationOver: GlobalCompositeOperation
-
-        @JsValue("difference")
-        val difference: GlobalCompositeOperation
-
-        @JsValue("exclusion")
-        val exclusion: GlobalCompositeOperation
-
-        @JsValue("hard-light")
-        val hardLight: GlobalCompositeOperation
-
-        @JsValue("hue")
-        val hue: GlobalCompositeOperation
-
-        @JsValue("lighten")
-        val lighten: GlobalCompositeOperation
-
-        @JsValue("lighter")
-        val lighter: GlobalCompositeOperation
-
-        @JsValue("luminosity")
-        val luminosity: GlobalCompositeOperation
-
-        @JsValue("multiply")
-        val multiply: GlobalCompositeOperation
-
-        @JsValue("overlay")
-        val overlay: GlobalCompositeOperation
-
-        @JsValue("saturation")
-        val saturation: GlobalCompositeOperation
-
-        @JsValue("screen")
-        val screen: GlobalCompositeOperation
-
-        @JsValue("soft-light")
-        val softLight: GlobalCompositeOperation
-
-        @JsValue("source-atop")
-        val sourceAtop: GlobalCompositeOperation
-
-        @JsValue("source-in")
-        val sourceIn: GlobalCompositeOperation
-
-        @JsValue("source-out")
-        val sourceOut: GlobalCompositeOperation
-
-        @JsValue("source-over")
-        val sourceOver: GlobalCompositeOperation
-
-        @JsValue("xor")
-        val xor: GlobalCompositeOperation
-    }
+    companion object
 }
+
+inline val GlobalCompositeOperation.Companion.color: GlobalCompositeOperation
+    get() = unsafeCast("color")
+
+inline val GlobalCompositeOperation.Companion.colorBurn: GlobalCompositeOperation
+    get() = unsafeCast("color-burn")
+
+inline val GlobalCompositeOperation.Companion.colorDodge: GlobalCompositeOperation
+    get() = unsafeCast("color-dodge")
+
+inline val GlobalCompositeOperation.Companion.copy: GlobalCompositeOperation
+    get() = unsafeCast("copy")
+
+inline val GlobalCompositeOperation.Companion.darken: GlobalCompositeOperation
+    get() = unsafeCast("darken")
+
+inline val GlobalCompositeOperation.Companion.destinationAtop: GlobalCompositeOperation
+    get() = unsafeCast("destination-atop")
+
+inline val GlobalCompositeOperation.Companion.destinationIn: GlobalCompositeOperation
+    get() = unsafeCast("destination-in")
+
+inline val GlobalCompositeOperation.Companion.destinationOut: GlobalCompositeOperation
+    get() = unsafeCast("destination-out")
+
+inline val GlobalCompositeOperation.Companion.destinationOver: GlobalCompositeOperation
+    get() = unsafeCast("destination-over")
+
+inline val GlobalCompositeOperation.Companion.difference: GlobalCompositeOperation
+    get() = unsafeCast("difference")
+
+inline val GlobalCompositeOperation.Companion.exclusion: GlobalCompositeOperation
+    get() = unsafeCast("exclusion")
+
+inline val GlobalCompositeOperation.Companion.hardLight: GlobalCompositeOperation
+    get() = unsafeCast("hard-light")
+
+inline val GlobalCompositeOperation.Companion.hue: GlobalCompositeOperation
+    get() = unsafeCast("hue")
+
+inline val GlobalCompositeOperation.Companion.lighten: GlobalCompositeOperation
+    get() = unsafeCast("lighten")
+
+inline val GlobalCompositeOperation.Companion.lighter: GlobalCompositeOperation
+    get() = unsafeCast("lighter")
+
+inline val GlobalCompositeOperation.Companion.luminosity: GlobalCompositeOperation
+    get() = unsafeCast("luminosity")
+
+inline val GlobalCompositeOperation.Companion.multiply: GlobalCompositeOperation
+    get() = unsafeCast("multiply")
+
+inline val GlobalCompositeOperation.Companion.overlay: GlobalCompositeOperation
+    get() = unsafeCast("overlay")
+
+inline val GlobalCompositeOperation.Companion.saturation: GlobalCompositeOperation
+    get() = unsafeCast("saturation")
+
+inline val GlobalCompositeOperation.Companion.screen: GlobalCompositeOperation
+    get() = unsafeCast("screen")
+
+inline val GlobalCompositeOperation.Companion.softLight: GlobalCompositeOperation
+    get() = unsafeCast("soft-light")
+
+inline val GlobalCompositeOperation.Companion.sourceAtop: GlobalCompositeOperation
+    get() = unsafeCast("source-atop")
+
+inline val GlobalCompositeOperation.Companion.sourceIn: GlobalCompositeOperation
+    get() = unsafeCast("source-in")
+
+inline val GlobalCompositeOperation.Companion.sourceOut: GlobalCompositeOperation
+    get() = unsafeCast("source-out")
+
+inline val GlobalCompositeOperation.Companion.sourceOver: GlobalCompositeOperation
+    get() = unsafeCast("source-over")
+
+inline val GlobalCompositeOperation.Companion.xor: GlobalCompositeOperation
+    get() = unsafeCast("xor")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/ImageSmoothingQuality.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/ImageSmoothingQuality.kt
@@ -6,17 +6,17 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ImageSmoothingQuality {
-    companion object {
-        @JsValue("high")
-        val high: ImageSmoothingQuality
-
-        @JsValue("low")
-        val low: ImageSmoothingQuality
-
-        @JsValue("medium")
-        val medium: ImageSmoothingQuality
-    }
+    companion object
 }
+
+inline val ImageSmoothingQuality.Companion.high: ImageSmoothingQuality
+    get() = unsafeCast("high")
+
+inline val ImageSmoothingQuality.Companion.low: ImageSmoothingQuality
+    get() = unsafeCast("low")
+
+inline val ImageSmoothingQuality.Companion.medium: ImageSmoothingQuality
+    get() = unsafeCast("medium")

--- a/kotlin-browser/src/commonMain/generated/web/canvas/OffscreenCanvasRenderingContext2D.kt
+++ b/kotlin-browser/src/commonMain/generated/web/canvas/OffscreenCanvasRenderingContext2D.kt
@@ -2,7 +2,7 @@
 
 package web.canvas
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.rendering.OffscreenRenderingContext
 import web.rendering.RenderingContextId
 
@@ -35,8 +35,8 @@ protected /* private */ constructor() :
      */
     val canvas: OffscreenCanvas
 
-    companion object {
-        @JsValue("2d")
-        val ID: RenderingContextId<OffscreenCanvasRenderingContext2D, CanvasRenderingContext2DSettings>
-    }
+    companion object
 }
+
+inline val OffscreenCanvasRenderingContext2D.Companion.ID: RenderingContextId<OffscreenCanvasRenderingContext2D, CanvasRenderingContext2DSettings>
+    get() = unsafeCast("2d")

--- a/kotlin-browser/src/commonMain/generated/web/clipboard/PresentationStyle.kt
+++ b/kotlin-browser/src/commonMain/generated/web/clipboard/PresentationStyle.kt
@@ -6,17 +6,17 @@
 
 package web.clipboard
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PresentationStyle {
-    companion object {
-        @JsValue("attachment")
-        val attachment: PresentationStyle
-
-        @JsValue("inline")
-        val inline: PresentationStyle
-
-        @JsValue("unspecified")
-        val unspecified: PresentationStyle
-    }
+    companion object
 }
+
+inline val PresentationStyle.Companion.attachment: PresentationStyle
+    get() = unsafeCast("attachment")
+
+inline val PresentationStyle.Companion.inline: PresentationStyle
+    get() = unsafeCast("inline")
+
+inline val PresentationStyle.Companion.unspecified: PresentationStyle
+    get() = unsafeCast("unspecified")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/AlphaOption.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/AlphaOption.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AlphaOption {
-    companion object {
-        @JsValue("discard")
-        val discard: AlphaOption
-
-        @JsValue("keep")
-        val keep: AlphaOption
-    }
+    companion object
 }
+
+inline val AlphaOption.Companion.discard: AlphaOption
+    get() = unsafeCast("discard")
+
+inline val AlphaOption.Companion.keep: AlphaOption
+    get() = unsafeCast("keep")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/AudioSampleFormat.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/AudioSampleFormat.kt
@@ -6,32 +6,32 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AudioSampleFormat {
-    companion object {
-        @JsValue("f32")
-        val f32: AudioSampleFormat
-
-        @JsValue("f32-planar")
-        val f32Planar: AudioSampleFormat
-
-        @JsValue("s16")
-        val s16: AudioSampleFormat
-
-        @JsValue("s16-planar")
-        val s16Planar: AudioSampleFormat
-
-        @JsValue("s32")
-        val s32: AudioSampleFormat
-
-        @JsValue("s32-planar")
-        val s32Planar: AudioSampleFormat
-
-        @JsValue("u8")
-        val u8: AudioSampleFormat
-
-        @JsValue("u8-planar")
-        val u8Planar: AudioSampleFormat
-    }
+    companion object
 }
+
+inline val AudioSampleFormat.Companion.f32: AudioSampleFormat
+    get() = unsafeCast("f32")
+
+inline val AudioSampleFormat.Companion.f32Planar: AudioSampleFormat
+    get() = unsafeCast("f32-planar")
+
+inline val AudioSampleFormat.Companion.s16: AudioSampleFormat
+    get() = unsafeCast("s16")
+
+inline val AudioSampleFormat.Companion.s16Planar: AudioSampleFormat
+    get() = unsafeCast("s16-planar")
+
+inline val AudioSampleFormat.Companion.s32: AudioSampleFormat
+    get() = unsafeCast("s32")
+
+inline val AudioSampleFormat.Companion.s32Planar: AudioSampleFormat
+    get() = unsafeCast("s32-planar")
+
+inline val AudioSampleFormat.Companion.u8: AudioSampleFormat
+    get() = unsafeCast("u8")
+
+inline val AudioSampleFormat.Companion.u8Planar: AudioSampleFormat
+    get() = unsafeCast("u8-planar")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/AvcBitstreamFormat.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/AvcBitstreamFormat.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AvcBitstreamFormat {
-    companion object {
-        @JsValue("annexb")
-        val annexb: AvcBitstreamFormat
-
-        @JsValue("avc")
-        val avc: AvcBitstreamFormat
-    }
+    companion object
 }
+
+inline val AvcBitstreamFormat.Companion.annexb: AvcBitstreamFormat
+    get() = unsafeCast("annexb")
+
+inline val AvcBitstreamFormat.Companion.avc: AvcBitstreamFormat
+    get() = unsafeCast("avc")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/BitrateMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/BitrateMode.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface BitrateMode {
-    companion object {
-        @JsValue("constant")
-        val constant: BitrateMode
-
-        @JsValue("variable")
-        val variable: BitrateMode
-    }
+    companion object
 }
+
+inline val BitrateMode.Companion.constant: BitrateMode
+    get() = unsafeCast("constant")
+
+inline val BitrateMode.Companion.variable: BitrateMode
+    get() = unsafeCast("variable")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/CodecState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/CodecState.kt
@@ -6,17 +6,17 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CodecState {
-    companion object {
-        @JsValue("closed")
-        val closed: CodecState
-
-        @JsValue("configured")
-        val configured: CodecState
-
-        @JsValue("unconfigured")
-        val unconfigured: CodecState
-    }
+    companion object
 }
+
+inline val CodecState.Companion.closed: CodecState
+    get() = unsafeCast("closed")
+
+inline val CodecState.Companion.configured: CodecState
+    get() = unsafeCast("configured")
+
+inline val CodecState.Companion.unconfigured: CodecState
+    get() = unsafeCast("unconfigured")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/EncodedAudioChunkType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/EncodedAudioChunkType.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EncodedAudioChunkType {
-    companion object {
-        @JsValue("delta")
-        val delta: EncodedAudioChunkType
-
-        @JsValue("key")
-        val key: EncodedAudioChunkType
-    }
+    companion object
 }
+
+inline val EncodedAudioChunkType.Companion.delta: EncodedAudioChunkType
+    get() = unsafeCast("delta")
+
+inline val EncodedAudioChunkType.Companion.key: EncodedAudioChunkType
+    get() = unsafeCast("key")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/EncodedVideoChunkType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/EncodedVideoChunkType.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EncodedVideoChunkType {
-    companion object {
-        @JsValue("delta")
-        val delta: EncodedVideoChunkType
-
-        @JsValue("key")
-        val key: EncodedVideoChunkType
-    }
+    companion object
 }
+
+inline val EncodedVideoChunkType.Companion.delta: EncodedVideoChunkType
+    get() = unsafeCast("delta")
+
+inline val EncodedVideoChunkType.Companion.key: EncodedVideoChunkType
+    get() = unsafeCast("key")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/HardwareAcceleration.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/HardwareAcceleration.kt
@@ -6,17 +6,17 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface HardwareAcceleration {
-    companion object {
-        @JsValue("no-preference")
-        val noPreference: HardwareAcceleration
-
-        @JsValue("prefer-hardware")
-        val preferHardware: HardwareAcceleration
-
-        @JsValue("prefer-software")
-        val preferSoftware: HardwareAcceleration
-    }
+    companion object
 }
+
+inline val HardwareAcceleration.Companion.noPreference: HardwareAcceleration
+    get() = unsafeCast("no-preference")
+
+inline val HardwareAcceleration.Companion.preferHardware: HardwareAcceleration
+    get() = unsafeCast("prefer-hardware")
+
+inline val HardwareAcceleration.Companion.preferSoftware: HardwareAcceleration
+    get() = unsafeCast("prefer-software")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/LatencyMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/LatencyMode.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LatencyMode {
-    companion object {
-        @JsValue("quality")
-        val quality: LatencyMode
-
-        @JsValue("realtime")
-        val realtime: LatencyMode
-    }
+    companion object
 }
+
+inline val LatencyMode.Companion.quality: LatencyMode
+    get() = unsafeCast("quality")
+
+inline val LatencyMode.Companion.realtime: LatencyMode
+    get() = unsafeCast("realtime")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/OpusBitstreamFormat.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/OpusBitstreamFormat.kt
@@ -6,14 +6,14 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface OpusBitstreamFormat {
-    companion object {
-        @JsValue("ogg")
-        val ogg: OpusBitstreamFormat
-
-        @JsValue("opus")
-        val opus: OpusBitstreamFormat
-    }
+    companion object
 }
+
+inline val OpusBitstreamFormat.Companion.ogg: OpusBitstreamFormat
+    get() = unsafeCast("ogg")
+
+inline val OpusBitstreamFormat.Companion.opus: OpusBitstreamFormat
+    get() = unsafeCast("opus")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/VideoColorPrimaries.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/VideoColorPrimaries.kt
@@ -6,17 +6,17 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface VideoColorPrimaries {
-    companion object {
-        @JsValue("bt470bg")
-        val bt470bg: VideoColorPrimaries
-
-        @JsValue("bt709")
-        val bt709: VideoColorPrimaries
-
-        @JsValue("smpte170m")
-        val smpte170m: VideoColorPrimaries
-    }
+    companion object
 }
+
+inline val VideoColorPrimaries.Companion.bt470bg: VideoColorPrimaries
+    get() = unsafeCast("bt470bg")
+
+inline val VideoColorPrimaries.Companion.bt709: VideoColorPrimaries
+    get() = unsafeCast("bt709")
+
+inline val VideoColorPrimaries.Companion.smpte170m: VideoColorPrimaries
+    get() = unsafeCast("smpte170m")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/VideoEncoderBitrateMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/VideoEncoderBitrateMode.kt
@@ -6,17 +6,17 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface VideoEncoderBitrateMode {
-    companion object {
-        @JsValue("constant")
-        val constant: VideoEncoderBitrateMode
-
-        @JsValue("quantizer")
-        val quantizer: VideoEncoderBitrateMode
-
-        @JsValue("variable")
-        val variable: VideoEncoderBitrateMode
-    }
+    companion object
 }
+
+inline val VideoEncoderBitrateMode.Companion.constant: VideoEncoderBitrateMode
+    get() = unsafeCast("constant")
+
+inline val VideoEncoderBitrateMode.Companion.quantizer: VideoEncoderBitrateMode
+    get() = unsafeCast("quantizer")
+
+inline val VideoEncoderBitrateMode.Companion.variable: VideoEncoderBitrateMode
+    get() = unsafeCast("variable")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/VideoMatrixCoefficients.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/VideoMatrixCoefficients.kt
@@ -6,20 +6,20 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface VideoMatrixCoefficients {
-    companion object {
-        @JsValue("bt470bg")
-        val bt470bg: VideoMatrixCoefficients
-
-        @JsValue("bt709")
-        val bt709: VideoMatrixCoefficients
-
-        @JsValue("rgb")
-        val rgb: VideoMatrixCoefficients
-
-        @JsValue("smpte170m")
-        val smpte170m: VideoMatrixCoefficients
-    }
+    companion object
 }
+
+inline val VideoMatrixCoefficients.Companion.bt470bg: VideoMatrixCoefficients
+    get() = unsafeCast("bt470bg")
+
+inline val VideoMatrixCoefficients.Companion.bt709: VideoMatrixCoefficients
+    get() = unsafeCast("bt709")
+
+inline val VideoMatrixCoefficients.Companion.rgb: VideoMatrixCoefficients
+    get() = unsafeCast("rgb")
+
+inline val VideoMatrixCoefficients.Companion.smpte170m: VideoMatrixCoefficients
+    get() = unsafeCast("smpte170m")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/VideoPixelFormat.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/VideoPixelFormat.kt
@@ -6,35 +6,35 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface VideoPixelFormat {
-    companion object {
-        @JsValue("BGRA")
-        val BGRA: VideoPixelFormat
-
-        @JsValue("BGRX")
-        val BGRX: VideoPixelFormat
-
-        @JsValue("I420")
-        val I420: VideoPixelFormat
-
-        @JsValue("I420A")
-        val I420A: VideoPixelFormat
-
-        @JsValue("I422")
-        val I422: VideoPixelFormat
-
-        @JsValue("I444")
-        val I444: VideoPixelFormat
-
-        @JsValue("NV12")
-        val NV12: VideoPixelFormat
-
-        @JsValue("RGBA")
-        val RGBA: VideoPixelFormat
-
-        @JsValue("RGBX")
-        val RGBX: VideoPixelFormat
-    }
+    companion object
 }
+
+inline val VideoPixelFormat.Companion.BGRA: VideoPixelFormat
+    get() = unsafeCast("BGRA")
+
+inline val VideoPixelFormat.Companion.BGRX: VideoPixelFormat
+    get() = unsafeCast("BGRX")
+
+inline val VideoPixelFormat.Companion.I420: VideoPixelFormat
+    get() = unsafeCast("I420")
+
+inline val VideoPixelFormat.Companion.I420A: VideoPixelFormat
+    get() = unsafeCast("I420A")
+
+inline val VideoPixelFormat.Companion.I422: VideoPixelFormat
+    get() = unsafeCast("I422")
+
+inline val VideoPixelFormat.Companion.I444: VideoPixelFormat
+    get() = unsafeCast("I444")
+
+inline val VideoPixelFormat.Companion.NV12: VideoPixelFormat
+    get() = unsafeCast("NV12")
+
+inline val VideoPixelFormat.Companion.RGBA: VideoPixelFormat
+    get() = unsafeCast("RGBA")
+
+inline val VideoPixelFormat.Companion.RGBX: VideoPixelFormat
+    get() = unsafeCast("RGBX")

--- a/kotlin-browser/src/commonMain/generated/web/codecs/VideoTransferCharacteristics.kt
+++ b/kotlin-browser/src/commonMain/generated/web/codecs/VideoTransferCharacteristics.kt
@@ -6,17 +6,17 @@
 
 package web.codecs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface VideoTransferCharacteristics {
-    companion object {
-        @JsValue("bt709")
-        val bt709: VideoTransferCharacteristics
-
-        @JsValue("iec61966-2-1")
-        val iec6196621: VideoTransferCharacteristics
-
-        @JsValue("smpte170m")
-        val smpte170m: VideoTransferCharacteristics
-    }
+    companion object
 }
+
+inline val VideoTransferCharacteristics.Companion.bt709: VideoTransferCharacteristics
+    get() = unsafeCast("bt709")
+
+inline val VideoTransferCharacteristics.Companion.iec6196621: VideoTransferCharacteristics
+    get() = unsafeCast("iec61966-2-1")
+
+inline val VideoTransferCharacteristics.Companion.smpte170m: VideoTransferCharacteristics
+    get() = unsafeCast("smpte170m")

--- a/kotlin-browser/src/commonMain/generated/web/components/ShadowRootMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/components/ShadowRootMode.kt
@@ -6,14 +6,14 @@
 
 package web.components
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ShadowRootMode {
-    companion object {
-        @JsValue("closed")
-        val closed: ShadowRootMode
-
-        @JsValue("open")
-        val open: ShadowRootMode
-    }
+    companion object
 }
+
+inline val ShadowRootMode.Companion.closed: ShadowRootMode
+    get() = unsafeCast("closed")
+
+inline val ShadowRootMode.Companion.open: ShadowRootMode
+    get() = unsafeCast("open")

--- a/kotlin-browser/src/commonMain/generated/web/components/SlotAssignmentMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/components/SlotAssignmentMode.kt
@@ -6,14 +6,14 @@
 
 package web.components
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SlotAssignmentMode {
-    companion object {
-        @JsValue("manual")
-        val manual: SlotAssignmentMode
-
-        @JsValue("named")
-        val named: SlotAssignmentMode
-    }
+    companion object
 }
+
+inline val SlotAssignmentMode.Companion.manual: SlotAssignmentMode
+    get() = unsafeCast("manual")
+
+inline val SlotAssignmentMode.Companion.named: SlotAssignmentMode
+    get() = unsafeCast("named")

--- a/kotlin-browser/src/commonMain/generated/web/cookie/CookieSameSite.kt
+++ b/kotlin-browser/src/commonMain/generated/web/cookie/CookieSameSite.kt
@@ -6,17 +6,17 @@
 
 package web.cookie
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CookieSameSite {
-    companion object {
-        @JsValue("lax")
-        val lax: CookieSameSite
-
-        @JsValue("none")
-        val none: CookieSameSite
-
-        @JsValue("strict")
-        val strict: CookieSameSite
-    }
+    companion object
 }
+
+inline val CookieSameSite.Companion.lax: CookieSameSite
+    get() = unsafeCast("lax")
+
+inline val CookieSameSite.Companion.none: CookieSameSite
+    get() = unsafeCast("none")
+
+inline val CookieSameSite.Companion.strict: CookieSameSite
+    get() = unsafeCast("strict")

--- a/kotlin-browser/src/commonMain/generated/web/credentials/CredentialMediationRequirement.kt
+++ b/kotlin-browser/src/commonMain/generated/web/credentials/CredentialMediationRequirement.kt
@@ -6,20 +6,20 @@
 
 package web.credentials
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CredentialMediationRequirement {
-    companion object {
-        @JsValue("conditional")
-        val conditional: CredentialMediationRequirement
-
-        @JsValue("optional")
-        val optional: CredentialMediationRequirement
-
-        @JsValue("required")
-        val required: CredentialMediationRequirement
-
-        @JsValue("silent")
-        val silent: CredentialMediationRequirement
-    }
+    companion object
 }
+
+inline val CredentialMediationRequirement.Companion.conditional: CredentialMediationRequirement
+    get() = unsafeCast("conditional")
+
+inline val CredentialMediationRequirement.Companion.optional: CredentialMediationRequirement
+    get() = unsafeCast("optional")
+
+inline val CredentialMediationRequirement.Companion.required: CredentialMediationRequirement
+    get() = unsafeCast("required")
+
+inline val CredentialMediationRequirement.Companion.silent: CredentialMediationRequirement
+    get() = unsafeCast("silent")

--- a/kotlin-browser/src/commonMain/generated/web/csp/SecurityPolicyViolationEventDisposition.kt
+++ b/kotlin-browser/src/commonMain/generated/web/csp/SecurityPolicyViolationEventDisposition.kt
@@ -6,14 +6,14 @@
 
 package web.csp
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SecurityPolicyViolationEventDisposition {
-    companion object {
-        @JsValue("enforce")
-        val enforce: SecurityPolicyViolationEventDisposition
-
-        @JsValue("report")
-        val report: SecurityPolicyViolationEventDisposition
-    }
+    companion object
 }
+
+inline val SecurityPolicyViolationEventDisposition.Companion.enforce: SecurityPolicyViolationEventDisposition
+    get() = unsafeCast("enforce")
+
+inline val SecurityPolicyViolationEventDisposition.Companion.report: SecurityPolicyViolationEventDisposition
+    get() = unsafeCast("report")

--- a/kotlin-browser/src/commonMain/generated/web/cssom/CSSMathOperator.kt
+++ b/kotlin-browser/src/commonMain/generated/web/cssom/CSSMathOperator.kt
@@ -6,29 +6,29 @@
 
 package web.cssom
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CSSMathOperator {
-    companion object {
-        @JsValue("clamp")
-        val clamp: CSSMathOperator
-
-        @JsValue("invert")
-        val invert: CSSMathOperator
-
-        @JsValue("max")
-        val max: CSSMathOperator
-
-        @JsValue("min")
-        val min: CSSMathOperator
-
-        @JsValue("negate")
-        val negate: CSSMathOperator
-
-        @JsValue("product")
-        val product: CSSMathOperator
-
-        @JsValue("sum")
-        val sum: CSSMathOperator
-    }
+    companion object
 }
+
+inline val CSSMathOperator.Companion.clamp: CSSMathOperator
+    get() = unsafeCast("clamp")
+
+inline val CSSMathOperator.Companion.invert: CSSMathOperator
+    get() = unsafeCast("invert")
+
+inline val CSSMathOperator.Companion.max: CSSMathOperator
+    get() = unsafeCast("max")
+
+inline val CSSMathOperator.Companion.min: CSSMathOperator
+    get() = unsafeCast("min")
+
+inline val CSSMathOperator.Companion.negate: CSSMathOperator
+    get() = unsafeCast("negate")
+
+inline val CSSMathOperator.Companion.product: CSSMathOperator
+    get() = unsafeCast("product")
+
+inline val CSSMathOperator.Companion.sum: CSSMathOperator
+    get() = unsafeCast("sum")

--- a/kotlin-browser/src/commonMain/generated/web/cssom/CSSNumericBaseType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/cssom/CSSNumericBaseType.kt
@@ -6,29 +6,29 @@
 
 package web.cssom
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CSSNumericBaseType {
-    companion object {
-        @JsValue("angle")
-        val angle: CSSNumericBaseType
-
-        @JsValue("flex")
-        val flex: CSSNumericBaseType
-
-        @JsValue("frequency")
-        val frequency: CSSNumericBaseType
-
-        @JsValue("length")
-        val length: CSSNumericBaseType
-
-        @JsValue("percent")
-        val percent: CSSNumericBaseType
-
-        @JsValue("resolution")
-        val resolution: CSSNumericBaseType
-
-        @JsValue("time")
-        val time: CSSNumericBaseType
-    }
+    companion object
 }
+
+inline val CSSNumericBaseType.Companion.angle: CSSNumericBaseType
+    get() = unsafeCast("angle")
+
+inline val CSSNumericBaseType.Companion.flex: CSSNumericBaseType
+    get() = unsafeCast("flex")
+
+inline val CSSNumericBaseType.Companion.frequency: CSSNumericBaseType
+    get() = unsafeCast("frequency")
+
+inline val CSSNumericBaseType.Companion.length: CSSNumericBaseType
+    get() = unsafeCast("length")
+
+inline val CSSNumericBaseType.Companion.percent: CSSNumericBaseType
+    get() = unsafeCast("percent")
+
+inline val CSSNumericBaseType.Companion.resolution: CSSNumericBaseType
+    get() = unsafeCast("resolution")
+
+inline val CSSNumericBaseType.Companion.time: CSSNumericBaseType
+    get() = unsafeCast("time")

--- a/kotlin-browser/src/commonMain/generated/web/data/AllowedEffect.kt
+++ b/kotlin-browser/src/commonMain/generated/web/data/AllowedEffect.kt
@@ -6,35 +6,35 @@
 
 package web.data
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AllowedEffect {
-    companion object {
-        @JsValue("none")
-        val none: AllowedEffect
-
-        @JsValue("copy")
-        val copy: AllowedEffect
-
-        @JsValue("copyLink")
-        val copyLink: AllowedEffect
-
-        @JsValue("copyMove")
-        val copyMove: AllowedEffect
-
-        @JsValue("link")
-        val link: AllowedEffect
-
-        @JsValue("linkMove")
-        val linkMove: AllowedEffect
-
-        @JsValue("move")
-        val move: AllowedEffect
-
-        @JsValue("all")
-        val all: AllowedEffect
-
-        @JsValue("uninitialized")
-        val uninitialized: AllowedEffect
-    }
+    companion object
 }
+
+inline val AllowedEffect.Companion.none: AllowedEffect
+    get() = unsafeCast("none")
+
+inline val AllowedEffect.Companion.copy: AllowedEffect
+    get() = unsafeCast("copy")
+
+inline val AllowedEffect.Companion.copyLink: AllowedEffect
+    get() = unsafeCast("copyLink")
+
+inline val AllowedEffect.Companion.copyMove: AllowedEffect
+    get() = unsafeCast("copyMove")
+
+inline val AllowedEffect.Companion.link: AllowedEffect
+    get() = unsafeCast("link")
+
+inline val AllowedEffect.Companion.linkMove: AllowedEffect
+    get() = unsafeCast("linkMove")
+
+inline val AllowedEffect.Companion.move: AllowedEffect
+    get() = unsafeCast("move")
+
+inline val AllowedEffect.Companion.all: AllowedEffect
+    get() = unsafeCast("all")
+
+inline val AllowedEffect.Companion.uninitialized: AllowedEffect
+    get() = unsafeCast("uninitialized")

--- a/kotlin-browser/src/commonMain/generated/web/data/DropEffect.kt
+++ b/kotlin-browser/src/commonMain/generated/web/data/DropEffect.kt
@@ -6,20 +6,20 @@
 
 package web.data
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DropEffect {
-    companion object {
-        @JsValue("none")
-        val none: DropEffect
-
-        @JsValue("copy")
-        val copy: DropEffect
-
-        @JsValue("link")
-        val link: DropEffect
-
-        @JsValue("move")
-        val move: DropEffect
-    }
+    companion object
 }
+
+inline val DropEffect.Companion.none: DropEffect
+    get() = unsafeCast("none")
+
+inline val DropEffect.Companion.copy: DropEffect
+    get() = unsafeCast("copy")
+
+inline val DropEffect.Companion.link: DropEffect
+    get() = unsafeCast("link")
+
+inline val DropEffect.Companion.move: DropEffect
+    get() = unsafeCast("move")

--- a/kotlin-browser/src/commonMain/generated/web/dom/DocumentReadyState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/dom/DocumentReadyState.kt
@@ -6,17 +6,17 @@
 
 package web.dom
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DocumentReadyState {
-    companion object {
-        @JsValue("complete")
-        val complete: DocumentReadyState
-
-        @JsValue("interactive")
-        val interactive: DocumentReadyState
-
-        @JsValue("loading")
-        val loading: DocumentReadyState
-    }
+    companion object
 }
+
+inline val DocumentReadyState.Companion.complete: DocumentReadyState
+    get() = unsafeCast("complete")
+
+inline val DocumentReadyState.Companion.interactive: DocumentReadyState
+    get() = unsafeCast("interactive")
+
+inline val DocumentReadyState.Companion.loading: DocumentReadyState
+    get() = unsafeCast("loading")

--- a/kotlin-browser/src/commonMain/generated/web/dom/DocumentVisibilityState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/dom/DocumentVisibilityState.kt
@@ -6,14 +6,14 @@
 
 package web.dom
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DocumentVisibilityState {
-    companion object {
-        @JsValue("hidden")
-        val hidden: DocumentVisibilityState
-
-        @JsValue("visible")
-        val visible: DocumentVisibilityState
-    }
+    companion object
 }
+
+inline val DocumentVisibilityState.Companion.hidden: DocumentVisibilityState
+    get() = unsafeCast("hidden")
+
+inline val DocumentVisibilityState.Companion.visible: DocumentVisibilityState
+    get() = unsafeCast("visible")

--- a/kotlin-browser/src/commonMain/generated/web/dom/InsertPosition.kt
+++ b/kotlin-browser/src/commonMain/generated/web/dom/InsertPosition.kt
@@ -6,20 +6,20 @@
 
 package web.dom
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface InsertPosition {
-    companion object {
-        @JsValue("afterbegin")
-        val afterbegin: InsertPosition
-
-        @JsValue("afterend")
-        val afterend: InsertPosition
-
-        @JsValue("beforebegin")
-        val beforebegin: InsertPosition
-
-        @JsValue("beforeend")
-        val beforeend: InsertPosition
-    }
+    companion object
 }
+
+inline val InsertPosition.Companion.afterbegin: InsertPosition
+    get() = unsafeCast("afterbegin")
+
+inline val InsertPosition.Companion.afterend: InsertPosition
+    get() = unsafeCast("afterend")
+
+inline val InsertPosition.Companion.beforebegin: InsertPosition
+    get() = unsafeCast("beforebegin")
+
+inline val InsertPosition.Companion.beforeend: InsertPosition
+    get() = unsafeCast("beforeend")

--- a/kotlin-browser/src/commonMain/generated/web/fedcm/LoginStatus.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fedcm/LoginStatus.kt
@@ -6,14 +6,14 @@
 
 package web.fedcm
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LoginStatus {
-    companion object {
-        @JsValue("logged-in")
-        val loggedIn: LoginStatus
-
-        @JsValue("logged-out")
-        val loggedOut: LoginStatus
-    }
+    companion object
 }
+
+inline val LoginStatus.Companion.loggedIn: LoginStatus
+    get() = unsafeCast("logged-in")
+
+inline val LoginStatus.Companion.loggedOut: LoginStatus
+    get() = unsafeCast("logged-out")

--- a/kotlin-browser/src/commonMain/generated/web/fonts/FontDisplay.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fonts/FontDisplay.kt
@@ -6,23 +6,23 @@
 
 package web.fonts
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FontDisplay {
-    companion object {
-        @JsValue("auto")
-        val auto: FontDisplay
-
-        @JsValue("block")
-        val block: FontDisplay
-
-        @JsValue("fallback")
-        val fallback: FontDisplay
-
-        @JsValue("optional")
-        val optional: FontDisplay
-
-        @JsValue("swap")
-        val swap: FontDisplay
-    }
+    companion object
 }
+
+inline val FontDisplay.Companion.auto: FontDisplay
+    get() = unsafeCast("auto")
+
+inline val FontDisplay.Companion.block: FontDisplay
+    get() = unsafeCast("block")
+
+inline val FontDisplay.Companion.fallback: FontDisplay
+    get() = unsafeCast("fallback")
+
+inline val FontDisplay.Companion.optional: FontDisplay
+    get() = unsafeCast("optional")
+
+inline val FontDisplay.Companion.swap: FontDisplay
+    get() = unsafeCast("swap")

--- a/kotlin-browser/src/commonMain/generated/web/fonts/FontFaceLoadStatus.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fonts/FontFaceLoadStatus.kt
@@ -6,20 +6,20 @@
 
 package web.fonts
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FontFaceLoadStatus {
-    companion object {
-        @JsValue("error")
-        val error: FontFaceLoadStatus
-
-        @JsValue("loaded")
-        val loaded: FontFaceLoadStatus
-
-        @JsValue("loading")
-        val loading: FontFaceLoadStatus
-
-        @JsValue("unloaded")
-        val unloaded: FontFaceLoadStatus
-    }
+    companion object
 }
+
+inline val FontFaceLoadStatus.Companion.error: FontFaceLoadStatus
+    get() = unsafeCast("error")
+
+inline val FontFaceLoadStatus.Companion.loaded: FontFaceLoadStatus
+    get() = unsafeCast("loaded")
+
+inline val FontFaceLoadStatus.Companion.loading: FontFaceLoadStatus
+    get() = unsafeCast("loading")
+
+inline val FontFaceLoadStatus.Companion.unloaded: FontFaceLoadStatus
+    get() = unsafeCast("unloaded")

--- a/kotlin-browser/src/commonMain/generated/web/fonts/FontFaceSetLoadStatus.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fonts/FontFaceSetLoadStatus.kt
@@ -6,14 +6,14 @@
 
 package web.fonts
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FontFaceSetLoadStatus {
-    companion object {
-        @JsValue("loaded")
-        val loaded: FontFaceSetLoadStatus
-
-        @JsValue("loading")
-        val loading: FontFaceSetLoadStatus
-    }
+    companion object
 }
+
+inline val FontFaceSetLoadStatus.Companion.loaded: FontFaceSetLoadStatus
+    get() = unsafeCast("loaded")
+
+inline val FontFaceSetLoadStatus.Companion.loading: FontFaceSetLoadStatus
+    get() = unsafeCast("loading")

--- a/kotlin-browser/src/commonMain/generated/web/form/FormEncType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/form/FormEncType.kt
@@ -6,20 +6,20 @@
 
 package web.form
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FormEncType {
-    companion object {
-        @JsValue("application/x-www-form-urlencoded")
-        val applicationXWwwFormUrlencoded: FormEncType
-
-        @JsValue("multipart/form-data")
-        val multipartFormData: FormEncType
-
-        @JsValue("application/json")
-        val applicationJson: FormEncType
-
-        @JsValue("text/plain")
-        val textPlain: FormEncType
-    }
+    companion object
 }
+
+inline val FormEncType.Companion.applicationXWwwFormUrlencoded: FormEncType
+    get() = unsafeCast("application/x-www-form-urlencoded")
+
+inline val FormEncType.Companion.multipartFormData: FormEncType
+    get() = unsafeCast("multipart/form-data")
+
+inline val FormEncType.Companion.applicationJson: FormEncType
+    get() = unsafeCast("application/json")
+
+inline val FormEncType.Companion.textPlain: FormEncType
+    get() = unsafeCast("text/plain")

--- a/kotlin-browser/src/commonMain/generated/web/form/FormMethod.kt
+++ b/kotlin-browser/src/commonMain/generated/web/form/FormMethod.kt
@@ -6,17 +6,17 @@
 
 package web.form
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FormMethod {
-    companion object {
-        @JsValue("get")
-        val get: FormMethod
-
-        @JsValue("dialog")
-        val dialog: FormMethod
-
-        @JsValue("post")
-        val post: FormMethod
-    }
+    companion object
 }
+
+inline val FormMethod.Companion.get: FormMethod
+    get() = unsafeCast("get")
+
+inline val FormMethod.Companion.dialog: FormMethod
+    get() = unsafeCast("dialog")
+
+inline val FormMethod.Companion.post: FormMethod
+    get() = unsafeCast("post")

--- a/kotlin-browser/src/commonMain/generated/web/form/FormStateRestoreMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/form/FormStateRestoreMode.kt
@@ -6,14 +6,14 @@
 
 package web.form
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FormStateRestoreMode {
-    companion object {
-        @JsValue("restore")
-        val restore: FormStateRestoreMode
-
-        @JsValue("autocomplete")
-        val autocomplete: FormStateRestoreMode
-    }
+    companion object
 }
+
+inline val FormStateRestoreMode.Companion.restore: FormStateRestoreMode
+    get() = unsafeCast("restore")
+
+inline val FormStateRestoreMode.Companion.autocomplete: FormStateRestoreMode
+    get() = unsafeCast("autocomplete")

--- a/kotlin-browser/src/commonMain/generated/web/fs/FileSystemHandleKind.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fs/FileSystemHandleKind.kt
@@ -6,17 +6,17 @@
 
 package web.fs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FileSystemHandleKind {
-    companion object {
-        @JsValue("directory")
-        val directory: directory
-
-        @JsValue("file")
-        val file: file
-    }
-
     sealed interface directory : FileSystemHandleKind
     sealed interface file : FileSystemHandleKind
+
+    companion object
 }
+
+inline val FileSystemHandleKind.Companion.directory: FileSystemHandleKind.directory
+    get() = unsafeCast("directory")
+
+inline val FileSystemHandleKind.Companion.file: FileSystemHandleKind.file
+    get() = unsafeCast("file")

--- a/kotlin-browser/src/commonMain/generated/web/fs/WriteCommandType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fs/WriteCommandType.kt
@@ -6,17 +6,17 @@
 
 package web.fs
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WriteCommandType {
-    companion object {
-        @JsValue("seek")
-        val seek: WriteCommandType
-
-        @JsValue("truncate")
-        val truncate: WriteCommandType
-
-        @JsValue("write")
-        val write: WriteCommandType
-    }
+    companion object
 }
+
+inline val WriteCommandType.Companion.seek: WriteCommandType
+    get() = unsafeCast("seek")
+
+inline val WriteCommandType.Companion.truncate: WriteCommandType
+    get() = unsafeCast("truncate")
+
+inline val WriteCommandType.Companion.write: WriteCommandType
+    get() = unsafeCast("write")

--- a/kotlin-browser/src/commonMain/generated/web/fullscreen/FullscreenNavigationUI.kt
+++ b/kotlin-browser/src/commonMain/generated/web/fullscreen/FullscreenNavigationUI.kt
@@ -6,17 +6,17 @@
 
 package web.fullscreen
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FullscreenNavigationUI {
-    companion object {
-        @JsValue("auto")
-        val auto: FullscreenNavigationUI
-
-        @JsValue("hide")
-        val hide: FullscreenNavigationUI
-
-        @JsValue("show")
-        val show: FullscreenNavigationUI
-    }
+    companion object
 }
+
+inline val FullscreenNavigationUI.Companion.auto: FullscreenNavigationUI
+    get() = unsafeCast("auto")
+
+inline val FullscreenNavigationUI.Companion.hide: FullscreenNavigationUI
+    get() = unsafeCast("hide")
+
+inline val FullscreenNavigationUI.Companion.show: FullscreenNavigationUI
+    get() = unsafeCast("show")

--- a/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadHapticEffectType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadHapticEffectType.kt
@@ -6,14 +6,14 @@
 
 package web.gamepad
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GamepadHapticEffectType {
-    companion object {
-        @JsValue("dual-rumble")
-        val dualRumble: GamepadHapticEffectType
-
-        @JsValue("trigger-rumble")
-        val triggerRumble: GamepadHapticEffectType
-    }
+    companion object
 }
+
+inline val GamepadHapticEffectType.Companion.dualRumble: GamepadHapticEffectType
+    get() = unsafeCast("dual-rumble")
+
+inline val GamepadHapticEffectType.Companion.triggerRumble: GamepadHapticEffectType
+    get() = unsafeCast("trigger-rumble")

--- a/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadHapticsResult.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadHapticsResult.kt
@@ -6,14 +6,14 @@
 
 package web.gamepad
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GamepadHapticsResult {
-    companion object {
-        @JsValue("complete")
-        val complete: GamepadHapticsResult
-
-        @JsValue("preempted")
-        val preempted: GamepadHapticsResult
-    }
+    companion object
 }
+
+inline val GamepadHapticsResult.Companion.complete: GamepadHapticsResult
+    get() = unsafeCast("complete")
+
+inline val GamepadHapticsResult.Companion.preempted: GamepadHapticsResult
+    get() = unsafeCast("preempted")

--- a/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadMappingType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gamepad/GamepadMappingType.kt
@@ -6,17 +6,17 @@
 
 package web.gamepad
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GamepadMappingType {
-    companion object {
-        @JsValue("")
-        val none: GamepadMappingType
-
-        @JsValue("standard")
-        val standard: GamepadMappingType
-
-        @JsValue("xr-standard")
-        val xrStandard: GamepadMappingType
-    }
+    companion object
 }
+
+inline val GamepadMappingType.Companion.none: GamepadMappingType
+    get() = unsafeCast("")
+
+inline val GamepadMappingType.Companion.standard: GamepadMappingType
+    get() = unsafeCast("standard")
+
+inline val GamepadMappingType.Companion.xrStandard: GamepadMappingType
+    get() = unsafeCast("xr-standard")

--- a/kotlin-browser/src/commonMain/generated/web/gl/WebGL2RenderingContext.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gl/WebGL2RenderingContext.kt
@@ -2,7 +2,7 @@
 
 package web.gl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.rendering.OffscreenRenderingContext
 import web.rendering.RenderingContext
 import web.rendering.RenderingContextId
@@ -576,8 +576,8 @@ protected /* private */ constructor() :
         val CONTEXT_LOST_WEBGL: GLenum
         val UNPACK_COLORSPACE_CONVERSION_WEBGL: GLenum
         val BROWSER_DEFAULT_WEBGL: GLenum
-
-        @JsValue("webgl2")
-        val ID: RenderingContextId<WebGL2RenderingContext, WebGLContextAttributes>
     }
 }
+
+inline val WebGL2RenderingContext.Companion.ID: RenderingContextId<WebGL2RenderingContext, WebGLContextAttributes>
+    get() = unsafeCast("webgl2")

--- a/kotlin-browser/src/commonMain/generated/web/gl/WebGLExtension.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gl/WebGLExtension.kt
@@ -6,113 +6,9 @@
 
 package web.gl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WebGLExtension {
-    companion object {
-        @JsValue("ANGLE_instanced_arrays")
-        val ANGLE_instanced_arrays: ANGLE_instanced_arrays
-
-        @JsValue("EXT_blend_minmax")
-        val EXT_blend_minmax: EXT_blend_minmax
-
-        @JsValue("EXT_color_buffer_float")
-        val EXT_color_buffer_float: EXT_color_buffer_float
-
-        @JsValue("EXT_color_buffer_half_float")
-        val EXT_color_buffer_half_float: EXT_color_buffer_half_float
-
-        @JsValue("EXT_float_blend")
-        val EXT_float_blend: EXT_float_blend
-
-        @JsValue("EXT_frag_depth")
-        val EXT_frag_depth: EXT_frag_depth
-
-        @JsValue("EXT_sRGB")
-        val EXT_sRGB: EXT_sRGB
-
-        @JsValue("EXT_shader_texture_lod")
-        val EXT_shader_texture_lod: EXT_shader_texture_lod
-
-        @JsValue("EXT_texture_compression_bptc")
-        val EXT_texture_compression_bptc: EXT_texture_compression_bptc
-
-        @JsValue("EXT_texture_compression_rgtc")
-        val EXT_texture_compression_rgtc: EXT_texture_compression_rgtc
-
-        @JsValue("EXT_texture_filter_anisotropic")
-        val EXT_texture_filter_anisotropic: EXT_texture_filter_anisotropic
-
-        @JsValue("KHR_parallel_shader_compile")
-        val KHR_parallel_shader_compile: KHR_parallel_shader_compile
-
-        @JsValue("OES_element_index_uint")
-        val OES_element_index_uint: OES_element_index_uint
-
-        @JsValue("OES_fbo_render_mipmap")
-        val OES_fbo_render_mipmap: OES_fbo_render_mipmap
-
-        @JsValue("OES_standard_derivatives")
-        val OES_standard_derivatives: OES_standard_derivatives
-
-        @JsValue("OES_texture_float")
-        val OES_texture_float: OES_texture_float
-
-        @JsValue("OES_texture_float_linear")
-        val OES_texture_float_linear: OES_texture_float_linear
-
-        @JsValue("OES_texture_half_float")
-        val OES_texture_half_float: OES_texture_half_float
-
-        @JsValue("OES_texture_half_float_linear")
-        val OES_texture_half_float_linear: OES_texture_half_float_linear
-
-        @JsValue("OES_vertex_array_object")
-        val OES_vertex_array_object: OES_vertex_array_object
-
-        @JsValue("OVR_multiview2")
-        val OVR_multiview2: OVR_multiview2
-
-        @JsValue("WEBGL_color_buffer_float")
-        val WEBGL_color_buffer_float: WEBGL_color_buffer_float
-
-        @JsValue("WEBGL_compressed_texture_astc")
-        val WEBGL_compressed_texture_astc: WEBGL_compressed_texture_astc
-
-        @JsValue("WEBGL_compressed_texture_etc")
-        val WEBGL_compressed_texture_etc: WEBGL_compressed_texture_etc
-
-        @JsValue("WEBGL_compressed_texture_etc1")
-        val WEBGL_compressed_texture_etc1: WEBGL_compressed_texture_etc1
-
-        @JsValue("WEBGL_compressed_texture_pvrtc")
-        val WEBGL_compressed_texture_pvrtc: WEBGL_compressed_texture_pvrtc
-
-        @JsValue("WEBGL_compressed_texture_s3tc")
-        val WEBGL_compressed_texture_s3tc: WEBGL_compressed_texture_s3tc
-
-        @JsValue("WEBGL_compressed_texture_s3tc_srgb")
-        val WEBGL_compressed_texture_s3tc_srgb: WEBGL_compressed_texture_s3tc_srgb
-
-        @JsValue("WEBGL_debug_renderer_info")
-        val WEBGL_debug_renderer_info: WEBGL_debug_renderer_info
-
-        @JsValue("WEBGL_debug_shaders")
-        val WEBGL_debug_shaders: WEBGL_debug_shaders
-
-        @JsValue("WEBGL_depth_texture")
-        val WEBGL_depth_texture: WEBGL_depth_texture
-
-        @JsValue("WEBGL_draw_buffers")
-        val WEBGL_draw_buffers: WEBGL_draw_buffers
-
-        @JsValue("WEBGL_lose_context")
-        val WEBGL_lose_context: WEBGL_lose_context
-
-        @JsValue("WEBGL_multi_draw")
-        val WEBGL_multi_draw: WEBGL_multi_draw
-    }
-
     sealed interface ANGLE_instanced_arrays : WebGLExtension
     sealed interface EXT_blend_minmax : WebGLExtension
     sealed interface EXT_color_buffer_float : WebGLExtension
@@ -147,4 +43,108 @@ sealed external interface WebGLExtension {
     sealed interface WEBGL_draw_buffers : WebGLExtension
     sealed interface WEBGL_lose_context : WebGLExtension
     sealed interface WEBGL_multi_draw : WebGLExtension
+
+    companion object
 }
+
+inline val WebGLExtension.Companion.ANGLE_instanced_arrays: WebGLExtension.ANGLE_instanced_arrays
+    get() = unsafeCast("ANGLE_instanced_arrays")
+
+inline val WebGLExtension.Companion.EXT_blend_minmax: WebGLExtension.EXT_blend_minmax
+    get() = unsafeCast("EXT_blend_minmax")
+
+inline val WebGLExtension.Companion.EXT_color_buffer_float: WebGLExtension.EXT_color_buffer_float
+    get() = unsafeCast("EXT_color_buffer_float")
+
+inline val WebGLExtension.Companion.EXT_color_buffer_half_float: WebGLExtension.EXT_color_buffer_half_float
+    get() = unsafeCast("EXT_color_buffer_half_float")
+
+inline val WebGLExtension.Companion.EXT_float_blend: WebGLExtension.EXT_float_blend
+    get() = unsafeCast("EXT_float_blend")
+
+inline val WebGLExtension.Companion.EXT_frag_depth: WebGLExtension.EXT_frag_depth
+    get() = unsafeCast("EXT_frag_depth")
+
+inline val WebGLExtension.Companion.EXT_sRGB: WebGLExtension.EXT_sRGB
+    get() = unsafeCast("EXT_sRGB")
+
+inline val WebGLExtension.Companion.EXT_shader_texture_lod: WebGLExtension.EXT_shader_texture_lod
+    get() = unsafeCast("EXT_shader_texture_lod")
+
+inline val WebGLExtension.Companion.EXT_texture_compression_bptc: WebGLExtension.EXT_texture_compression_bptc
+    get() = unsafeCast("EXT_texture_compression_bptc")
+
+inline val WebGLExtension.Companion.EXT_texture_compression_rgtc: WebGLExtension.EXT_texture_compression_rgtc
+    get() = unsafeCast("EXT_texture_compression_rgtc")
+
+inline val WebGLExtension.Companion.EXT_texture_filter_anisotropic: WebGLExtension.EXT_texture_filter_anisotropic
+    get() = unsafeCast("EXT_texture_filter_anisotropic")
+
+inline val WebGLExtension.Companion.KHR_parallel_shader_compile: WebGLExtension.KHR_parallel_shader_compile
+    get() = unsafeCast("KHR_parallel_shader_compile")
+
+inline val WebGLExtension.Companion.OES_element_index_uint: WebGLExtension.OES_element_index_uint
+    get() = unsafeCast("OES_element_index_uint")
+
+inline val WebGLExtension.Companion.OES_fbo_render_mipmap: WebGLExtension.OES_fbo_render_mipmap
+    get() = unsafeCast("OES_fbo_render_mipmap")
+
+inline val WebGLExtension.Companion.OES_standard_derivatives: WebGLExtension.OES_standard_derivatives
+    get() = unsafeCast("OES_standard_derivatives")
+
+inline val WebGLExtension.Companion.OES_texture_float: WebGLExtension.OES_texture_float
+    get() = unsafeCast("OES_texture_float")
+
+inline val WebGLExtension.Companion.OES_texture_float_linear: WebGLExtension.OES_texture_float_linear
+    get() = unsafeCast("OES_texture_float_linear")
+
+inline val WebGLExtension.Companion.OES_texture_half_float: WebGLExtension.OES_texture_half_float
+    get() = unsafeCast("OES_texture_half_float")
+
+inline val WebGLExtension.Companion.OES_texture_half_float_linear: WebGLExtension.OES_texture_half_float_linear
+    get() = unsafeCast("OES_texture_half_float_linear")
+
+inline val WebGLExtension.Companion.OES_vertex_array_object: WebGLExtension.OES_vertex_array_object
+    get() = unsafeCast("OES_vertex_array_object")
+
+inline val WebGLExtension.Companion.OVR_multiview2: WebGLExtension.OVR_multiview2
+    get() = unsafeCast("OVR_multiview2")
+
+inline val WebGLExtension.Companion.WEBGL_color_buffer_float: WebGLExtension.WEBGL_color_buffer_float
+    get() = unsafeCast("WEBGL_color_buffer_float")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_astc: WebGLExtension.WEBGL_compressed_texture_astc
+    get() = unsafeCast("WEBGL_compressed_texture_astc")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_etc: WebGLExtension.WEBGL_compressed_texture_etc
+    get() = unsafeCast("WEBGL_compressed_texture_etc")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_etc1: WebGLExtension.WEBGL_compressed_texture_etc1
+    get() = unsafeCast("WEBGL_compressed_texture_etc1")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_pvrtc: WebGLExtension.WEBGL_compressed_texture_pvrtc
+    get() = unsafeCast("WEBGL_compressed_texture_pvrtc")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_s3tc: WebGLExtension.WEBGL_compressed_texture_s3tc
+    get() = unsafeCast("WEBGL_compressed_texture_s3tc")
+
+inline val WebGLExtension.Companion.WEBGL_compressed_texture_s3tc_srgb: WebGLExtension.WEBGL_compressed_texture_s3tc_srgb
+    get() = unsafeCast("WEBGL_compressed_texture_s3tc_srgb")
+
+inline val WebGLExtension.Companion.WEBGL_debug_renderer_info: WebGLExtension.WEBGL_debug_renderer_info
+    get() = unsafeCast("WEBGL_debug_renderer_info")
+
+inline val WebGLExtension.Companion.WEBGL_debug_shaders: WebGLExtension.WEBGL_debug_shaders
+    get() = unsafeCast("WEBGL_debug_shaders")
+
+inline val WebGLExtension.Companion.WEBGL_depth_texture: WebGLExtension.WEBGL_depth_texture
+    get() = unsafeCast("WEBGL_depth_texture")
+
+inline val WebGLExtension.Companion.WEBGL_draw_buffers: WebGLExtension.WEBGL_draw_buffers
+    get() = unsafeCast("WEBGL_draw_buffers")
+
+inline val WebGLExtension.Companion.WEBGL_lose_context: WebGLExtension.WEBGL_lose_context
+    get() = unsafeCast("WEBGL_lose_context")
+
+inline val WebGLExtension.Companion.WEBGL_multi_draw: WebGLExtension.WEBGL_multi_draw
+    get() = unsafeCast("WEBGL_multi_draw")

--- a/kotlin-browser/src/commonMain/generated/web/gl/WebGLPowerPreference.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gl/WebGLPowerPreference.kt
@@ -6,17 +6,17 @@
 
 package web.gl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WebGLPowerPreference {
-    companion object {
-        @JsValue("default")
-        val default: WebGLPowerPreference
-
-        @JsValue("high-performance")
-        val highPerformance: WebGLPowerPreference
-
-        @JsValue("low-power")
-        val lowPower: WebGLPowerPreference
-    }
+    companion object
 }
+
+inline val WebGLPowerPreference.Companion.default: WebGLPowerPreference
+    get() = unsafeCast("default")
+
+inline val WebGLPowerPreference.Companion.highPerformance: WebGLPowerPreference
+    get() = unsafeCast("high-performance")
+
+inline val WebGLPowerPreference.Companion.lowPower: WebGLPowerPreference
+    get() = unsafeCast("low-power")

--- a/kotlin-browser/src/commonMain/generated/web/gl/WebGLRenderingContext.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gl/WebGLRenderingContext.kt
@@ -2,7 +2,7 @@
 
 package web.gl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.rendering.OffscreenRenderingContext
 import web.rendering.RenderingContext
 import web.rendering.RenderingContextId
@@ -313,8 +313,8 @@ protected /* private */ constructor() :
         val CONTEXT_LOST_WEBGL: GLenum
         val UNPACK_COLORSPACE_CONVERSION_WEBGL: GLenum
         val BROWSER_DEFAULT_WEBGL: GLenum
-
-        @JsValue("webgl")
-        val ID: RenderingContextId<WebGLRenderingContext, WebGLContextAttributes>
     }
 }
+
+inline val WebGLRenderingContext.Companion.ID: RenderingContextId<WebGLRenderingContext, WebGLContextAttributes>
+    get() = unsafeCast("webgl")

--- a/kotlin-browser/src/commonMain/generated/web/gpu/GPUCanvasContext.kt
+++ b/kotlin-browser/src/commonMain/generated/web/gpu/GPUCanvasContext.kt
@@ -2,7 +2,7 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.events.EventTarget
 import web.rendering.OffscreenRenderingContext
 import web.rendering.RenderingContext
@@ -37,8 +37,8 @@ private constructor() :
      */
     fun unconfigure()
 
-    companion object {
-        @JsValue("webgpu")
-        val ID: RenderingContextId<GPUCanvasContext, GPUCanvasConfiguration>
-    }
+    companion object
 }
+
+inline val GPUCanvasContext.Companion.ID: RenderingContextId<GPUCanvasContext, GPUCanvasConfiguration>
+    get() = unsafeCast("webgpu")

--- a/kotlin-browser/src/commonMain/generated/web/highlight/HighlightType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/highlight/HighlightType.kt
@@ -6,17 +6,17 @@
 
 package web.highlight
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface HighlightType {
-    companion object {
-        @JsValue("grammar-error")
-        val grammarError: HighlightType
-
-        @JsValue("highlight")
-        val highlight: HighlightType
-
-        @JsValue("spelling-error")
-        val spellingError: HighlightType
-    }
+    companion object
 }
+
+inline val HighlightType.Companion.grammarError: HighlightType
+    get() = unsafeCast("grammar-error")
+
+inline val HighlightType.Companion.highlight: HighlightType
+    get() = unsafeCast("highlight")
+
+inline val HighlightType.Companion.spellingError: HighlightType
+    get() = unsafeCast("spelling-error")

--- a/kotlin-browser/src/commonMain/generated/web/history/ScrollRestoration.kt
+++ b/kotlin-browser/src/commonMain/generated/web/history/ScrollRestoration.kt
@@ -6,14 +6,14 @@
 
 package web.history
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ScrollRestoration {
-    companion object {
-        @JsValue("auto")
-        val auto: ScrollRestoration
-
-        @JsValue("manual")
-        val manual: ScrollRestoration
-    }
+    companion object
 }
+
+inline val ScrollRestoration.Companion.auto: ScrollRestoration
+    get() = unsafeCast("auto")
+
+inline val ScrollRestoration.Companion.manual: ScrollRestoration
+    get() = unsafeCast("manual")

--- a/kotlin-browser/src/commonMain/generated/web/html/AutoCapitalize.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/AutoCapitalize.kt
@@ -6,26 +6,26 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoCapitalize {
-    companion object {
-        @JsValue("off")
-        val off: AutoCapitalize
-
-        @JsValue("none")
-        val none: AutoCapitalize
-
-        @JsValue("on")
-        val on: AutoCapitalize
-
-        @JsValue("sentences")
-        val sentences: AutoCapitalize
-
-        @JsValue("words")
-        val words: AutoCapitalize
-
-        @JsValue("characters")
-        val characters: AutoCapitalize
-    }
+    companion object
 }
+
+inline val AutoCapitalize.Companion.off: AutoCapitalize
+    get() = unsafeCast("off")
+
+inline val AutoCapitalize.Companion.none: AutoCapitalize
+    get() = unsafeCast("none")
+
+inline val AutoCapitalize.Companion.on: AutoCapitalize
+    get() = unsafeCast("on")
+
+inline val AutoCapitalize.Companion.sentences: AutoCapitalize
+    get() = unsafeCast("sentences")
+
+inline val AutoCapitalize.Companion.words: AutoCapitalize
+    get() = unsafeCast("words")
+
+inline val AutoCapitalize.Companion.characters: AutoCapitalize
+    get() = unsafeCast("characters")

--- a/kotlin-browser/src/commonMain/generated/web/html/Blocking.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/Blocking.kt
@@ -6,11 +6,11 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Blocking {
-    companion object {
-        @JsValue("render")
-        val render: Blocking
-    }
+    companion object
 }
+
+inline val Blocking.Companion.render: Blocking
+    get() = unsafeCast("render")

--- a/kotlin-browser/src/commonMain/generated/web/html/ButtonType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/ButtonType.kt
@@ -6,17 +6,17 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ButtonType {
-    companion object {
-        @JsValue("submit")
-        val submit: ButtonType
-
-        @JsValue("reset")
-        val reset: ButtonType
-
-        @JsValue("button")
-        val button: ButtonType
-    }
+    companion object
 }
+
+inline val ButtonType.Companion.submit: ButtonType
+    get() = unsafeCast("submit")
+
+inline val ButtonType.Companion.reset: ButtonType
+    get() = unsafeCast("reset")
+
+inline val ButtonType.Companion.button: ButtonType
+    get() = unsafeCast("button")

--- a/kotlin-browser/src/commonMain/generated/web/html/CanPlayTypeResult.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/CanPlayTypeResult.kt
@@ -6,17 +6,17 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CanPlayTypeResult {
-    companion object {
-        @JsValue("")
-        val none: CanPlayTypeResult
-
-        @JsValue("maybe")
-        val maybe: CanPlayTypeResult
-
-        @JsValue("probably")
-        val probably: CanPlayTypeResult
-    }
+    companion object
 }
+
+inline val CanPlayTypeResult.Companion.none: CanPlayTypeResult
+    get() = unsafeCast("")
+
+inline val CanPlayTypeResult.Companion.maybe: CanPlayTypeResult
+    get() = unsafeCast("maybe")
+
+inline val CanPlayTypeResult.Companion.probably: CanPlayTypeResult
+    get() = unsafeCast("probably")

--- a/kotlin-browser/src/commonMain/generated/web/html/EnterKeyHint.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/EnterKeyHint.kt
@@ -6,29 +6,29 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EnterKeyHint {
-    companion object {
-        @JsValue("enter")
-        val enter: EnterKeyHint
-
-        @JsValue("done")
-        val done: EnterKeyHint
-
-        @JsValue("go")
-        val go: EnterKeyHint
-
-        @JsValue("next")
-        val next: EnterKeyHint
-
-        @JsValue("previous")
-        val previous: EnterKeyHint
-
-        @JsValue("search")
-        val search: EnterKeyHint
-
-        @JsValue("send")
-        val send: EnterKeyHint
-    }
+    companion object
 }
+
+inline val EnterKeyHint.Companion.enter: EnterKeyHint
+    get() = unsafeCast("enter")
+
+inline val EnterKeyHint.Companion.done: EnterKeyHint
+    get() = unsafeCast("done")
+
+inline val EnterKeyHint.Companion.go: EnterKeyHint
+    get() = unsafeCast("go")
+
+inline val EnterKeyHint.Companion.next: EnterKeyHint
+    get() = unsafeCast("next")
+
+inline val EnterKeyHint.Companion.previous: EnterKeyHint
+    get() = unsafeCast("previous")
+
+inline val EnterKeyHint.Companion.search: EnterKeyHint
+    get() = unsafeCast("search")
+
+inline val EnterKeyHint.Companion.send: EnterKeyHint
+    get() = unsafeCast("send")

--- a/kotlin-browser/src/commonMain/generated/web/html/ImageDecoding.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/ImageDecoding.kt
@@ -6,17 +6,17 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ImageDecoding {
-    companion object {
-        @JsValue("async")
-        val async: ImageDecoding
-
-        @JsValue("sync")
-        val sync: ImageDecoding
-
-        @JsValue("auto")
-        val auto: ImageDecoding
-    }
+    companion object
 }
+
+inline val ImageDecoding.Companion.async: ImageDecoding
+    get() = unsafeCast("async")
+
+inline val ImageDecoding.Companion.sync: ImageDecoding
+    get() = unsafeCast("sync")
+
+inline val ImageDecoding.Companion.auto: ImageDecoding
+    get() = unsafeCast("auto")

--- a/kotlin-browser/src/commonMain/generated/web/html/InputMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/InputMode.kt
@@ -6,32 +6,32 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface InputMode {
-    companion object {
-        @JsValue("none")
-        val none: InputMode
-
-        @JsValue("text")
-        val text: InputMode
-
-        @JsValue("tel")
-        val tel: InputMode
-
-        @JsValue("url")
-        val url: InputMode
-
-        @JsValue("email")
-        val email: InputMode
-
-        @JsValue("numeric")
-        val numeric: InputMode
-
-        @JsValue("decimal")
-        val decimal: InputMode
-
-        @JsValue("search")
-        val search: InputMode
-    }
+    companion object
 }
+
+inline val InputMode.Companion.none: InputMode
+    get() = unsafeCast("none")
+
+inline val InputMode.Companion.text: InputMode
+    get() = unsafeCast("text")
+
+inline val InputMode.Companion.tel: InputMode
+    get() = unsafeCast("tel")
+
+inline val InputMode.Companion.url: InputMode
+    get() = unsafeCast("url")
+
+inline val InputMode.Companion.email: InputMode
+    get() = unsafeCast("email")
+
+inline val InputMode.Companion.numeric: InputMode
+    get() = unsafeCast("numeric")
+
+inline val InputMode.Companion.decimal: InputMode
+    get() = unsafeCast("decimal")
+
+inline val InputMode.Companion.search: InputMode
+    get() = unsafeCast("search")

--- a/kotlin-browser/src/commonMain/generated/web/html/InputType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/InputType.kt
@@ -6,74 +6,74 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface InputType {
-    companion object {
-        @JsValue("button")
-        val button: InputType
-
-        @JsValue("checkbox")
-        val checkbox: InputType
-
-        @JsValue("color")
-        val color: InputType
-
-        @JsValue("date")
-        val date: InputType
-
-        @JsValue("datetime-local")
-        val datetimeLocal: InputType
-
-        @JsValue("email")
-        val email: InputType
-
-        @JsValue("file")
-        val file: InputType
-
-        @JsValue("hidden")
-        val hidden: InputType
-
-        @JsValue("image")
-        val image: InputType
-
-        @JsValue("month")
-        val month: InputType
-
-        @JsValue("number")
-        val number: InputType
-
-        @JsValue("password")
-        val password: InputType
-
-        @JsValue("radio")
-        val radio: InputType
-
-        @JsValue("range")
-        val range: InputType
-
-        @JsValue("reset")
-        val reset: InputType
-
-        @JsValue("search")
-        val search: InputType
-
-        @JsValue("submit")
-        val submit: InputType
-
-        @JsValue("tel")
-        val tel: InputType
-
-        @JsValue("text")
-        val text: InputType
-
-        @JsValue("time")
-        val time: InputType
-
-        @JsValue("url")
-        val url: InputType
-
-        @JsValue("week")
-        val week: InputType
-    }
+    companion object
 }
+
+inline val InputType.Companion.button: InputType
+    get() = unsafeCast("button")
+
+inline val InputType.Companion.checkbox: InputType
+    get() = unsafeCast("checkbox")
+
+inline val InputType.Companion.color: InputType
+    get() = unsafeCast("color")
+
+inline val InputType.Companion.date: InputType
+    get() = unsafeCast("date")
+
+inline val InputType.Companion.datetimeLocal: InputType
+    get() = unsafeCast("datetime-local")
+
+inline val InputType.Companion.email: InputType
+    get() = unsafeCast("email")
+
+inline val InputType.Companion.file: InputType
+    get() = unsafeCast("file")
+
+inline val InputType.Companion.hidden: InputType
+    get() = unsafeCast("hidden")
+
+inline val InputType.Companion.image: InputType
+    get() = unsafeCast("image")
+
+inline val InputType.Companion.month: InputType
+    get() = unsafeCast("month")
+
+inline val InputType.Companion.number: InputType
+    get() = unsafeCast("number")
+
+inline val InputType.Companion.password: InputType
+    get() = unsafeCast("password")
+
+inline val InputType.Companion.radio: InputType
+    get() = unsafeCast("radio")
+
+inline val InputType.Companion.range: InputType
+    get() = unsafeCast("range")
+
+inline val InputType.Companion.reset: InputType
+    get() = unsafeCast("reset")
+
+inline val InputType.Companion.search: InputType
+    get() = unsafeCast("search")
+
+inline val InputType.Companion.submit: InputType
+    get() = unsafeCast("submit")
+
+inline val InputType.Companion.tel: InputType
+    get() = unsafeCast("tel")
+
+inline val InputType.Companion.text: InputType
+    get() = unsafeCast("text")
+
+inline val InputType.Companion.time: InputType
+    get() = unsafeCast("time")
+
+inline val InputType.Companion.url: InputType
+    get() = unsafeCast("url")
+
+inline val InputType.Companion.week: InputType
+    get() = unsafeCast("week")

--- a/kotlin-browser/src/commonMain/generated/web/html/Loading.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/Loading.kt
@@ -6,14 +6,14 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Loading {
-    companion object {
-        @JsValue("eager")
-        val eager: Loading
-
-        @JsValue("lazy")
-        val lazy: Loading
-    }
+    companion object
 }
+
+inline val Loading.Companion.eager: Loading
+    get() = unsafeCast("eager")
+
+inline val Loading.Companion.lazy: Loading
+    get() = unsafeCast("lazy")

--- a/kotlin-browser/src/commonMain/generated/web/html/Preload.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/Preload.kt
@@ -6,17 +6,17 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Preload {
-    companion object {
-        @JsValue("none")
-        val none: Preload
-
-        @JsValue("metadata")
-        val metadata: Preload
-
-        @JsValue("auto")
-        val auto: Preload
-    }
+    companion object
 }
+
+inline val Preload.Companion.none: Preload
+    get() = unsafeCast("none")
+
+inline val Preload.Companion.metadata: Preload
+    get() = unsafeCast("metadata")
+
+inline val Preload.Companion.auto: Preload
+    get() = unsafeCast("auto")

--- a/kotlin-browser/src/commonMain/generated/web/html/SelectType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/SelectType.kt
@@ -6,14 +6,14 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SelectType {
-    companion object {
-        @JsValue("select-one")
-        val selectOne: SelectType
-
-        @JsValue("select-multiple")
-        val selectMultiple: SelectType
-    }
+    companion object
 }
+
+inline val SelectType.Companion.selectOne: SelectType
+    get() = unsafeCast("select-one")
+
+inline val SelectType.Companion.selectMultiple: SelectType
+    get() = unsafeCast("select-multiple")

--- a/kotlin-browser/src/commonMain/generated/web/html/SelectionDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/SelectionDirection.kt
@@ -6,17 +6,17 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SelectionDirection {
-    companion object {
-        @JsValue("forward")
-        val forward: SelectionDirection
-
-        @JsValue("backward")
-        val backward: SelectionDirection
-
-        @JsValue("none")
-        val none: SelectionDirection
-    }
+    companion object
 }
+
+inline val SelectionDirection.Companion.forward: SelectionDirection
+    get() = unsafeCast("forward")
+
+inline val SelectionDirection.Companion.backward: SelectionDirection
+    get() = unsafeCast("backward")
+
+inline val SelectionDirection.Companion.none: SelectionDirection
+    get() = unsafeCast("none")

--- a/kotlin-browser/src/commonMain/generated/web/html/SelectionMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/html/SelectionMode.kt
@@ -6,20 +6,20 @@
 
 package web.html
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SelectionMode {
-    companion object {
-        @JsValue("end")
-        val end: SelectionMode
-
-        @JsValue("preserve")
-        val preserve: SelectionMode
-
-        @JsValue("select")
-        val select: SelectionMode
-
-        @JsValue("start")
-        val start: SelectionMode
-    }
+    companion object
 }
+
+inline val SelectionMode.Companion.end: SelectionMode
+    get() = unsafeCast("end")
+
+inline val SelectionMode.Companion.preserve: SelectionMode
+    get() = unsafeCast("preserve")
+
+inline val SelectionMode.Companion.select: SelectionMode
+    get() = unsafeCast("select")
+
+inline val SelectionMode.Companion.start: SelectionMode
+    get() = unsafeCast("start")

--- a/kotlin-browser/src/commonMain/generated/web/idb/IDBCursorDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/idb/IDBCursorDirection.kt
@@ -6,20 +6,20 @@
 
 package web.idb
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface IDBCursorDirection {
-    companion object {
-        @JsValue("next")
-        val next: IDBCursorDirection
-
-        @JsValue("nextunique")
-        val nextunique: IDBCursorDirection
-
-        @JsValue("prev")
-        val prev: IDBCursorDirection
-
-        @JsValue("prevunique")
-        val prevunique: IDBCursorDirection
-    }
+    companion object
 }
+
+inline val IDBCursorDirection.Companion.next: IDBCursorDirection
+    get() = unsafeCast("next")
+
+inline val IDBCursorDirection.Companion.nextunique: IDBCursorDirection
+    get() = unsafeCast("nextunique")
+
+inline val IDBCursorDirection.Companion.prev: IDBCursorDirection
+    get() = unsafeCast("prev")
+
+inline val IDBCursorDirection.Companion.prevunique: IDBCursorDirection
+    get() = unsafeCast("prevunique")

--- a/kotlin-browser/src/commonMain/generated/web/idb/IDBRequestReadyState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/idb/IDBRequestReadyState.kt
@@ -6,14 +6,14 @@
 
 package web.idb
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface IDBRequestReadyState {
-    companion object {
-        @JsValue("done")
-        val done: IDBRequestReadyState
-
-        @JsValue("pending")
-        val pending: IDBRequestReadyState
-    }
+    companion object
 }
+
+inline val IDBRequestReadyState.Companion.done: IDBRequestReadyState
+    get() = unsafeCast("done")
+
+inline val IDBRequestReadyState.Companion.pending: IDBRequestReadyState
+    get() = unsafeCast("pending")

--- a/kotlin-browser/src/commonMain/generated/web/idb/IDBTransactionDurability.kt
+++ b/kotlin-browser/src/commonMain/generated/web/idb/IDBTransactionDurability.kt
@@ -6,17 +6,17 @@
 
 package web.idb
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface IDBTransactionDurability {
-    companion object {
-        @JsValue("default")
-        val default: IDBTransactionDurability
-
-        @JsValue("relaxed")
-        val relaxed: IDBTransactionDurability
-
-        @JsValue("strict")
-        val strict: IDBTransactionDurability
-    }
+    companion object
 }
+
+inline val IDBTransactionDurability.Companion.default: IDBTransactionDurability
+    get() = unsafeCast("default")
+
+inline val IDBTransactionDurability.Companion.relaxed: IDBTransactionDurability
+    get() = unsafeCast("relaxed")
+
+inline val IDBTransactionDurability.Companion.strict: IDBTransactionDurability
+    get() = unsafeCast("strict")

--- a/kotlin-browser/src/commonMain/generated/web/idb/IDBTransactionMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/idb/IDBTransactionMode.kt
@@ -6,17 +6,17 @@
 
 package web.idb
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface IDBTransactionMode {
-    companion object {
-        @JsValue("readonly")
-        val readonly: IDBTransactionMode
-
-        @JsValue("readwrite")
-        val readwrite: IDBTransactionMode
-
-        @JsValue("versionchange")
-        val versionchange: IDBTransactionMode
-    }
+    companion object
 }
+
+inline val IDBTransactionMode.Companion.readonly: IDBTransactionMode
+    get() = unsafeCast("readonly")
+
+inline val IDBTransactionMode.Companion.readwrite: IDBTransactionMode
+    get() = unsafeCast("readwrite")
+
+inline val IDBTransactionMode.Companion.versionchange: IDBTransactionMode
+    get() = unsafeCast("versionchange")

--- a/kotlin-browser/src/commonMain/generated/web/imagecapture/FillLightMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/imagecapture/FillLightMode.kt
@@ -6,17 +6,17 @@
 
 package web.imagecapture
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FillLightMode {
-    companion object {
-        @JsValue("auto")
-        val auto: FillLightMode
-
-        @JsValue("flash")
-        val flash: FillLightMode
-
-        @JsValue("off")
-        val off: FillLightMode
-    }
+    companion object
 }
+
+inline val FillLightMode.Companion.auto: FillLightMode
+    get() = unsafeCast("auto")
+
+inline val FillLightMode.Companion.flash: FillLightMode
+    get() = unsafeCast("flash")
+
+inline val FillLightMode.Companion.off: FillLightMode
+    get() = unsafeCast("off")

--- a/kotlin-browser/src/commonMain/generated/web/imagecapture/RedEyeReduction.kt
+++ b/kotlin-browser/src/commonMain/generated/web/imagecapture/RedEyeReduction.kt
@@ -6,17 +6,17 @@
 
 package web.imagecapture
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RedEyeReduction {
-    companion object {
-        @JsValue("always")
-        val always: RedEyeReduction
-
-        @JsValue("controllable")
-        val controllable: RedEyeReduction
-
-        @JsValue("never")
-        val never: RedEyeReduction
-    }
+    companion object
 }
+
+inline val RedEyeReduction.Companion.always: RedEyeReduction
+    get() = unsafeCast("always")
+
+inline val RedEyeReduction.Companion.controllable: RedEyeReduction
+    get() = unsafeCast("controllable")
+
+inline val RedEyeReduction.Companion.never: RedEyeReduction
+    get() = unsafeCast("never")

--- a/kotlin-browser/src/commonMain/generated/web/images/ImageBitmapRenderingContext.kt
+++ b/kotlin-browser/src/commonMain/generated/web/images/ImageBitmapRenderingContext.kt
@@ -2,7 +2,7 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 import web.events.EventTarget
 import web.rendering.OffscreenRenderingContext
 import web.rendering.RenderingContext
@@ -31,8 +31,8 @@ private constructor() :
      */
     fun transferFromImageBitmap(bitmap: ImageBitmap?)
 
-    companion object {
-        @JsValue("bitmaprenderer")
-        val ID: RenderingContextId<ImageBitmapRenderingContext, ImageBitmapRenderingContextSettings>
-    }
+    companion object
 }
+
+inline val ImageBitmapRenderingContext.Companion.ID: RenderingContextId<ImageBitmapRenderingContext, ImageBitmapRenderingContextSettings>
+    get() = unsafeCast("bitmaprenderer")

--- a/kotlin-browser/src/commonMain/generated/web/keyboard/KeyCode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/keyboard/KeyCode.kt
@@ -6,494 +6,494 @@
 
 package web.keyboard
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface KeyCode {
-    companion object {
-        @JsValue("Backquote")
-        val Backquote: KeyCode
-
-        @JsValue("Backslash")
-        val Backslash: KeyCode
-
-        @JsValue("Backspace")
-        val Backspace: KeyCode
-
-        @JsValue("BracketLeft")
-        val BracketLeft: KeyCode
-
-        @JsValue("BracketRight")
-        val BracketRight: KeyCode
-
-        @JsValue("Comma")
-        val Comma: KeyCode
-
-        @JsValue("Digit0")
-        val Digit0: KeyCode
-
-        @JsValue("Digit1")
-        val Digit1: KeyCode
-
-        @JsValue("Digit2")
-        val Digit2: KeyCode
-
-        @JsValue("Digit3")
-        val Digit3: KeyCode
-
-        @JsValue("Digit4")
-        val Digit4: KeyCode
-
-        @JsValue("Digit5")
-        val Digit5: KeyCode
-
-        @JsValue("Digit6")
-        val Digit6: KeyCode
-
-        @JsValue("Digit7")
-        val Digit7: KeyCode
-
-        @JsValue("Digit8")
-        val Digit8: KeyCode
-
-        @JsValue("Digit9")
-        val Digit9: KeyCode
-
-        @JsValue("Equal")
-        val Equal: KeyCode
-
-        @JsValue("IntlBackslash")
-        val IntlBackslash: KeyCode
-
-        @JsValue("IntlRo")
-        val IntlRo: KeyCode
-
-        @JsValue("IntlYen")
-        val IntlYen: KeyCode
-
-        @JsValue("KeyA")
-        val KeyA: KeyCode
-
-        @JsValue("KeyB")
-        val KeyB: KeyCode
-
-        @JsValue("KeyC")
-        val KeyC: KeyCode
-
-        @JsValue("KeyD")
-        val KeyD: KeyCode
-
-        @JsValue("KeyE")
-        val KeyE: KeyCode
-
-        @JsValue("KeyF")
-        val KeyF: KeyCode
-
-        @JsValue("KeyG")
-        val KeyG: KeyCode
-
-        @JsValue("KeyH")
-        val KeyH: KeyCode
-
-        @JsValue("KeyI")
-        val KeyI: KeyCode
-
-        @JsValue("KeyJ")
-        val KeyJ: KeyCode
-
-        @JsValue("KeyK")
-        val KeyK: KeyCode
-
-        @JsValue("KeyL")
-        val KeyL: KeyCode
-
-        @JsValue("KeyM")
-        val KeyM: KeyCode
-
-        @JsValue("KeyN")
-        val KeyN: KeyCode
-
-        @JsValue("KeyO")
-        val KeyO: KeyCode
-
-        @JsValue("KeyP")
-        val KeyP: KeyCode
-
-        @JsValue("KeyQ")
-        val KeyQ: KeyCode
-
-        @JsValue("KeyR")
-        val KeyR: KeyCode
-
-        @JsValue("KeyS")
-        val KeyS: KeyCode
-
-        @JsValue("KeyT")
-        val KeyT: KeyCode
-
-        @JsValue("KeyU")
-        val KeyU: KeyCode
-
-        @JsValue("KeyV")
-        val KeyV: KeyCode
-
-        @JsValue("KeyW")
-        val KeyW: KeyCode
-
-        @JsValue("KeyX")
-        val KeyX: KeyCode
-
-        @JsValue("KeyY")
-        val KeyY: KeyCode
-
-        @JsValue("KeyZ")
-        val KeyZ: KeyCode
-
-        @JsValue("Minus")
-        val Minus: KeyCode
-
-        @JsValue("Period")
-        val Period: KeyCode
-
-        @JsValue("Quote")
-        val Quote: KeyCode
-
-        @JsValue("Semicolon")
-        val Semicolon: KeyCode
-
-        @JsValue("Slash")
-        val Slash: KeyCode
-
-        @JsValue("AltLeft")
-        val AltLeft: KeyCode
-
-        @JsValue("AltRight")
-        val AltRight: KeyCode
-
-        @JsValue("CapsLock")
-        val CapsLock: KeyCode
-
-        @JsValue("ContextMenu")
-        val ContextMenu: KeyCode
-
-        @JsValue("ControlLeft")
-        val ControlLeft: KeyCode
-
-        @JsValue("ControlRight")
-        val ControlRight: KeyCode
-
-        @JsValue("Enter")
-        val Enter: KeyCode
-
-        @JsValue("MetaLeft")
-        val MetaLeft: KeyCode
-
-        @JsValue("MetaRight")
-        val MetaRight: KeyCode
-
-        @JsValue("ShiftLeft")
-        val ShiftLeft: KeyCode
-
-        @JsValue("ShiftRight")
-        val ShiftRight: KeyCode
-
-        @JsValue("Space")
-        val Space: KeyCode
-
-        @JsValue("Tab")
-        val Tab: KeyCode
-
-        @JsValue("Convert")
-        val Convert: KeyCode
-
-        @JsValue("KanaMode")
-        val KanaMode: KeyCode
-
-        @JsValue("Lang1")
-        val Lang1: KeyCode
-
-        @JsValue("Lang2")
-        val Lang2: KeyCode
-
-        @JsValue("Lang3")
-        val Lang3: KeyCode
-
-        @JsValue("Lang4")
-        val Lang4: KeyCode
-
-        @JsValue("Lang5")
-        val Lang5: KeyCode
-
-        @JsValue("NonConvert")
-        val NonConvert: KeyCode
-
-        @JsValue("OSLeft")
-        val OSLeft: KeyCode
-
-        @JsValue("OSRight")
-        val OSRight: KeyCode
-
-        @JsValue("Delete")
-        val Delete: KeyCode
-
-        @JsValue("End")
-        val End: KeyCode
-
-        @JsValue("Help")
-        val Help: KeyCode
-
-        @JsValue("Home")
-        val Home: KeyCode
-
-        @JsValue("Insert")
-        val Insert: KeyCode
-
-        @JsValue("PageDown")
-        val PageDown: KeyCode
-
-        @JsValue("PageUp")
-        val PageUp: KeyCode
-
-        @JsValue("ArrowDown")
-        val ArrowDown: KeyCode
-
-        @JsValue("ArrowLeft")
-        val ArrowLeft: KeyCode
-
-        @JsValue("ArrowRight")
-        val ArrowRight: KeyCode
-
-        @JsValue("ArrowUp")
-        val ArrowUp: KeyCode
-
-        @JsValue("NumLock")
-        val NumLock: KeyCode
-
-        @JsValue("Numpad0")
-        val Numpad0: KeyCode
-
-        @JsValue("Numpad1")
-        val Numpad1: KeyCode
-
-        @JsValue("Numpad2")
-        val Numpad2: KeyCode
-
-        @JsValue("Numpad3")
-        val Numpad3: KeyCode
-
-        @JsValue("Numpad4")
-        val Numpad4: KeyCode
-
-        @JsValue("Numpad5")
-        val Numpad5: KeyCode
-
-        @JsValue("Numpad6")
-        val Numpad6: KeyCode
-
-        @JsValue("Numpad7")
-        val Numpad7: KeyCode
-
-        @JsValue("Numpad8")
-        val Numpad8: KeyCode
-
-        @JsValue("Numpad9")
-        val Numpad9: KeyCode
-
-        @JsValue("NumpadAdd")
-        val NumpadAdd: KeyCode
-
-        @JsValue("NumpadBackspace")
-        val NumpadBackspace: KeyCode
-
-        @JsValue("NumpadClear")
-        val NumpadClear: KeyCode
-
-        @JsValue("NumpadClearEntry")
-        val NumpadClearEntry: KeyCode
-
-        @JsValue("NumpadComma")
-        val NumpadComma: KeyCode
-
-        @JsValue("NumpadDecimal")
-        val NumpadDecimal: KeyCode
-
-        @JsValue("NumpadDivide")
-        val NumpadDivide: KeyCode
-
-        @JsValue("NumpadEnter")
-        val NumpadEnter: KeyCode
-
-        @JsValue("NumpadEqual")
-        val NumpadEqual: KeyCode
-
-        @JsValue("NumpadHash")
-        val NumpadHash: KeyCode
-
-        @JsValue("NumpadMemoryAdd")
-        val NumpadMemoryAdd: KeyCode
-
-        @JsValue("NumpadMemoryClear")
-        val NumpadMemoryClear: KeyCode
-
-        @JsValue("NumpadMemoryRecall")
-        val NumpadMemoryRecall: KeyCode
-
-        @JsValue("NumpadMemoryStore")
-        val NumpadMemoryStore: KeyCode
-
-        @JsValue("NumpadMemorySubtract")
-        val NumpadMemorySubtract: KeyCode
-
-        @JsValue("NumpadMultiply")
-        val NumpadMultiply: KeyCode
-
-        @JsValue("NumpadParenLeft")
-        val NumpadParenLeft: KeyCode
-
-        @JsValue("NumpadParenRight")
-        val NumpadParenRight: KeyCode
-
-        @JsValue("NumpadStar")
-        val NumpadStar: KeyCode
-
-        @JsValue("NumpadSubtract")
-        val NumpadSubtract: KeyCode
-
-        @JsValue("Escape")
-        val Escape: KeyCode
-
-        @JsValue("F1")
-        val F1: KeyCode
-
-        @JsValue("F2")
-        val F2: KeyCode
-
-        @JsValue("F3")
-        val F3: KeyCode
-
-        @JsValue("F4")
-        val F4: KeyCode
-
-        @JsValue("F5")
-        val F5: KeyCode
-
-        @JsValue("F6")
-        val F6: KeyCode
-
-        @JsValue("F7")
-        val F7: KeyCode
-
-        @JsValue("F8")
-        val F8: KeyCode
-
-        @JsValue("F9")
-        val F9: KeyCode
-
-        @JsValue("F10")
-        val F10: KeyCode
-
-        @JsValue("F11")
-        val F11: KeyCode
-
-        @JsValue("F12")
-        val F12: KeyCode
-
-        @JsValue("F13")
-        val F13: KeyCode
-
-        @JsValue("F14")
-        val F14: KeyCode
-
-        @JsValue("F15")
-        val F15: KeyCode
-
-        @JsValue("Fn")
-        val Fn: KeyCode
-
-        @JsValue("FnLock")
-        val FnLock: KeyCode
-
-        @JsValue("PrintScreen")
-        val PrintScreen: KeyCode
-
-        @JsValue("ScrollLock")
-        val ScrollLock: KeyCode
-
-        @JsValue("Pause")
-        val Pause: KeyCode
-
-        @JsValue("BrowserBack")
-        val BrowserBack: KeyCode
-
-        @JsValue("BrowserFavorites")
-        val BrowserFavorites: KeyCode
-
-        @JsValue("BrowserForward")
-        val BrowserForward: KeyCode
-
-        @JsValue("BrowserHome")
-        val BrowserHome: KeyCode
-
-        @JsValue("BrowserRefresh")
-        val BrowserRefresh: KeyCode
-
-        @JsValue("BrowserSearch")
-        val BrowserSearch: KeyCode
-
-        @JsValue("BrowserStop")
-        val BrowserStop: KeyCode
-
-        @JsValue("Eject")
-        val Eject: KeyCode
-
-        @JsValue("LaunchApp1")
-        val LaunchApp1: KeyCode
-
-        @JsValue("LaunchApp2")
-        val LaunchApp2: KeyCode
-
-        @JsValue("LaunchMail")
-        val LaunchMail: KeyCode
-
-        @JsValue("MediaPlayPause")
-        val MediaPlayPause: KeyCode
-
-        @JsValue("MediaSelect")
-        val MediaSelect: KeyCode
-
-        @JsValue("MediaStop")
-        val MediaStop: KeyCode
-
-        @JsValue("MediaTrackNext")
-        val MediaTrackNext: KeyCode
-
-        @JsValue("MediaTrackPrevious")
-        val MediaTrackPrevious: KeyCode
-
-        @JsValue("Power")
-        val Power: KeyCode
-
-        @JsValue("Sleep")
-        val Sleep: KeyCode
-
-        @JsValue("AudioVolumeDown")
-        val AudioVolumeDown: KeyCode
-
-        @JsValue("AudioVolumeMute")
-        val AudioVolumeMute: KeyCode
-
-        @JsValue("AudioVolumeUp")
-        val AudioVolumeUp: KeyCode
-
-        @JsValue("WakeUp")
-        val WakeUp: KeyCode
-
-        @JsValue("Hiragana")
-        val Hiragana: KeyCode
-
-        @JsValue("Katakana")
-        val Katakana: KeyCode
-
-        @JsValue("Unidentified")
-        val Unidentified: KeyCode
-    }
+    companion object
 }
+
+inline val KeyCode.Companion.Backquote: KeyCode
+    get() = unsafeCast("Backquote")
+
+inline val KeyCode.Companion.Backslash: KeyCode
+    get() = unsafeCast("Backslash")
+
+inline val KeyCode.Companion.Backspace: KeyCode
+    get() = unsafeCast("Backspace")
+
+inline val KeyCode.Companion.BracketLeft: KeyCode
+    get() = unsafeCast("BracketLeft")
+
+inline val KeyCode.Companion.BracketRight: KeyCode
+    get() = unsafeCast("BracketRight")
+
+inline val KeyCode.Companion.Comma: KeyCode
+    get() = unsafeCast("Comma")
+
+inline val KeyCode.Companion.Digit0: KeyCode
+    get() = unsafeCast("Digit0")
+
+inline val KeyCode.Companion.Digit1: KeyCode
+    get() = unsafeCast("Digit1")
+
+inline val KeyCode.Companion.Digit2: KeyCode
+    get() = unsafeCast("Digit2")
+
+inline val KeyCode.Companion.Digit3: KeyCode
+    get() = unsafeCast("Digit3")
+
+inline val KeyCode.Companion.Digit4: KeyCode
+    get() = unsafeCast("Digit4")
+
+inline val KeyCode.Companion.Digit5: KeyCode
+    get() = unsafeCast("Digit5")
+
+inline val KeyCode.Companion.Digit6: KeyCode
+    get() = unsafeCast("Digit6")
+
+inline val KeyCode.Companion.Digit7: KeyCode
+    get() = unsafeCast("Digit7")
+
+inline val KeyCode.Companion.Digit8: KeyCode
+    get() = unsafeCast("Digit8")
+
+inline val KeyCode.Companion.Digit9: KeyCode
+    get() = unsafeCast("Digit9")
+
+inline val KeyCode.Companion.Equal: KeyCode
+    get() = unsafeCast("Equal")
+
+inline val KeyCode.Companion.IntlBackslash: KeyCode
+    get() = unsafeCast("IntlBackslash")
+
+inline val KeyCode.Companion.IntlRo: KeyCode
+    get() = unsafeCast("IntlRo")
+
+inline val KeyCode.Companion.IntlYen: KeyCode
+    get() = unsafeCast("IntlYen")
+
+inline val KeyCode.Companion.KeyA: KeyCode
+    get() = unsafeCast("KeyA")
+
+inline val KeyCode.Companion.KeyB: KeyCode
+    get() = unsafeCast("KeyB")
+
+inline val KeyCode.Companion.KeyC: KeyCode
+    get() = unsafeCast("KeyC")
+
+inline val KeyCode.Companion.KeyD: KeyCode
+    get() = unsafeCast("KeyD")
+
+inline val KeyCode.Companion.KeyE: KeyCode
+    get() = unsafeCast("KeyE")
+
+inline val KeyCode.Companion.KeyF: KeyCode
+    get() = unsafeCast("KeyF")
+
+inline val KeyCode.Companion.KeyG: KeyCode
+    get() = unsafeCast("KeyG")
+
+inline val KeyCode.Companion.KeyH: KeyCode
+    get() = unsafeCast("KeyH")
+
+inline val KeyCode.Companion.KeyI: KeyCode
+    get() = unsafeCast("KeyI")
+
+inline val KeyCode.Companion.KeyJ: KeyCode
+    get() = unsafeCast("KeyJ")
+
+inline val KeyCode.Companion.KeyK: KeyCode
+    get() = unsafeCast("KeyK")
+
+inline val KeyCode.Companion.KeyL: KeyCode
+    get() = unsafeCast("KeyL")
+
+inline val KeyCode.Companion.KeyM: KeyCode
+    get() = unsafeCast("KeyM")
+
+inline val KeyCode.Companion.KeyN: KeyCode
+    get() = unsafeCast("KeyN")
+
+inline val KeyCode.Companion.KeyO: KeyCode
+    get() = unsafeCast("KeyO")
+
+inline val KeyCode.Companion.KeyP: KeyCode
+    get() = unsafeCast("KeyP")
+
+inline val KeyCode.Companion.KeyQ: KeyCode
+    get() = unsafeCast("KeyQ")
+
+inline val KeyCode.Companion.KeyR: KeyCode
+    get() = unsafeCast("KeyR")
+
+inline val KeyCode.Companion.KeyS: KeyCode
+    get() = unsafeCast("KeyS")
+
+inline val KeyCode.Companion.KeyT: KeyCode
+    get() = unsafeCast("KeyT")
+
+inline val KeyCode.Companion.KeyU: KeyCode
+    get() = unsafeCast("KeyU")
+
+inline val KeyCode.Companion.KeyV: KeyCode
+    get() = unsafeCast("KeyV")
+
+inline val KeyCode.Companion.KeyW: KeyCode
+    get() = unsafeCast("KeyW")
+
+inline val KeyCode.Companion.KeyX: KeyCode
+    get() = unsafeCast("KeyX")
+
+inline val KeyCode.Companion.KeyY: KeyCode
+    get() = unsafeCast("KeyY")
+
+inline val KeyCode.Companion.KeyZ: KeyCode
+    get() = unsafeCast("KeyZ")
+
+inline val KeyCode.Companion.Minus: KeyCode
+    get() = unsafeCast("Minus")
+
+inline val KeyCode.Companion.Period: KeyCode
+    get() = unsafeCast("Period")
+
+inline val KeyCode.Companion.Quote: KeyCode
+    get() = unsafeCast("Quote")
+
+inline val KeyCode.Companion.Semicolon: KeyCode
+    get() = unsafeCast("Semicolon")
+
+inline val KeyCode.Companion.Slash: KeyCode
+    get() = unsafeCast("Slash")
+
+inline val KeyCode.Companion.AltLeft: KeyCode
+    get() = unsafeCast("AltLeft")
+
+inline val KeyCode.Companion.AltRight: KeyCode
+    get() = unsafeCast("AltRight")
+
+inline val KeyCode.Companion.CapsLock: KeyCode
+    get() = unsafeCast("CapsLock")
+
+inline val KeyCode.Companion.ContextMenu: KeyCode
+    get() = unsafeCast("ContextMenu")
+
+inline val KeyCode.Companion.ControlLeft: KeyCode
+    get() = unsafeCast("ControlLeft")
+
+inline val KeyCode.Companion.ControlRight: KeyCode
+    get() = unsafeCast("ControlRight")
+
+inline val KeyCode.Companion.Enter: KeyCode
+    get() = unsafeCast("Enter")
+
+inline val KeyCode.Companion.MetaLeft: KeyCode
+    get() = unsafeCast("MetaLeft")
+
+inline val KeyCode.Companion.MetaRight: KeyCode
+    get() = unsafeCast("MetaRight")
+
+inline val KeyCode.Companion.ShiftLeft: KeyCode
+    get() = unsafeCast("ShiftLeft")
+
+inline val KeyCode.Companion.ShiftRight: KeyCode
+    get() = unsafeCast("ShiftRight")
+
+inline val KeyCode.Companion.Space: KeyCode
+    get() = unsafeCast("Space")
+
+inline val KeyCode.Companion.Tab: KeyCode
+    get() = unsafeCast("Tab")
+
+inline val KeyCode.Companion.Convert: KeyCode
+    get() = unsafeCast("Convert")
+
+inline val KeyCode.Companion.KanaMode: KeyCode
+    get() = unsafeCast("KanaMode")
+
+inline val KeyCode.Companion.Lang1: KeyCode
+    get() = unsafeCast("Lang1")
+
+inline val KeyCode.Companion.Lang2: KeyCode
+    get() = unsafeCast("Lang2")
+
+inline val KeyCode.Companion.Lang3: KeyCode
+    get() = unsafeCast("Lang3")
+
+inline val KeyCode.Companion.Lang4: KeyCode
+    get() = unsafeCast("Lang4")
+
+inline val KeyCode.Companion.Lang5: KeyCode
+    get() = unsafeCast("Lang5")
+
+inline val KeyCode.Companion.NonConvert: KeyCode
+    get() = unsafeCast("NonConvert")
+
+inline val KeyCode.Companion.OSLeft: KeyCode
+    get() = unsafeCast("OSLeft")
+
+inline val KeyCode.Companion.OSRight: KeyCode
+    get() = unsafeCast("OSRight")
+
+inline val KeyCode.Companion.Delete: KeyCode
+    get() = unsafeCast("Delete")
+
+inline val KeyCode.Companion.End: KeyCode
+    get() = unsafeCast("End")
+
+inline val KeyCode.Companion.Help: KeyCode
+    get() = unsafeCast("Help")
+
+inline val KeyCode.Companion.Home: KeyCode
+    get() = unsafeCast("Home")
+
+inline val KeyCode.Companion.Insert: KeyCode
+    get() = unsafeCast("Insert")
+
+inline val KeyCode.Companion.PageDown: KeyCode
+    get() = unsafeCast("PageDown")
+
+inline val KeyCode.Companion.PageUp: KeyCode
+    get() = unsafeCast("PageUp")
+
+inline val KeyCode.Companion.ArrowDown: KeyCode
+    get() = unsafeCast("ArrowDown")
+
+inline val KeyCode.Companion.ArrowLeft: KeyCode
+    get() = unsafeCast("ArrowLeft")
+
+inline val KeyCode.Companion.ArrowRight: KeyCode
+    get() = unsafeCast("ArrowRight")
+
+inline val KeyCode.Companion.ArrowUp: KeyCode
+    get() = unsafeCast("ArrowUp")
+
+inline val KeyCode.Companion.NumLock: KeyCode
+    get() = unsafeCast("NumLock")
+
+inline val KeyCode.Companion.Numpad0: KeyCode
+    get() = unsafeCast("Numpad0")
+
+inline val KeyCode.Companion.Numpad1: KeyCode
+    get() = unsafeCast("Numpad1")
+
+inline val KeyCode.Companion.Numpad2: KeyCode
+    get() = unsafeCast("Numpad2")
+
+inline val KeyCode.Companion.Numpad3: KeyCode
+    get() = unsafeCast("Numpad3")
+
+inline val KeyCode.Companion.Numpad4: KeyCode
+    get() = unsafeCast("Numpad4")
+
+inline val KeyCode.Companion.Numpad5: KeyCode
+    get() = unsafeCast("Numpad5")
+
+inline val KeyCode.Companion.Numpad6: KeyCode
+    get() = unsafeCast("Numpad6")
+
+inline val KeyCode.Companion.Numpad7: KeyCode
+    get() = unsafeCast("Numpad7")
+
+inline val KeyCode.Companion.Numpad8: KeyCode
+    get() = unsafeCast("Numpad8")
+
+inline val KeyCode.Companion.Numpad9: KeyCode
+    get() = unsafeCast("Numpad9")
+
+inline val KeyCode.Companion.NumpadAdd: KeyCode
+    get() = unsafeCast("NumpadAdd")
+
+inline val KeyCode.Companion.NumpadBackspace: KeyCode
+    get() = unsafeCast("NumpadBackspace")
+
+inline val KeyCode.Companion.NumpadClear: KeyCode
+    get() = unsafeCast("NumpadClear")
+
+inline val KeyCode.Companion.NumpadClearEntry: KeyCode
+    get() = unsafeCast("NumpadClearEntry")
+
+inline val KeyCode.Companion.NumpadComma: KeyCode
+    get() = unsafeCast("NumpadComma")
+
+inline val KeyCode.Companion.NumpadDecimal: KeyCode
+    get() = unsafeCast("NumpadDecimal")
+
+inline val KeyCode.Companion.NumpadDivide: KeyCode
+    get() = unsafeCast("NumpadDivide")
+
+inline val KeyCode.Companion.NumpadEnter: KeyCode
+    get() = unsafeCast("NumpadEnter")
+
+inline val KeyCode.Companion.NumpadEqual: KeyCode
+    get() = unsafeCast("NumpadEqual")
+
+inline val KeyCode.Companion.NumpadHash: KeyCode
+    get() = unsafeCast("NumpadHash")
+
+inline val KeyCode.Companion.NumpadMemoryAdd: KeyCode
+    get() = unsafeCast("NumpadMemoryAdd")
+
+inline val KeyCode.Companion.NumpadMemoryClear: KeyCode
+    get() = unsafeCast("NumpadMemoryClear")
+
+inline val KeyCode.Companion.NumpadMemoryRecall: KeyCode
+    get() = unsafeCast("NumpadMemoryRecall")
+
+inline val KeyCode.Companion.NumpadMemoryStore: KeyCode
+    get() = unsafeCast("NumpadMemoryStore")
+
+inline val KeyCode.Companion.NumpadMemorySubtract: KeyCode
+    get() = unsafeCast("NumpadMemorySubtract")
+
+inline val KeyCode.Companion.NumpadMultiply: KeyCode
+    get() = unsafeCast("NumpadMultiply")
+
+inline val KeyCode.Companion.NumpadParenLeft: KeyCode
+    get() = unsafeCast("NumpadParenLeft")
+
+inline val KeyCode.Companion.NumpadParenRight: KeyCode
+    get() = unsafeCast("NumpadParenRight")
+
+inline val KeyCode.Companion.NumpadStar: KeyCode
+    get() = unsafeCast("NumpadStar")
+
+inline val KeyCode.Companion.NumpadSubtract: KeyCode
+    get() = unsafeCast("NumpadSubtract")
+
+inline val KeyCode.Companion.Escape: KeyCode
+    get() = unsafeCast("Escape")
+
+inline val KeyCode.Companion.F1: KeyCode
+    get() = unsafeCast("F1")
+
+inline val KeyCode.Companion.F2: KeyCode
+    get() = unsafeCast("F2")
+
+inline val KeyCode.Companion.F3: KeyCode
+    get() = unsafeCast("F3")
+
+inline val KeyCode.Companion.F4: KeyCode
+    get() = unsafeCast("F4")
+
+inline val KeyCode.Companion.F5: KeyCode
+    get() = unsafeCast("F5")
+
+inline val KeyCode.Companion.F6: KeyCode
+    get() = unsafeCast("F6")
+
+inline val KeyCode.Companion.F7: KeyCode
+    get() = unsafeCast("F7")
+
+inline val KeyCode.Companion.F8: KeyCode
+    get() = unsafeCast("F8")
+
+inline val KeyCode.Companion.F9: KeyCode
+    get() = unsafeCast("F9")
+
+inline val KeyCode.Companion.F10: KeyCode
+    get() = unsafeCast("F10")
+
+inline val KeyCode.Companion.F11: KeyCode
+    get() = unsafeCast("F11")
+
+inline val KeyCode.Companion.F12: KeyCode
+    get() = unsafeCast("F12")
+
+inline val KeyCode.Companion.F13: KeyCode
+    get() = unsafeCast("F13")
+
+inline val KeyCode.Companion.F14: KeyCode
+    get() = unsafeCast("F14")
+
+inline val KeyCode.Companion.F15: KeyCode
+    get() = unsafeCast("F15")
+
+inline val KeyCode.Companion.Fn: KeyCode
+    get() = unsafeCast("Fn")
+
+inline val KeyCode.Companion.FnLock: KeyCode
+    get() = unsafeCast("FnLock")
+
+inline val KeyCode.Companion.PrintScreen: KeyCode
+    get() = unsafeCast("PrintScreen")
+
+inline val KeyCode.Companion.ScrollLock: KeyCode
+    get() = unsafeCast("ScrollLock")
+
+inline val KeyCode.Companion.Pause: KeyCode
+    get() = unsafeCast("Pause")
+
+inline val KeyCode.Companion.BrowserBack: KeyCode
+    get() = unsafeCast("BrowserBack")
+
+inline val KeyCode.Companion.BrowserFavorites: KeyCode
+    get() = unsafeCast("BrowserFavorites")
+
+inline val KeyCode.Companion.BrowserForward: KeyCode
+    get() = unsafeCast("BrowserForward")
+
+inline val KeyCode.Companion.BrowserHome: KeyCode
+    get() = unsafeCast("BrowserHome")
+
+inline val KeyCode.Companion.BrowserRefresh: KeyCode
+    get() = unsafeCast("BrowserRefresh")
+
+inline val KeyCode.Companion.BrowserSearch: KeyCode
+    get() = unsafeCast("BrowserSearch")
+
+inline val KeyCode.Companion.BrowserStop: KeyCode
+    get() = unsafeCast("BrowserStop")
+
+inline val KeyCode.Companion.Eject: KeyCode
+    get() = unsafeCast("Eject")
+
+inline val KeyCode.Companion.LaunchApp1: KeyCode
+    get() = unsafeCast("LaunchApp1")
+
+inline val KeyCode.Companion.LaunchApp2: KeyCode
+    get() = unsafeCast("LaunchApp2")
+
+inline val KeyCode.Companion.LaunchMail: KeyCode
+    get() = unsafeCast("LaunchMail")
+
+inline val KeyCode.Companion.MediaPlayPause: KeyCode
+    get() = unsafeCast("MediaPlayPause")
+
+inline val KeyCode.Companion.MediaSelect: KeyCode
+    get() = unsafeCast("MediaSelect")
+
+inline val KeyCode.Companion.MediaStop: KeyCode
+    get() = unsafeCast("MediaStop")
+
+inline val KeyCode.Companion.MediaTrackNext: KeyCode
+    get() = unsafeCast("MediaTrackNext")
+
+inline val KeyCode.Companion.MediaTrackPrevious: KeyCode
+    get() = unsafeCast("MediaTrackPrevious")
+
+inline val KeyCode.Companion.Power: KeyCode
+    get() = unsafeCast("Power")
+
+inline val KeyCode.Companion.Sleep: KeyCode
+    get() = unsafeCast("Sleep")
+
+inline val KeyCode.Companion.AudioVolumeDown: KeyCode
+    get() = unsafeCast("AudioVolumeDown")
+
+inline val KeyCode.Companion.AudioVolumeMute: KeyCode
+    get() = unsafeCast("AudioVolumeMute")
+
+inline val KeyCode.Companion.AudioVolumeUp: KeyCode
+    get() = unsafeCast("AudioVolumeUp")
+
+inline val KeyCode.Companion.WakeUp: KeyCode
+    get() = unsafeCast("WakeUp")
+
+inline val KeyCode.Companion.Hiragana: KeyCode
+    get() = unsafeCast("Hiragana")
+
+inline val KeyCode.Companion.Katakana: KeyCode
+    get() = unsafeCast("Katakana")
+
+inline val KeyCode.Companion.Unidentified: KeyCode
+    get() = unsafeCast("Unidentified")

--- a/kotlin-browser/src/commonMain/generated/web/keyboard/ModifierKeyCode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/keyboard/ModifierKeyCode.kt
@@ -6,44 +6,44 @@
 
 package web.keyboard
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ModifierKeyCode {
-    companion object {
-        @JsValue("Alt")
-        val Alt: ModifierKeyCode
-
-        @JsValue("AltGraph")
-        val AltGraph: ModifierKeyCode
-
-        @JsValue("CapsLock")
-        val CapsLock: ModifierKeyCode
-
-        @JsValue("Control")
-        val Control: ModifierKeyCode
-
-        @JsValue("Fn")
-        val Fn: ModifierKeyCode
-
-        @JsValue("FnLock")
-        val FnLock: ModifierKeyCode
-
-        @JsValue("Meta")
-        val Meta: ModifierKeyCode
-
-        @JsValue("NumLock")
-        val NumLock: ModifierKeyCode
-
-        @JsValue("ScrollLock")
-        val ScrollLock: ModifierKeyCode
-
-        @JsValue("Shift")
-        val Shift: ModifierKeyCode
-
-        @JsValue("Symbol")
-        val Symbol: ModifierKeyCode
-
-        @JsValue("SymbolLock")
-        val SymbolLock: ModifierKeyCode
-    }
+    companion object
 }
+
+inline val ModifierKeyCode.Companion.Alt: ModifierKeyCode
+    get() = unsafeCast("Alt")
+
+inline val ModifierKeyCode.Companion.AltGraph: ModifierKeyCode
+    get() = unsafeCast("AltGraph")
+
+inline val ModifierKeyCode.Companion.CapsLock: ModifierKeyCode
+    get() = unsafeCast("CapsLock")
+
+inline val ModifierKeyCode.Companion.Control: ModifierKeyCode
+    get() = unsafeCast("Control")
+
+inline val ModifierKeyCode.Companion.Fn: ModifierKeyCode
+    get() = unsafeCast("Fn")
+
+inline val ModifierKeyCode.Companion.FnLock: ModifierKeyCode
+    get() = unsafeCast("FnLock")
+
+inline val ModifierKeyCode.Companion.Meta: ModifierKeyCode
+    get() = unsafeCast("Meta")
+
+inline val ModifierKeyCode.Companion.NumLock: ModifierKeyCode
+    get() = unsafeCast("NumLock")
+
+inline val ModifierKeyCode.Companion.ScrollLock: ModifierKeyCode
+    get() = unsafeCast("ScrollLock")
+
+inline val ModifierKeyCode.Companion.Shift: ModifierKeyCode
+    get() = unsafeCast("Shift")
+
+inline val ModifierKeyCode.Companion.Symbol: ModifierKeyCode
+    get() = unsafeCast("Symbol")
+
+inline val ModifierKeyCode.Companion.SymbolLock: ModifierKeyCode
+    get() = unsafeCast("SymbolLock")

--- a/kotlin-browser/src/commonMain/generated/web/locks/LockMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/locks/LockMode.kt
@@ -6,14 +6,14 @@
 
 package web.locks
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LockMode {
-    companion object {
-        @JsValue("exclusive")
-        val exclusive: LockMode
-
-        @JsValue("shared")
-        val shared: LockMode
-    }
+    companion object
 }
+
+inline val LockMode.Companion.exclusive: LockMode
+    get() = unsafeCast("exclusive")
+
+inline val LockMode.Companion.shared: LockMode
+    get() = unsafeCast("shared")

--- a/kotlin-browser/src/commonMain/generated/web/mediacapabilities/ColorGamut.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediacapabilities/ColorGamut.kt
@@ -6,17 +6,17 @@
 
 package web.mediacapabilities
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ColorGamut {
-    companion object {
-        @JsValue("p3")
-        val p3: ColorGamut
-
-        @JsValue("rec2020")
-        val rec2020: ColorGamut
-
-        @JsValue("srgb")
-        val srgb: ColorGamut
-    }
+    companion object
 }
+
+inline val ColorGamut.Companion.p3: ColorGamut
+    get() = unsafeCast("p3")
+
+inline val ColorGamut.Companion.rec2020: ColorGamut
+    get() = unsafeCast("rec2020")
+
+inline val ColorGamut.Companion.srgb: ColorGamut
+    get() = unsafeCast("srgb")

--- a/kotlin-browser/src/commonMain/generated/web/mediacapabilities/HdrMetadataType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediacapabilities/HdrMetadataType.kt
@@ -6,17 +6,17 @@
 
 package web.mediacapabilities
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface HdrMetadataType {
-    companion object {
-        @JsValue("smpteSt2086")
-        val smpteSt2086: HdrMetadataType
-
-        @JsValue("smpteSt2094-10")
-        val smpteSt209410: HdrMetadataType
-
-        @JsValue("smpteSt2094-40")
-        val smpteSt209440: HdrMetadataType
-    }
+    companion object
 }
+
+inline val HdrMetadataType.Companion.smpteSt2086: HdrMetadataType
+    get() = unsafeCast("smpteSt2086")
+
+inline val HdrMetadataType.Companion.smpteSt209410: HdrMetadataType
+    get() = unsafeCast("smpteSt2094-10")
+
+inline val HdrMetadataType.Companion.smpteSt209440: HdrMetadataType
+    get() = unsafeCast("smpteSt2094-40")

--- a/kotlin-browser/src/commonMain/generated/web/mediacapabilities/MediaDecodingType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediacapabilities/MediaDecodingType.kt
@@ -6,17 +6,17 @@
 
 package web.mediacapabilities
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaDecodingType {
-    companion object {
-        @JsValue("file")
-        val file: MediaDecodingType
-
-        @JsValue("media-source")
-        val mediaSource: MediaDecodingType
-
-        @JsValue("webrtc")
-        val webrtc: MediaDecodingType
-    }
+    companion object
 }
+
+inline val MediaDecodingType.Companion.file: MediaDecodingType
+    get() = unsafeCast("file")
+
+inline val MediaDecodingType.Companion.mediaSource: MediaDecodingType
+    get() = unsafeCast("media-source")
+
+inline val MediaDecodingType.Companion.webrtc: MediaDecodingType
+    get() = unsafeCast("webrtc")

--- a/kotlin-browser/src/commonMain/generated/web/mediacapabilities/MediaEncodingType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediacapabilities/MediaEncodingType.kt
@@ -6,14 +6,14 @@
 
 package web.mediacapabilities
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaEncodingType {
-    companion object {
-        @JsValue("record")
-        val record: MediaEncodingType
-
-        @JsValue("webrtc")
-        val webrtc: MediaEncodingType
-    }
+    companion object
 }
+
+inline val MediaEncodingType.Companion.record: MediaEncodingType
+    get() = unsafeCast("record")
+
+inline val MediaEncodingType.Companion.webrtc: MediaEncodingType
+    get() = unsafeCast("webrtc")

--- a/kotlin-browser/src/commonMain/generated/web/mediacapabilities/TransferFunction.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediacapabilities/TransferFunction.kt
@@ -6,17 +6,17 @@
 
 package web.mediacapabilities
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TransferFunction {
-    companion object {
-        @JsValue("hlg")
-        val hlg: TransferFunction
-
-        @JsValue("pq")
-        val pq: TransferFunction
-
-        @JsValue("srgb")
-        val srgb: TransferFunction
-    }
+    companion object
 }
+
+inline val TransferFunction.Companion.hlg: TransferFunction
+    get() = unsafeCast("hlg")
+
+inline val TransferFunction.Companion.pq: TransferFunction
+    get() = unsafeCast("pq")
+
+inline val TransferFunction.Companion.srgb: TransferFunction
+    get() = unsafeCast("srgb")

--- a/kotlin-browser/src/commonMain/generated/web/mediadevices/MediaDeviceKind.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediadevices/MediaDeviceKind.kt
@@ -6,17 +6,17 @@
 
 package web.mediadevices
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaDeviceKind {
-    companion object {
-        @JsValue("audioinput")
-        val audioinput: MediaDeviceKind
-
-        @JsValue("audiooutput")
-        val audiooutput: MediaDeviceKind
-
-        @JsValue("videoinput")
-        val videoinput: MediaDeviceKind
-    }
+    companion object
 }
+
+inline val MediaDeviceKind.Companion.audioinput: MediaDeviceKind
+    get() = unsafeCast("audioinput")
+
+inline val MediaDeviceKind.Companion.audiooutput: MediaDeviceKind
+    get() = unsafeCast("audiooutput")
+
+inline val MediaDeviceKind.Companion.videoinput: MediaDeviceKind
+    get() = unsafeCast("videoinput")

--- a/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeyMessageType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeyMessageType.kt
@@ -6,20 +6,20 @@
 
 package web.mediakey
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaKeyMessageType {
-    companion object {
-        @JsValue("individualization-request")
-        val individualizationRequest: MediaKeyMessageType
-
-        @JsValue("license-release")
-        val licenseRelease: MediaKeyMessageType
-
-        @JsValue("license-renewal")
-        val licenseRenewal: MediaKeyMessageType
-
-        @JsValue("license-request")
-        val licenseRequest: MediaKeyMessageType
-    }
+    companion object
 }
+
+inline val MediaKeyMessageType.Companion.individualizationRequest: MediaKeyMessageType
+    get() = unsafeCast("individualization-request")
+
+inline val MediaKeyMessageType.Companion.licenseRelease: MediaKeyMessageType
+    get() = unsafeCast("license-release")
+
+inline val MediaKeyMessageType.Companion.licenseRenewal: MediaKeyMessageType
+    get() = unsafeCast("license-renewal")
+
+inline val MediaKeyMessageType.Companion.licenseRequest: MediaKeyMessageType
+    get() = unsafeCast("license-request")

--- a/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeySessionClosedReason.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeySessionClosedReason.kt
@@ -6,23 +6,23 @@
 
 package web.mediakey
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaKeySessionClosedReason {
-    companion object {
-        @JsValue("closed-by-application")
-        val closedByApplication: MediaKeySessionClosedReason
-
-        @JsValue("hardware-context-reset")
-        val hardwareContextReset: MediaKeySessionClosedReason
-
-        @JsValue("internal-error")
-        val internalError: MediaKeySessionClosedReason
-
-        @JsValue("release-acknowledged")
-        val releaseAcknowledged: MediaKeySessionClosedReason
-
-        @JsValue("resource-evicted")
-        val resourceEvicted: MediaKeySessionClosedReason
-    }
+    companion object
 }
+
+inline val MediaKeySessionClosedReason.Companion.closedByApplication: MediaKeySessionClosedReason
+    get() = unsafeCast("closed-by-application")
+
+inline val MediaKeySessionClosedReason.Companion.hardwareContextReset: MediaKeySessionClosedReason
+    get() = unsafeCast("hardware-context-reset")
+
+inline val MediaKeySessionClosedReason.Companion.internalError: MediaKeySessionClosedReason
+    get() = unsafeCast("internal-error")
+
+inline val MediaKeySessionClosedReason.Companion.releaseAcknowledged: MediaKeySessionClosedReason
+    get() = unsafeCast("release-acknowledged")
+
+inline val MediaKeySessionClosedReason.Companion.resourceEvicted: MediaKeySessionClosedReason
+    get() = unsafeCast("resource-evicted")

--- a/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeySessionType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeySessionType.kt
@@ -6,14 +6,14 @@
 
 package web.mediakey
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaKeySessionType {
-    companion object {
-        @JsValue("persistent-license")
-        val persistentLicense: MediaKeySessionType
-
-        @JsValue("temporary")
-        val temporary: MediaKeySessionType
-    }
+    companion object
 }
+
+inline val MediaKeySessionType.Companion.persistentLicense: MediaKeySessionType
+    get() = unsafeCast("persistent-license")
+
+inline val MediaKeySessionType.Companion.temporary: MediaKeySessionType
+    get() = unsafeCast("temporary")

--- a/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeyStatus.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeyStatus.kt
@@ -6,32 +6,32 @@
 
 package web.mediakey
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaKeyStatus {
-    companion object {
-        @JsValue("expired")
-        val expired: MediaKeyStatus
-
-        @JsValue("internal-error")
-        val internalError: MediaKeyStatus
-
-        @JsValue("output-downscaled")
-        val outputDownscaled: MediaKeyStatus
-
-        @JsValue("output-restricted")
-        val outputRestricted: MediaKeyStatus
-
-        @JsValue("released")
-        val released: MediaKeyStatus
-
-        @JsValue("status-pending")
-        val statusPending: MediaKeyStatus
-
-        @JsValue("usable")
-        val usable: MediaKeyStatus
-
-        @JsValue("usable-in-future")
-        val usableInFuture: MediaKeyStatus
-    }
+    companion object
 }
+
+inline val MediaKeyStatus.Companion.expired: MediaKeyStatus
+    get() = unsafeCast("expired")
+
+inline val MediaKeyStatus.Companion.internalError: MediaKeyStatus
+    get() = unsafeCast("internal-error")
+
+inline val MediaKeyStatus.Companion.outputDownscaled: MediaKeyStatus
+    get() = unsafeCast("output-downscaled")
+
+inline val MediaKeyStatus.Companion.outputRestricted: MediaKeyStatus
+    get() = unsafeCast("output-restricted")
+
+inline val MediaKeyStatus.Companion.released: MediaKeyStatus
+    get() = unsafeCast("released")
+
+inline val MediaKeyStatus.Companion.statusPending: MediaKeyStatus
+    get() = unsafeCast("status-pending")
+
+inline val MediaKeyStatus.Companion.usable: MediaKeyStatus
+    get() = unsafeCast("usable")
+
+inline val MediaKeyStatus.Companion.usableInFuture: MediaKeyStatus
+    get() = unsafeCast("usable-in-future")

--- a/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeysRequirement.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediakey/MediaKeysRequirement.kt
@@ -6,17 +6,17 @@
 
 package web.mediakey
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaKeysRequirement {
-    companion object {
-        @JsValue("not-allowed")
-        val notAllowed: MediaKeysRequirement
-
-        @JsValue("optional")
-        val optional: MediaKeysRequirement
-
-        @JsValue("required")
-        val required: MediaKeysRequirement
-    }
+    companion object
 }
+
+inline val MediaKeysRequirement.Companion.notAllowed: MediaKeysRequirement
+    get() = unsafeCast("not-allowed")
+
+inline val MediaKeysRequirement.Companion.optional: MediaKeysRequirement
+    get() = unsafeCast("optional")
+
+inline val MediaKeysRequirement.Companion.required: MediaKeysRequirement
+    get() = unsafeCast("required")

--- a/kotlin-browser/src/commonMain/generated/web/mediarecorder/RecordingState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediarecorder/RecordingState.kt
@@ -6,17 +6,17 @@
 
 package web.mediarecorder
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RecordingState {
-    companion object {
-        @JsValue("inactive")
-        val inactive: RecordingState
-
-        @JsValue("paused")
-        val paused: RecordingState
-
-        @JsValue("recording")
-        val recording: RecordingState
-    }
+    companion object
 }
+
+inline val RecordingState.Companion.inactive: RecordingState
+    get() = unsafeCast("inactive")
+
+inline val RecordingState.Companion.paused: RecordingState
+    get() = unsafeCast("paused")
+
+inline val RecordingState.Companion.recording: RecordingState
+    get() = unsafeCast("recording")

--- a/kotlin-browser/src/commonMain/generated/web/mediasession/MediaSessionAction.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediasession/MediaSessionAction.kt
@@ -6,35 +6,35 @@
 
 package web.mediasession
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaSessionAction {
-    companion object {
-        @JsValue("nexttrack")
-        val nexttrack: MediaSessionAction
-
-        @JsValue("pause")
-        val pause: MediaSessionAction
-
-        @JsValue("play")
-        val play: MediaSessionAction
-
-        @JsValue("previoustrack")
-        val previoustrack: MediaSessionAction
-
-        @JsValue("seekbackward")
-        val seekbackward: MediaSessionAction
-
-        @JsValue("seekforward")
-        val seekforward: MediaSessionAction
-
-        @JsValue("seekto")
-        val seekto: MediaSessionAction
-
-        @JsValue("skipad")
-        val skipad: MediaSessionAction
-
-        @JsValue("stop")
-        val stop: MediaSessionAction
-    }
+    companion object
 }
+
+inline val MediaSessionAction.Companion.nexttrack: MediaSessionAction
+    get() = unsafeCast("nexttrack")
+
+inline val MediaSessionAction.Companion.pause: MediaSessionAction
+    get() = unsafeCast("pause")
+
+inline val MediaSessionAction.Companion.play: MediaSessionAction
+    get() = unsafeCast("play")
+
+inline val MediaSessionAction.Companion.previoustrack: MediaSessionAction
+    get() = unsafeCast("previoustrack")
+
+inline val MediaSessionAction.Companion.seekbackward: MediaSessionAction
+    get() = unsafeCast("seekbackward")
+
+inline val MediaSessionAction.Companion.seekforward: MediaSessionAction
+    get() = unsafeCast("seekforward")
+
+inline val MediaSessionAction.Companion.seekto: MediaSessionAction
+    get() = unsafeCast("seekto")
+
+inline val MediaSessionAction.Companion.skipad: MediaSessionAction
+    get() = unsafeCast("skipad")
+
+inline val MediaSessionAction.Companion.stop: MediaSessionAction
+    get() = unsafeCast("stop")

--- a/kotlin-browser/src/commonMain/generated/web/mediasession/MediaSessionPlaybackState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediasession/MediaSessionPlaybackState.kt
@@ -6,17 +6,17 @@
 
 package web.mediasession
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaSessionPlaybackState {
-    companion object {
-        @JsValue("none")
-        val none: MediaSessionPlaybackState
-
-        @JsValue("paused")
-        val paused: MediaSessionPlaybackState
-
-        @JsValue("playing")
-        val playing: MediaSessionPlaybackState
-    }
+    companion object
 }
+
+inline val MediaSessionPlaybackState.Companion.none: MediaSessionPlaybackState
+    get() = unsafeCast("none")
+
+inline val MediaSessionPlaybackState.Companion.paused: MediaSessionPlaybackState
+    get() = unsafeCast("paused")
+
+inline val MediaSessionPlaybackState.Companion.playing: MediaSessionPlaybackState
+    get() = unsafeCast("playing")

--- a/kotlin-browser/src/commonMain/generated/web/mediasource/AppendMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediasource/AppendMode.kt
@@ -6,14 +6,14 @@
 
 package web.mediasource
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AppendMode {
-    companion object {
-        @JsValue("segments")
-        val segments: AppendMode
-
-        @JsValue("sequence")
-        val sequence: AppendMode
-    }
+    companion object
 }
+
+inline val AppendMode.Companion.segments: AppendMode
+    get() = unsafeCast("segments")
+
+inline val AppendMode.Companion.sequence: AppendMode
+    get() = unsafeCast("sequence")

--- a/kotlin-browser/src/commonMain/generated/web/mediasource/EndOfStreamError.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediasource/EndOfStreamError.kt
@@ -6,14 +6,14 @@
 
 package web.mediasource
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EndOfStreamError {
-    companion object {
-        @JsValue("decode")
-        val decode: EndOfStreamError
-
-        @JsValue("network")
-        val network: EndOfStreamError
-    }
+    companion object
 }
+
+inline val EndOfStreamError.Companion.decode: EndOfStreamError
+    get() = unsafeCast("decode")
+
+inline val EndOfStreamError.Companion.network: EndOfStreamError
+    get() = unsafeCast("network")

--- a/kotlin-browser/src/commonMain/generated/web/mediasource/ReadyState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediasource/ReadyState.kt
@@ -6,17 +6,17 @@
 
 package web.mediasource
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ReadyState {
-    companion object {
-        @JsValue("closed")
-        val closed: ReadyState
-
-        @JsValue("ended")
-        val ended: ReadyState
-
-        @JsValue("open")
-        val open: ReadyState
-    }
+    companion object
 }
+
+inline val ReadyState.Companion.closed: ReadyState
+    get() = unsafeCast("closed")
+
+inline val ReadyState.Companion.ended: ReadyState
+    get() = unsafeCast("ended")
+
+inline val ReadyState.Companion.open: ReadyState
+    get() = unsafeCast("open")

--- a/kotlin-browser/src/commonMain/generated/web/mediastreams/MediaStreamTrackState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mediastreams/MediaStreamTrackState.kt
@@ -6,14 +6,14 @@
 
 package web.mediastreams
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MediaStreamTrackState {
-    companion object {
-        @JsValue("ended")
-        val ended: MediaStreamTrackState
-
-        @JsValue("live")
-        val live: MediaStreamTrackState
-    }
+    companion object
 }
+
+inline val MediaStreamTrackState.Companion.ended: MediaStreamTrackState
+    get() = unsafeCast("ended")
+
+inline val MediaStreamTrackState.Companion.live: MediaStreamTrackState
+    get() = unsafeCast("live")

--- a/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortConnectionState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortConnectionState.kt
@@ -6,17 +6,17 @@
 
 package web.midi
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MIDIPortConnectionState {
-    companion object {
-        @JsValue("closed")
-        val closed: MIDIPortConnectionState
-
-        @JsValue("open")
-        val open: MIDIPortConnectionState
-
-        @JsValue("pending")
-        val pending: MIDIPortConnectionState
-    }
+    companion object
 }
+
+inline val MIDIPortConnectionState.Companion.closed: MIDIPortConnectionState
+    get() = unsafeCast("closed")
+
+inline val MIDIPortConnectionState.Companion.open: MIDIPortConnectionState
+    get() = unsafeCast("open")
+
+inline val MIDIPortConnectionState.Companion.pending: MIDIPortConnectionState
+    get() = unsafeCast("pending")

--- a/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortDeviceState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortDeviceState.kt
@@ -6,14 +6,14 @@
 
 package web.midi
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MIDIPortDeviceState {
-    companion object {
-        @JsValue("connected")
-        val connected: MIDIPortDeviceState
-
-        @JsValue("disconnected")
-        val disconnected: MIDIPortDeviceState
-    }
+    companion object
 }
+
+inline val MIDIPortDeviceState.Companion.connected: MIDIPortDeviceState
+    get() = unsafeCast("connected")
+
+inline val MIDIPortDeviceState.Companion.disconnected: MIDIPortDeviceState
+    get() = unsafeCast("disconnected")

--- a/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/midi/MIDIPortType.kt
@@ -6,14 +6,14 @@
 
 package web.midi
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MIDIPortType {
-    companion object {
-        @JsValue("input")
-        val input: MIDIPortType
-
-        @JsValue("output")
-        val output: MIDIPortType
-    }
+    companion object
 }
+
+inline val MIDIPortType.Companion.input: MIDIPortType
+    get() = unsafeCast("input")
+
+inline val MIDIPortType.Companion.output: MIDIPortType
+    get() = unsafeCast("output")

--- a/kotlin-browser/src/commonMain/generated/web/mutation/MutationRecordType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/mutation/MutationRecordType.kt
@@ -6,17 +6,17 @@
 
 package web.mutation
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MutationRecordType {
-    companion object {
-        @JsValue("attributes")
-        val attributes: MutationRecordType
-
-        @JsValue("characterData")
-        val characterData: MutationRecordType
-
-        @JsValue("childList")
-        val childList: MutationRecordType
-    }
+    companion object
 }
+
+inline val MutationRecordType.Companion.attributes: MutationRecordType
+    get() = unsafeCast("attributes")
+
+inline val MutationRecordType.Companion.characterData: MutationRecordType
+    get() = unsafeCast("characterData")
+
+inline val MutationRecordType.Companion.childList: MutationRecordType
+    get() = unsafeCast("childList")

--- a/kotlin-browser/src/commonMain/generated/web/navigation/NavigationType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/navigation/NavigationType.kt
@@ -6,20 +6,20 @@
 
 package web.navigation
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface NavigationType {
-    companion object {
-        @JsValue("push")
-        val push: NavigationType
-
-        @JsValue("reload")
-        val reload: NavigationType
-
-        @JsValue("replace")
-        val replace: NavigationType
-
-        @JsValue("traverse")
-        val traverse: NavigationType
-    }
+    companion object
 }
+
+inline val NavigationType.Companion.push: NavigationType
+    get() = unsafeCast("push")
+
+inline val NavigationType.Companion.reload: NavigationType
+    get() = unsafeCast("reload")
+
+inline val NavigationType.Companion.replace: NavigationType
+    get() = unsafeCast("replace")
+
+inline val NavigationType.Companion.traverse: NavigationType
+    get() = unsafeCast("traverse")

--- a/kotlin-browser/src/commonMain/generated/web/notifications/NotificationDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/notifications/NotificationDirection.kt
@@ -6,17 +6,17 @@
 
 package web.notifications
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface NotificationDirection {
-    companion object {
-        @JsValue("auto")
-        val auto: NotificationDirection
-
-        @JsValue("ltr")
-        val ltr: NotificationDirection
-
-        @JsValue("rtl")
-        val rtl: NotificationDirection
-    }
+    companion object
 }
+
+inline val NotificationDirection.Companion.auto: NotificationDirection
+    get() = unsafeCast("auto")
+
+inline val NotificationDirection.Companion.ltr: NotificationDirection
+    get() = unsafeCast("ltr")
+
+inline val NotificationDirection.Companion.rtl: NotificationDirection
+    get() = unsafeCast("rtl")

--- a/kotlin-browser/src/commonMain/generated/web/notifications/NotificationPermission.kt
+++ b/kotlin-browser/src/commonMain/generated/web/notifications/NotificationPermission.kt
@@ -6,17 +6,17 @@
 
 package web.notifications
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface NotificationPermission {
-    companion object {
-        @JsValue("default")
-        val default: NotificationPermission
-
-        @JsValue("denied")
-        val denied: NotificationPermission
-
-        @JsValue("granted")
-        val granted: NotificationPermission
-    }
+    companion object
 }
+
+inline val NotificationPermission.Companion.default: NotificationPermission
+    get() = unsafeCast("default")
+
+inline val NotificationPermission.Companion.denied: NotificationPermission
+    get() = unsafeCast("denied")
+
+inline val NotificationPermission.Companion.granted: NotificationPermission
+    get() = unsafeCast("granted")

--- a/kotlin-browser/src/commonMain/generated/web/parsing/DOMParserSupportedType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/parsing/DOMParserSupportedType.kt
@@ -6,23 +6,23 @@
 
 package web.parsing
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DOMParserSupportedType {
-    companion object {
-        @JsValue("application/xhtml+xml")
-        val applicationXhtmlXml: DOMParserSupportedType
-
-        @JsValue("application/xml")
-        val applicationXml: DOMParserSupportedType
-
-        @JsValue("image/svg+xml")
-        val imageSvgXml: DOMParserSupportedType
-
-        @JsValue("text/html")
-        val textHtml: DOMParserSupportedType
-
-        @JsValue("text/xml")
-        val textXml: DOMParserSupportedType
-    }
+    companion object
 }
+
+inline val DOMParserSupportedType.Companion.applicationXhtmlXml: DOMParserSupportedType
+    get() = unsafeCast("application/xhtml+xml")
+
+inline val DOMParserSupportedType.Companion.applicationXml: DOMParserSupportedType
+    get() = unsafeCast("application/xml")
+
+inline val DOMParserSupportedType.Companion.imageSvgXml: DOMParserSupportedType
+    get() = unsafeCast("image/svg+xml")
+
+inline val DOMParserSupportedType.Companion.textHtml: DOMParserSupportedType
+    get() = unsafeCast("text/html")
+
+inline val DOMParserSupportedType.Companion.textXml: DOMParserSupportedType
+    get() = unsafeCast("text/xml")

--- a/kotlin-browser/src/commonMain/generated/web/payment/PaymentComplete.kt
+++ b/kotlin-browser/src/commonMain/generated/web/payment/PaymentComplete.kt
@@ -6,17 +6,17 @@
 
 package web.payment
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PaymentComplete {
-    companion object {
-        @JsValue("fail")
-        val fail: PaymentComplete
-
-        @JsValue("success")
-        val success: PaymentComplete
-
-        @JsValue("unknown")
-        val unknown: PaymentComplete
-    }
+    companion object
 }
+
+inline val PaymentComplete.Companion.fail: PaymentComplete
+    get() = unsafeCast("fail")
+
+inline val PaymentComplete.Companion.success: PaymentComplete
+    get() = unsafeCast("success")
+
+inline val PaymentComplete.Companion.unknown: PaymentComplete
+    get() = unsafeCast("unknown")

--- a/kotlin-browser/src/commonMain/generated/web/payment/PaymentShippingType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/payment/PaymentShippingType.kt
@@ -6,17 +6,17 @@
 
 package web.payment
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PaymentShippingType {
-    companion object {
-        @JsValue("delivery")
-        val delivery: PaymentShippingType
-
-        @JsValue("pickup")
-        val pickup: PaymentShippingType
-
-        @JsValue("shipping")
-        val shipping: PaymentShippingType
-    }
+    companion object
 }
+
+inline val PaymentShippingType.Companion.delivery: PaymentShippingType
+    get() = unsafeCast("delivery")
+
+inline val PaymentShippingType.Companion.pickup: PaymentShippingType
+    get() = unsafeCast("pickup")
+
+inline val PaymentShippingType.Companion.shipping: PaymentShippingType
+    get() = unsafeCast("shipping")

--- a/kotlin-browser/src/commonMain/generated/web/permissions/PermissionName.kt
+++ b/kotlin-browser/src/commonMain/generated/web/permissions/PermissionName.kt
@@ -6,35 +6,35 @@
 
 package web.permissions
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PermissionName {
-    companion object {
-        @JsValue("camera")
-        val camera: PermissionName
-
-        @JsValue("geolocation")
-        val geolocation: PermissionName
-
-        @JsValue("microphone")
-        val microphone: PermissionName
-
-        @JsValue("midi")
-        val midi: PermissionName
-
-        @JsValue("notifications")
-        val notifications: PermissionName
-
-        @JsValue("persistent-storage")
-        val persistentStorage: PermissionName
-
-        @JsValue("push")
-        val push: PermissionName
-
-        @JsValue("screen-wake-lock")
-        val screenWakeLock: PermissionName
-
-        @JsValue("storage-access")
-        val storageAccess: PermissionName
-    }
+    companion object
 }
+
+inline val PermissionName.Companion.camera: PermissionName
+    get() = unsafeCast("camera")
+
+inline val PermissionName.Companion.geolocation: PermissionName
+    get() = unsafeCast("geolocation")
+
+inline val PermissionName.Companion.microphone: PermissionName
+    get() = unsafeCast("microphone")
+
+inline val PermissionName.Companion.midi: PermissionName
+    get() = unsafeCast("midi")
+
+inline val PermissionName.Companion.notifications: PermissionName
+    get() = unsafeCast("notifications")
+
+inline val PermissionName.Companion.persistentStorage: PermissionName
+    get() = unsafeCast("persistent-storage")
+
+inline val PermissionName.Companion.push: PermissionName
+    get() = unsafeCast("push")
+
+inline val PermissionName.Companion.screenWakeLock: PermissionName
+    get() = unsafeCast("screen-wake-lock")
+
+inline val PermissionName.Companion.storageAccess: PermissionName
+    get() = unsafeCast("storage-access")

--- a/kotlin-browser/src/commonMain/generated/web/permissions/PermissionState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/permissions/PermissionState.kt
@@ -6,17 +6,17 @@
 
 package web.permissions
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PermissionState {
-    companion object {
-        @JsValue("denied")
-        val denied: PermissionState
-
-        @JsValue("granted")
-        val granted: PermissionState
-
-        @JsValue("prompt")
-        val prompt: PermissionState
-    }
+    companion object
 }
+
+inline val PermissionState.Companion.denied: PermissionState
+    get() = unsafeCast("denied")
+
+inline val PermissionState.Companion.granted: PermissionState
+    get() = unsafeCast("granted")
+
+inline val PermissionState.Companion.prompt: PermissionState
+    get() = unsafeCast("prompt")

--- a/kotlin-browser/src/commonMain/generated/web/popover/Popover.kt
+++ b/kotlin-browser/src/commonMain/generated/web/popover/Popover.kt
@@ -6,14 +6,14 @@
 
 package web.popover
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Popover {
-    companion object {
-        @JsValue("auto")
-        val auto: Popover
-
-        @JsValue("manual")
-        val manual: Popover
-    }
+    companion object
 }
+
+inline val Popover.Companion.auto: Popover
+    get() = unsafeCast("auto")
+
+inline val Popover.Companion.manual: Popover
+    get() = unsafeCast("manual")

--- a/kotlin-browser/src/commonMain/generated/web/popover/PopoverTargetAction.kt
+++ b/kotlin-browser/src/commonMain/generated/web/popover/PopoverTargetAction.kt
@@ -6,17 +6,17 @@
 
 package web.popover
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PopoverTargetAction {
-    companion object {
-        @JsValue("hide")
-        val hide: PopoverTargetAction
-
-        @JsValue("show")
-        val show: PopoverTargetAction
-
-        @JsValue("toggle")
-        val toggle: PopoverTargetAction
-    }
+    companion object
 }
+
+inline val PopoverTargetAction.Companion.hide: PopoverTargetAction
+    get() = unsafeCast("hide")
+
+inline val PopoverTargetAction.Companion.show: PopoverTargetAction
+    get() = unsafeCast("show")
+
+inline val PopoverTargetAction.Companion.toggle: PopoverTargetAction
+    get() = unsafeCast("toggle")

--- a/kotlin-browser/src/commonMain/generated/web/popover/ToggleState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/popover/ToggleState.kt
@@ -6,14 +6,14 @@
 
 package web.popover
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ToggleState {
-    companion object {
-        @JsValue("open")
-        val open: ToggleState
-
-        @JsValue("closed")
-        val closed: ToggleState
-    }
+    companion object
 }
+
+inline val ToggleState.Companion.open: ToggleState
+    get() = unsafeCast("open")
+
+inline val ToggleState.Companion.closed: ToggleState
+    get() = unsafeCast("closed")

--- a/kotlin-browser/src/commonMain/generated/web/push/PushEncryptionKeyName.kt
+++ b/kotlin-browser/src/commonMain/generated/web/push/PushEncryptionKeyName.kt
@@ -6,14 +6,14 @@
 
 package web.push
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PushEncryptionKeyName {
-    companion object {
-        @JsValue("auth")
-        val auth: PushEncryptionKeyName
-
-        @JsValue("p256dh")
-        val p256dh: PushEncryptionKeyName
-    }
+    companion object
 }
+
+inline val PushEncryptionKeyName.Companion.auth: PushEncryptionKeyName
+    get() = unsafeCast("auth")
+
+inline val PushEncryptionKeyName.Companion.p256dh: PushEncryptionKeyName
+    get() = unsafeCast("p256dh")

--- a/kotlin-browser/src/commonMain/generated/web/remoteplayback/RemotePlaybackState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/remoteplayback/RemotePlaybackState.kt
@@ -6,17 +6,17 @@
 
 package web.remoteplayback
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RemotePlaybackState {
-    companion object {
-        @JsValue("connected")
-        val connected: RemotePlaybackState
-
-        @JsValue("connecting")
-        val connecting: RemotePlaybackState
-
-        @JsValue("disconnected")
-        val disconnected: RemotePlaybackState
-    }
+    companion object
 }
+
+inline val RemotePlaybackState.Companion.connected: RemotePlaybackState
+    get() = unsafeCast("connected")
+
+inline val RemotePlaybackState.Companion.connecting: RemotePlaybackState
+    get() = unsafeCast("connecting")
+
+inline val RemotePlaybackState.Companion.disconnected: RemotePlaybackState
+    get() = unsafeCast("disconnected")

--- a/kotlin-browser/src/commonMain/generated/web/resize/ResizeObserverBoxOptions.kt
+++ b/kotlin-browser/src/commonMain/generated/web/resize/ResizeObserverBoxOptions.kt
@@ -6,17 +6,17 @@
 
 package web.resize
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ResizeObserverBoxOptions {
-    companion object {
-        @JsValue("border-box")
-        val borderBox: ResizeObserverBoxOptions
-
-        @JsValue("content-box")
-        val contentBox: ResizeObserverBoxOptions
-
-        @JsValue("device-pixel-content-box")
-        val devicePixelContentBox: ResizeObserverBoxOptions
-    }
+    companion object
 }
+
+inline val ResizeObserverBoxOptions.Companion.borderBox: ResizeObserverBoxOptions
+    get() = unsafeCast("border-box")
+
+inline val ResizeObserverBoxOptions.Companion.contentBox: ResizeObserverBoxOptions
+    get() = unsafeCast("content-box")
+
+inline val ResizeObserverBoxOptions.Companion.devicePixelContentBox: ResizeObserverBoxOptions
+    get() = unsafeCast("device-pixel-content-box")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCBundlePolicy.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCBundlePolicy.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCBundlePolicy {
-    companion object {
-        @JsValue("balanced")
-        val balanced: RTCBundlePolicy
-
-        @JsValue("max-bundle")
-        val maxBundle: RTCBundlePolicy
-
-        @JsValue("max-compat")
-        val maxCompat: RTCBundlePolicy
-    }
+    companion object
 }
+
+inline val RTCBundlePolicy.Companion.balanced: RTCBundlePolicy
+    get() = unsafeCast("balanced")
+
+inline val RTCBundlePolicy.Companion.maxBundle: RTCBundlePolicy
+    get() = unsafeCast("max-bundle")
+
+inline val RTCBundlePolicy.Companion.maxCompat: RTCBundlePolicy
+    get() = unsafeCast("max-compat")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCDataChannelState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCDataChannelState.kt
@@ -6,20 +6,20 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCDataChannelState {
-    companion object {
-        @JsValue("closed")
-        val closed: RTCDataChannelState
-
-        @JsValue("closing")
-        val closing: RTCDataChannelState
-
-        @JsValue("connecting")
-        val connecting: RTCDataChannelState
-
-        @JsValue("open")
-        val open: RTCDataChannelState
-    }
+    companion object
 }
+
+inline val RTCDataChannelState.Companion.closed: RTCDataChannelState
+    get() = unsafeCast("closed")
+
+inline val RTCDataChannelState.Companion.closing: RTCDataChannelState
+    get() = unsafeCast("closing")
+
+inline val RTCDataChannelState.Companion.connecting: RTCDataChannelState
+    get() = unsafeCast("connecting")
+
+inline val RTCDataChannelState.Companion.open: RTCDataChannelState
+    get() = unsafeCast("open")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCDegradationPreference.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCDegradationPreference.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCDegradationPreference {
-    companion object {
-        @JsValue("balanced")
-        val balanced: RTCDegradationPreference
-
-        @JsValue("maintain-framerate")
-        val maintainFramerate: RTCDegradationPreference
-
-        @JsValue("maintain-resolution")
-        val maintainResolution: RTCDegradationPreference
-    }
+    companion object
 }
+
+inline val RTCDegradationPreference.Companion.balanced: RTCDegradationPreference
+    get() = unsafeCast("balanced")
+
+inline val RTCDegradationPreference.Companion.maintainFramerate: RTCDegradationPreference
+    get() = unsafeCast("maintain-framerate")
+
+inline val RTCDegradationPreference.Companion.maintainResolution: RTCDegradationPreference
+    get() = unsafeCast("maintain-resolution")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCDtlsRole.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCDtlsRole.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCDtlsRole {
-    companion object {
-        @JsValue("client")
-        val client: RTCDtlsRole
-
-        @JsValue("server")
-        val server: RTCDtlsRole
-
-        @JsValue("unknown")
-        val unknown: RTCDtlsRole
-    }
+    companion object
 }
+
+inline val RTCDtlsRole.Companion.client: RTCDtlsRole
+    get() = unsafeCast("client")
+
+inline val RTCDtlsRole.Companion.server: RTCDtlsRole
+    get() = unsafeCast("server")
+
+inline val RTCDtlsRole.Companion.unknown: RTCDtlsRole
+    get() = unsafeCast("unknown")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCDtlsTransportState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCDtlsTransportState.kt
@@ -6,23 +6,23 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCDtlsTransportState {
-    companion object {
-        @JsValue("closed")
-        val closed: RTCDtlsTransportState
-
-        @JsValue("connected")
-        val connected: RTCDtlsTransportState
-
-        @JsValue("connecting")
-        val connecting: RTCDtlsTransportState
-
-        @JsValue("failed")
-        val failed: RTCDtlsTransportState
-
-        @JsValue("new")
-        val new: RTCDtlsTransportState
-    }
+    companion object
 }
+
+inline val RTCDtlsTransportState.Companion.closed: RTCDtlsTransportState
+    get() = unsafeCast("closed")
+
+inline val RTCDtlsTransportState.Companion.connected: RTCDtlsTransportState
+    get() = unsafeCast("connected")
+
+inline val RTCDtlsTransportState.Companion.connecting: RTCDtlsTransportState
+    get() = unsafeCast("connecting")
+
+inline val RTCDtlsTransportState.Companion.failed: RTCDtlsTransportState
+    get() = unsafeCast("failed")
+
+inline val RTCDtlsTransportState.Companion.new: RTCDtlsTransportState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCEncodedVideoFrameType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCEncodedVideoFrameType.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCEncodedVideoFrameType {
-    companion object {
-        @JsValue("delta")
-        val delta: RTCEncodedVideoFrameType
-
-        @JsValue("empty")
-        val empty: RTCEncodedVideoFrameType
-
-        @JsValue("key")
-        val key: RTCEncodedVideoFrameType
-    }
+    companion object
 }
+
+inline val RTCEncodedVideoFrameType.Companion.delta: RTCEncodedVideoFrameType
+    get() = unsafeCast("delta")
+
+inline val RTCEncodedVideoFrameType.Companion.empty: RTCEncodedVideoFrameType
+    get() = unsafeCast("empty")
+
+inline val RTCEncodedVideoFrameType.Companion.key: RTCEncodedVideoFrameType
+    get() = unsafeCast("key")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCErrorDetailType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCErrorDetailType.kt
@@ -6,29 +6,29 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCErrorDetailType {
-    companion object {
-        @JsValue("data-channel-failure")
-        val dataChannelFailure: RTCErrorDetailType
-
-        @JsValue("dtls-failure")
-        val dtlsFailure: RTCErrorDetailType
-
-        @JsValue("fingerprint-failure")
-        val fingerprintFailure: RTCErrorDetailType
-
-        @JsValue("hardware-encoder-error")
-        val hardwareEncoderError: RTCErrorDetailType
-
-        @JsValue("hardware-encoder-not-available")
-        val hardwareEncoderNotAvailable: RTCErrorDetailType
-
-        @JsValue("sctp-failure")
-        val sctpFailure: RTCErrorDetailType
-
-        @JsValue("sdp-syntax-error")
-        val sdpSyntaxError: RTCErrorDetailType
-    }
+    companion object
 }
+
+inline val RTCErrorDetailType.Companion.dataChannelFailure: RTCErrorDetailType
+    get() = unsafeCast("data-channel-failure")
+
+inline val RTCErrorDetailType.Companion.dtlsFailure: RTCErrorDetailType
+    get() = unsafeCast("dtls-failure")
+
+inline val RTCErrorDetailType.Companion.fingerprintFailure: RTCErrorDetailType
+    get() = unsafeCast("fingerprint-failure")
+
+inline val RTCErrorDetailType.Companion.hardwareEncoderError: RTCErrorDetailType
+    get() = unsafeCast("hardware-encoder-error")
+
+inline val RTCErrorDetailType.Companion.hardwareEncoderNotAvailable: RTCErrorDetailType
+    get() = unsafeCast("hardware-encoder-not-available")
+
+inline val RTCErrorDetailType.Companion.sctpFailure: RTCErrorDetailType
+    get() = unsafeCast("sctp-failure")
+
+inline val RTCErrorDetailType.Companion.sdpSyntaxError: RTCErrorDetailType
+    get() = unsafeCast("sdp-syntax-error")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceCandidateType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceCandidateType.kt
@@ -6,20 +6,20 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceCandidateType {
-    companion object {
-        @JsValue("host")
-        val host: RTCIceCandidateType
-
-        @JsValue("prflx")
-        val prflx: RTCIceCandidateType
-
-        @JsValue("relay")
-        val relay: RTCIceCandidateType
-
-        @JsValue("srflx")
-        val srflx: RTCIceCandidateType
-    }
+    companion object
 }
+
+inline val RTCIceCandidateType.Companion.host: RTCIceCandidateType
+    get() = unsafeCast("host")
+
+inline val RTCIceCandidateType.Companion.prflx: RTCIceCandidateType
+    get() = unsafeCast("prflx")
+
+inline val RTCIceCandidateType.Companion.relay: RTCIceCandidateType
+    get() = unsafeCast("relay")
+
+inline val RTCIceCandidateType.Companion.srflx: RTCIceCandidateType
+    get() = unsafeCast("srflx")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceComponent.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceComponent.kt
@@ -6,14 +6,14 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceComponent {
-    companion object {
-        @JsValue("rtcp")
-        val rtcp: RTCIceComponent
-
-        @JsValue("rtp")
-        val rtp: RTCIceComponent
-    }
+    companion object
 }
+
+inline val RTCIceComponent.Companion.rtcp: RTCIceComponent
+    get() = unsafeCast("rtcp")
+
+inline val RTCIceComponent.Companion.rtp: RTCIceComponent
+    get() = unsafeCast("rtp")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceConnectionState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceConnectionState.kt
@@ -6,29 +6,29 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceConnectionState {
-    companion object {
-        @JsValue("checking")
-        val checking: RTCIceConnectionState
-
-        @JsValue("closed")
-        val closed: RTCIceConnectionState
-
-        @JsValue("completed")
-        val completed: RTCIceConnectionState
-
-        @JsValue("connected")
-        val connected: RTCIceConnectionState
-
-        @JsValue("disconnected")
-        val disconnected: RTCIceConnectionState
-
-        @JsValue("failed")
-        val failed: RTCIceConnectionState
-
-        @JsValue("new")
-        val new: RTCIceConnectionState
-    }
+    companion object
 }
+
+inline val RTCIceConnectionState.Companion.checking: RTCIceConnectionState
+    get() = unsafeCast("checking")
+
+inline val RTCIceConnectionState.Companion.closed: RTCIceConnectionState
+    get() = unsafeCast("closed")
+
+inline val RTCIceConnectionState.Companion.completed: RTCIceConnectionState
+    get() = unsafeCast("completed")
+
+inline val RTCIceConnectionState.Companion.connected: RTCIceConnectionState
+    get() = unsafeCast("connected")
+
+inline val RTCIceConnectionState.Companion.disconnected: RTCIceConnectionState
+    get() = unsafeCast("disconnected")
+
+inline val RTCIceConnectionState.Companion.failed: RTCIceConnectionState
+    get() = unsafeCast("failed")
+
+inline val RTCIceConnectionState.Companion.new: RTCIceConnectionState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceGathererState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceGathererState.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceGathererState {
-    companion object {
-        @JsValue("complete")
-        val complete: RTCIceGathererState
-
-        @JsValue("gathering")
-        val gathering: RTCIceGathererState
-
-        @JsValue("new")
-        val new: RTCIceGathererState
-    }
+    companion object
 }
+
+inline val RTCIceGathererState.Companion.complete: RTCIceGathererState
+    get() = unsafeCast("complete")
+
+inline val RTCIceGathererState.Companion.gathering: RTCIceGathererState
+    get() = unsafeCast("gathering")
+
+inline val RTCIceGathererState.Companion.new: RTCIceGathererState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceGatheringState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceGatheringState.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceGatheringState {
-    companion object {
-        @JsValue("complete")
-        val complete: RTCIceGatheringState
-
-        @JsValue("gathering")
-        val gathering: RTCIceGatheringState
-
-        @JsValue("new")
-        val new: RTCIceGatheringState
-    }
+    companion object
 }
+
+inline val RTCIceGatheringState.Companion.complete: RTCIceGatheringState
+    get() = unsafeCast("complete")
+
+inline val RTCIceGatheringState.Companion.gathering: RTCIceGatheringState
+    get() = unsafeCast("gathering")
+
+inline val RTCIceGatheringState.Companion.new: RTCIceGatheringState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceProtocol.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceProtocol.kt
@@ -6,14 +6,14 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceProtocol {
-    companion object {
-        @JsValue("tcp")
-        val tcp: RTCIceProtocol
-
-        @JsValue("udp")
-        val udp: RTCIceProtocol
-    }
+    companion object
 }
+
+inline val RTCIceProtocol.Companion.tcp: RTCIceProtocol
+    get() = unsafeCast("tcp")
+
+inline val RTCIceProtocol.Companion.udp: RTCIceProtocol
+    get() = unsafeCast("udp")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceRole.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceRole.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceRole {
-    companion object {
-        @JsValue("controlled")
-        val controlled: RTCIceRole
-
-        @JsValue("controlling")
-        val controlling: RTCIceRole
-
-        @JsValue("unknown")
-        val unknown: RTCIceRole
-    }
+    companion object
 }
+
+inline val RTCIceRole.Companion.controlled: RTCIceRole
+    get() = unsafeCast("controlled")
+
+inline val RTCIceRole.Companion.controlling: RTCIceRole
+    get() = unsafeCast("controlling")
+
+inline val RTCIceRole.Companion.unknown: RTCIceRole
+    get() = unsafeCast("unknown")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTcpCandidateType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTcpCandidateType.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceTcpCandidateType {
-    companion object {
-        @JsValue("active")
-        val active: RTCIceTcpCandidateType
-
-        @JsValue("passive")
-        val passive: RTCIceTcpCandidateType
-
-        @JsValue("so")
-        val so: RTCIceTcpCandidateType
-    }
+    companion object
 }
+
+inline val RTCIceTcpCandidateType.Companion.active: RTCIceTcpCandidateType
+    get() = unsafeCast("active")
+
+inline val RTCIceTcpCandidateType.Companion.passive: RTCIceTcpCandidateType
+    get() = unsafeCast("passive")
+
+inline val RTCIceTcpCandidateType.Companion.so: RTCIceTcpCandidateType
+    get() = unsafeCast("so")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTransportPolicy.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTransportPolicy.kt
@@ -6,14 +6,14 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceTransportPolicy {
-    companion object {
-        @JsValue("all")
-        val all: RTCIceTransportPolicy
-
-        @JsValue("relay")
-        val relay: RTCIceTransportPolicy
-    }
+    companion object
 }
+
+inline val RTCIceTransportPolicy.Companion.all: RTCIceTransportPolicy
+    get() = unsafeCast("all")
+
+inline val RTCIceTransportPolicy.Companion.relay: RTCIceTransportPolicy
+    get() = unsafeCast("relay")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTransportState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCIceTransportState.kt
@@ -6,29 +6,29 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCIceTransportState {
-    companion object {
-        @JsValue("checking")
-        val checking: RTCIceTransportState
-
-        @JsValue("closed")
-        val closed: RTCIceTransportState
-
-        @JsValue("completed")
-        val completed: RTCIceTransportState
-
-        @JsValue("connected")
-        val connected: RTCIceTransportState
-
-        @JsValue("disconnected")
-        val disconnected: RTCIceTransportState
-
-        @JsValue("failed")
-        val failed: RTCIceTransportState
-
-        @JsValue("new")
-        val new: RTCIceTransportState
-    }
+    companion object
 }
+
+inline val RTCIceTransportState.Companion.checking: RTCIceTransportState
+    get() = unsafeCast("checking")
+
+inline val RTCIceTransportState.Companion.closed: RTCIceTransportState
+    get() = unsafeCast("closed")
+
+inline val RTCIceTransportState.Companion.completed: RTCIceTransportState
+    get() = unsafeCast("completed")
+
+inline val RTCIceTransportState.Companion.connected: RTCIceTransportState
+    get() = unsafeCast("connected")
+
+inline val RTCIceTransportState.Companion.disconnected: RTCIceTransportState
+    get() = unsafeCast("disconnected")
+
+inline val RTCIceTransportState.Companion.failed: RTCIceTransportState
+    get() = unsafeCast("failed")
+
+inline val RTCIceTransportState.Companion.new: RTCIceTransportState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCPeerConnectionState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCPeerConnectionState.kt
@@ -6,26 +6,26 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCPeerConnectionState {
-    companion object {
-        @JsValue("closed")
-        val closed: RTCPeerConnectionState
-
-        @JsValue("connected")
-        val connected: RTCPeerConnectionState
-
-        @JsValue("connecting")
-        val connecting: RTCPeerConnectionState
-
-        @JsValue("disconnected")
-        val disconnected: RTCPeerConnectionState
-
-        @JsValue("failed")
-        val failed: RTCPeerConnectionState
-
-        @JsValue("new")
-        val new: RTCPeerConnectionState
-    }
+    companion object
 }
+
+inline val RTCPeerConnectionState.Companion.closed: RTCPeerConnectionState
+    get() = unsafeCast("closed")
+
+inline val RTCPeerConnectionState.Companion.connected: RTCPeerConnectionState
+    get() = unsafeCast("connected")
+
+inline val RTCPeerConnectionState.Companion.connecting: RTCPeerConnectionState
+    get() = unsafeCast("connecting")
+
+inline val RTCPeerConnectionState.Companion.disconnected: RTCPeerConnectionState
+    get() = unsafeCast("disconnected")
+
+inline val RTCPeerConnectionState.Companion.failed: RTCPeerConnectionState
+    get() = unsafeCast("failed")
+
+inline val RTCPeerConnectionState.Companion.new: RTCPeerConnectionState
+    get() = unsafeCast("new")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCPriorityType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCPriorityType.kt
@@ -6,20 +6,20 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCPriorityType {
-    companion object {
-        @JsValue("high")
-        val high: RTCPriorityType
-
-        @JsValue("low")
-        val low: RTCPriorityType
-
-        @JsValue("medium")
-        val medium: RTCPriorityType
-
-        @JsValue("very-low")
-        val veryLow: RTCPriorityType
-    }
+    companion object
 }
+
+inline val RTCPriorityType.Companion.high: RTCPriorityType
+    get() = unsafeCast("high")
+
+inline val RTCPriorityType.Companion.low: RTCPriorityType
+    get() = unsafeCast("low")
+
+inline val RTCPriorityType.Companion.medium: RTCPriorityType
+    get() = unsafeCast("medium")
+
+inline val RTCPriorityType.Companion.veryLow: RTCPriorityType
+    get() = unsafeCast("very-low")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCQualityLimitationReason.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCQualityLimitationReason.kt
@@ -6,20 +6,20 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCQualityLimitationReason {
-    companion object {
-        @JsValue("bandwidth")
-        val bandwidth: RTCQualityLimitationReason
-
-        @JsValue("cpu")
-        val cpu: RTCQualityLimitationReason
-
-        @JsValue("none")
-        val none: RTCQualityLimitationReason
-
-        @JsValue("other")
-        val other: RTCQualityLimitationReason
-    }
+    companion object
 }
+
+inline val RTCQualityLimitationReason.Companion.bandwidth: RTCQualityLimitationReason
+    get() = unsafeCast("bandwidth")
+
+inline val RTCQualityLimitationReason.Companion.cpu: RTCQualityLimitationReason
+    get() = unsafeCast("cpu")
+
+inline val RTCQualityLimitationReason.Companion.none: RTCQualityLimitationReason
+    get() = unsafeCast("none")
+
+inline val RTCQualityLimitationReason.Companion.other: RTCQualityLimitationReason
+    get() = unsafeCast("other")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCRtcpMuxPolicy.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCRtcpMuxPolicy.kt
@@ -6,11 +6,11 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCRtcpMuxPolicy {
-    companion object {
-        @JsValue("require")
-        val require: RTCRtcpMuxPolicy
-    }
+    companion object
 }
+
+inline val RTCRtcpMuxPolicy.Companion.require: RTCRtcpMuxPolicy
+    get() = unsafeCast("require")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCRtpTransceiverDirection.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCRtpTransceiverDirection.kt
@@ -6,23 +6,23 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCRtpTransceiverDirection {
-    companion object {
-        @JsValue("inactive")
-        val inactive: RTCRtpTransceiverDirection
-
-        @JsValue("recvonly")
-        val recvonly: RTCRtpTransceiverDirection
-
-        @JsValue("sendonly")
-        val sendonly: RTCRtpTransceiverDirection
-
-        @JsValue("sendrecv")
-        val sendrecv: RTCRtpTransceiverDirection
-
-        @JsValue("stopped")
-        val stopped: RTCRtpTransceiverDirection
-    }
+    companion object
 }
+
+inline val RTCRtpTransceiverDirection.Companion.inactive: RTCRtpTransceiverDirection
+    get() = unsafeCast("inactive")
+
+inline val RTCRtpTransceiverDirection.Companion.recvonly: RTCRtpTransceiverDirection
+    get() = unsafeCast("recvonly")
+
+inline val RTCRtpTransceiverDirection.Companion.sendonly: RTCRtpTransceiverDirection
+    get() = unsafeCast("sendonly")
+
+inline val RTCRtpTransceiverDirection.Companion.sendrecv: RTCRtpTransceiverDirection
+    get() = unsafeCast("sendrecv")
+
+inline val RTCRtpTransceiverDirection.Companion.stopped: RTCRtpTransceiverDirection
+    get() = unsafeCast("stopped")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCSctpTransportState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCSctpTransportState.kt
@@ -6,17 +6,17 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCSctpTransportState {
-    companion object {
-        @JsValue("closed")
-        val closed: RTCSctpTransportState
-
-        @JsValue("connected")
-        val connected: RTCSctpTransportState
-
-        @JsValue("connecting")
-        val connecting: RTCSctpTransportState
-    }
+    companion object
 }
+
+inline val RTCSctpTransportState.Companion.closed: RTCSctpTransportState
+    get() = unsafeCast("closed")
+
+inline val RTCSctpTransportState.Companion.connected: RTCSctpTransportState
+    get() = unsafeCast("connected")
+
+inline val RTCSctpTransportState.Companion.connecting: RTCSctpTransportState
+    get() = unsafeCast("connecting")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCSdpType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCSdpType.kt
@@ -6,20 +6,20 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCSdpType {
-    companion object {
-        @JsValue("answer")
-        val answer: RTCSdpType
-
-        @JsValue("offer")
-        val offer: RTCSdpType
-
-        @JsValue("pranswer")
-        val pranswer: RTCSdpType
-
-        @JsValue("rollback")
-        val rollback: RTCSdpType
-    }
+    companion object
 }
+
+inline val RTCSdpType.Companion.answer: RTCSdpType
+    get() = unsafeCast("answer")
+
+inline val RTCSdpType.Companion.offer: RTCSdpType
+    get() = unsafeCast("offer")
+
+inline val RTCSdpType.Companion.pranswer: RTCSdpType
+    get() = unsafeCast("pranswer")
+
+inline val RTCSdpType.Companion.rollback: RTCSdpType
+    get() = unsafeCast("rollback")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCSignalingState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCSignalingState.kt
@@ -6,26 +6,26 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCSignalingState {
-    companion object {
-        @JsValue("closed")
-        val closed: RTCSignalingState
-
-        @JsValue("have-local-offer")
-        val haveLocalOffer: RTCSignalingState
-
-        @JsValue("have-local-pranswer")
-        val haveLocalPranswer: RTCSignalingState
-
-        @JsValue("have-remote-offer")
-        val haveRemoteOffer: RTCSignalingState
-
-        @JsValue("have-remote-pranswer")
-        val haveRemotePranswer: RTCSignalingState
-
-        @JsValue("stable")
-        val stable: RTCSignalingState
-    }
+    companion object
 }
+
+inline val RTCSignalingState.Companion.closed: RTCSignalingState
+    get() = unsafeCast("closed")
+
+inline val RTCSignalingState.Companion.haveLocalOffer: RTCSignalingState
+    get() = unsafeCast("have-local-offer")
+
+inline val RTCSignalingState.Companion.haveLocalPranswer: RTCSignalingState
+    get() = unsafeCast("have-local-pranswer")
+
+inline val RTCSignalingState.Companion.haveRemoteOffer: RTCSignalingState
+    get() = unsafeCast("have-remote-offer")
+
+inline val RTCSignalingState.Companion.haveRemotePranswer: RTCSignalingState
+    get() = unsafeCast("have-remote-pranswer")
+
+inline val RTCSignalingState.Companion.stable: RTCSignalingState
+    get() = unsafeCast("stable")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCStatsIceCandidatePairState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCStatsIceCandidatePairState.kt
@@ -6,26 +6,26 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCStatsIceCandidatePairState {
-    companion object {
-        @JsValue("failed")
-        val failed: RTCStatsIceCandidatePairState
-
-        @JsValue("frozen")
-        val frozen: RTCStatsIceCandidatePairState
-
-        @JsValue("in-progress")
-        val inProgress: RTCStatsIceCandidatePairState
-
-        @JsValue("inprogress")
-        val inprogress: RTCStatsIceCandidatePairState
-
-        @JsValue("succeeded")
-        val succeeded: RTCStatsIceCandidatePairState
-
-        @JsValue("waiting")
-        val waiting: RTCStatsIceCandidatePairState
-    }
+    companion object
 }
+
+inline val RTCStatsIceCandidatePairState.Companion.failed: RTCStatsIceCandidatePairState
+    get() = unsafeCast("failed")
+
+inline val RTCStatsIceCandidatePairState.Companion.frozen: RTCStatsIceCandidatePairState
+    get() = unsafeCast("frozen")
+
+inline val RTCStatsIceCandidatePairState.Companion.inProgress: RTCStatsIceCandidatePairState
+    get() = unsafeCast("in-progress")
+
+inline val RTCStatsIceCandidatePairState.Companion.inprogress: RTCStatsIceCandidatePairState
+    get() = unsafeCast("inprogress")
+
+inline val RTCStatsIceCandidatePairState.Companion.succeeded: RTCStatsIceCandidatePairState
+    get() = unsafeCast("succeeded")
+
+inline val RTCStatsIceCandidatePairState.Companion.waiting: RTCStatsIceCandidatePairState
+    get() = unsafeCast("waiting")

--- a/kotlin-browser/src/commonMain/generated/web/rtc/RTCStatsType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/rtc/RTCStatsType.kt
@@ -6,50 +6,50 @@
 
 package web.rtc
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RTCStatsType {
-    companion object {
-        @JsValue("candidate-pair")
-        val candidatePair: RTCStatsType
-
-        @JsValue("certificate")
-        val certificate: RTCStatsType
-
-        @JsValue("codec")
-        val codec: RTCStatsType
-
-        @JsValue("data-channel")
-        val dataChannel: RTCStatsType
-
-        @JsValue("inbound-rtp")
-        val inboundRtp: RTCStatsType
-
-        @JsValue("local-candidate")
-        val localCandidate: RTCStatsType
-
-        @JsValue("media-playout")
-        val mediaPlayout: RTCStatsType
-
-        @JsValue("media-source")
-        val mediaSource: RTCStatsType
-
-        @JsValue("outbound-rtp")
-        val outboundRtp: RTCStatsType
-
-        @JsValue("peer-connection")
-        val peerConnection: RTCStatsType
-
-        @JsValue("remote-candidate")
-        val remoteCandidate: RTCStatsType
-
-        @JsValue("remote-inbound-rtp")
-        val remoteInboundRtp: RTCStatsType
-
-        @JsValue("remote-outbound-rtp")
-        val remoteOutboundRtp: RTCStatsType
-
-        @JsValue("transport")
-        val transport: RTCStatsType
-    }
+    companion object
 }
+
+inline val RTCStatsType.Companion.candidatePair: RTCStatsType
+    get() = unsafeCast("candidate-pair")
+
+inline val RTCStatsType.Companion.certificate: RTCStatsType
+    get() = unsafeCast("certificate")
+
+inline val RTCStatsType.Companion.codec: RTCStatsType
+    get() = unsafeCast("codec")
+
+inline val RTCStatsType.Companion.dataChannel: RTCStatsType
+    get() = unsafeCast("data-channel")
+
+inline val RTCStatsType.Companion.inboundRtp: RTCStatsType
+    get() = unsafeCast("inbound-rtp")
+
+inline val RTCStatsType.Companion.localCandidate: RTCStatsType
+    get() = unsafeCast("local-candidate")
+
+inline val RTCStatsType.Companion.mediaPlayout: RTCStatsType
+    get() = unsafeCast("media-playout")
+
+inline val RTCStatsType.Companion.mediaSource: RTCStatsType
+    get() = unsafeCast("media-source")
+
+inline val RTCStatsType.Companion.outboundRtp: RTCStatsType
+    get() = unsafeCast("outbound-rtp")
+
+inline val RTCStatsType.Companion.peerConnection: RTCStatsType
+    get() = unsafeCast("peer-connection")
+
+inline val RTCStatsType.Companion.remoteCandidate: RTCStatsType
+    get() = unsafeCast("remote-candidate")
+
+inline val RTCStatsType.Companion.remoteInboundRtp: RTCStatsType
+    get() = unsafeCast("remote-inbound-rtp")
+
+inline val RTCStatsType.Companion.remoteOutboundRtp: RTCStatsType
+    get() = unsafeCast("remote-outbound-rtp")
+
+inline val RTCStatsType.Companion.transport: RTCStatsType
+    get() = unsafeCast("transport")

--- a/kotlin-browser/src/commonMain/generated/web/screen/OrientationType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/screen/OrientationType.kt
@@ -6,20 +6,20 @@
 
 package web.screen
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface OrientationType {
-    companion object {
-        @JsValue("landscape-primary")
-        val landscapePrimary: OrientationType
-
-        @JsValue("landscape-secondary")
-        val landscapeSecondary: OrientationType
-
-        @JsValue("portrait-primary")
-        val portraitPrimary: OrientationType
-
-        @JsValue("portrait-secondary")
-        val portraitSecondary: OrientationType
-    }
+    companion object
 }
+
+inline val OrientationType.Companion.landscapePrimary: OrientationType
+    get() = unsafeCast("landscape-primary")
+
+inline val OrientationType.Companion.landscapeSecondary: OrientationType
+    get() = unsafeCast("landscape-secondary")
+
+inline val OrientationType.Companion.portraitPrimary: OrientationType
+    get() = unsafeCast("portrait-primary")
+
+inline val OrientationType.Companion.portraitSecondary: OrientationType
+    get() = unsafeCast("portrait-secondary")

--- a/kotlin-browser/src/commonMain/generated/web/scroll/ScrollBehavior.kt
+++ b/kotlin-browser/src/commonMain/generated/web/scroll/ScrollBehavior.kt
@@ -6,17 +6,17 @@
 
 package web.scroll
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ScrollBehavior {
-    companion object {
-        @JsValue("auto")
-        val auto: ScrollBehavior
-
-        @JsValue("instant")
-        val instant: ScrollBehavior
-
-        @JsValue("smooth")
-        val smooth: ScrollBehavior
-    }
+    companion object
 }
+
+inline val ScrollBehavior.Companion.auto: ScrollBehavior
+    get() = unsafeCast("auto")
+
+inline val ScrollBehavior.Companion.instant: ScrollBehavior
+    get() = unsafeCast("instant")
+
+inline val ScrollBehavior.Companion.smooth: ScrollBehavior
+    get() = unsafeCast("smooth")

--- a/kotlin-browser/src/commonMain/generated/web/scroll/ScrollLogicalPosition.kt
+++ b/kotlin-browser/src/commonMain/generated/web/scroll/ScrollLogicalPosition.kt
@@ -6,20 +6,20 @@
 
 package web.scroll
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ScrollLogicalPosition {
-    companion object {
-        @JsValue("center")
-        val center: ScrollLogicalPosition
-
-        @JsValue("end")
-        val end: ScrollLogicalPosition
-
-        @JsValue("nearest")
-        val nearest: ScrollLogicalPosition
-
-        @JsValue("start")
-        val start: ScrollLogicalPosition
-    }
+    companion object
 }
+
+inline val ScrollLogicalPosition.Companion.center: ScrollLogicalPosition
+    get() = unsafeCast("center")
+
+inline val ScrollLogicalPosition.Companion.end: ScrollLogicalPosition
+    get() = unsafeCast("end")
+
+inline val ScrollLogicalPosition.Companion.nearest: ScrollLogicalPosition
+    get() = unsafeCast("nearest")
+
+inline val ScrollLogicalPosition.Companion.start: ScrollLogicalPosition
+    get() = unsafeCast("start")

--- a/kotlin-browser/src/commonMain/generated/web/serviceworker/ClientTypes.kt
+++ b/kotlin-browser/src/commonMain/generated/web/serviceworker/ClientTypes.kt
@@ -6,20 +6,20 @@
 
 package web.serviceworker
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ClientTypes {
-    companion object {
-        @JsValue("all")
-        val all: ClientTypes
-
-        @JsValue("sharedworker")
-        val sharedworker: ClientTypes
-
-        @JsValue("window")
-        val window: ClientTypes
-
-        @JsValue("worker")
-        val worker: ClientTypes
-    }
+    companion object
 }
+
+inline val ClientTypes.Companion.all: ClientTypes
+    get() = unsafeCast("all")
+
+inline val ClientTypes.Companion.sharedworker: ClientTypes
+    get() = unsafeCast("sharedworker")
+
+inline val ClientTypes.Companion.window: ClientTypes
+    get() = unsafeCast("window")
+
+inline val ClientTypes.Companion.worker: ClientTypes
+    get() = unsafeCast("worker")

--- a/kotlin-browser/src/commonMain/generated/web/serviceworker/FrameType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/serviceworker/FrameType.kt
@@ -6,20 +6,20 @@
 
 package web.serviceworker
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FrameType {
-    companion object {
-        @JsValue("auxiliary")
-        val auxiliary: FrameType
-
-        @JsValue("nested")
-        val nested: FrameType
-
-        @JsValue("none")
-        val none: FrameType
-
-        @JsValue("top-level")
-        val topLevel: FrameType
-    }
+    companion object
 }
+
+inline val FrameType.Companion.auxiliary: FrameType
+    get() = unsafeCast("auxiliary")
+
+inline val FrameType.Companion.nested: FrameType
+    get() = unsafeCast("nested")
+
+inline val FrameType.Companion.none: FrameType
+    get() = unsafeCast("none")
+
+inline val FrameType.Companion.topLevel: FrameType
+    get() = unsafeCast("top-level")

--- a/kotlin-browser/src/commonMain/generated/web/serviceworker/ServiceWorkerState.kt
+++ b/kotlin-browser/src/commonMain/generated/web/serviceworker/ServiceWorkerState.kt
@@ -6,26 +6,26 @@
 
 package web.serviceworker
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ServiceWorkerState {
-    companion object {
-        @JsValue("activated")
-        val activated: ServiceWorkerState
-
-        @JsValue("activating")
-        val activating: ServiceWorkerState
-
-        @JsValue("installed")
-        val installed: ServiceWorkerState
-
-        @JsValue("installing")
-        val installing: ServiceWorkerState
-
-        @JsValue("parsed")
-        val parsed: ServiceWorkerState
-
-        @JsValue("redundant")
-        val redundant: ServiceWorkerState
-    }
+    companion object
 }
+
+inline val ServiceWorkerState.Companion.activated: ServiceWorkerState
+    get() = unsafeCast("activated")
+
+inline val ServiceWorkerState.Companion.activating: ServiceWorkerState
+    get() = unsafeCast("activating")
+
+inline val ServiceWorkerState.Companion.installed: ServiceWorkerState
+    get() = unsafeCast("installed")
+
+inline val ServiceWorkerState.Companion.installing: ServiceWorkerState
+    get() = unsafeCast("installing")
+
+inline val ServiceWorkerState.Companion.parsed: ServiceWorkerState
+    get() = unsafeCast("parsed")
+
+inline val ServiceWorkerState.Companion.redundant: ServiceWorkerState
+    get() = unsafeCast("redundant")

--- a/kotlin-browser/src/commonMain/generated/web/serviceworker/ServiceWorkerUpdateViaCache.kt
+++ b/kotlin-browser/src/commonMain/generated/web/serviceworker/ServiceWorkerUpdateViaCache.kt
@@ -6,17 +6,17 @@
 
 package web.serviceworker
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ServiceWorkerUpdateViaCache {
-    companion object {
-        @JsValue("all")
-        val all: ServiceWorkerUpdateViaCache
-
-        @JsValue("imports")
-        val imports: ServiceWorkerUpdateViaCache
-
-        @JsValue("none")
-        val none: ServiceWorkerUpdateViaCache
-    }
+    companion object
 }
+
+inline val ServiceWorkerUpdateViaCache.Companion.all: ServiceWorkerUpdateViaCache
+    get() = unsafeCast("all")
+
+inline val ServiceWorkerUpdateViaCache.Companion.imports: ServiceWorkerUpdateViaCache
+    get() = unsafeCast("imports")
+
+inline val ServiceWorkerUpdateViaCache.Companion.none: ServiceWorkerUpdateViaCache
+    get() = unsafeCast("none")

--- a/kotlin-browser/src/commonMain/generated/web/speech/SpeechSynthesisErrorCode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/speech/SpeechSynthesisErrorCode.kt
@@ -6,44 +6,44 @@
 
 package web.speech
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SpeechSynthesisErrorCode {
-    companion object {
-        @JsValue("audio-busy")
-        val audioBusy: SpeechSynthesisErrorCode
-
-        @JsValue("audio-hardware")
-        val audioHardware: SpeechSynthesisErrorCode
-
-        @JsValue("canceled")
-        val canceled: SpeechSynthesisErrorCode
-
-        @JsValue("interrupted")
-        val interrupted: SpeechSynthesisErrorCode
-
-        @JsValue("invalid-argument")
-        val invalidArgument: SpeechSynthesisErrorCode
-
-        @JsValue("language-unavailable")
-        val languageUnavailable: SpeechSynthesisErrorCode
-
-        @JsValue("network")
-        val network: SpeechSynthesisErrorCode
-
-        @JsValue("not-allowed")
-        val notAllowed: SpeechSynthesisErrorCode
-
-        @JsValue("synthesis-failed")
-        val synthesisFailed: SpeechSynthesisErrorCode
-
-        @JsValue("synthesis-unavailable")
-        val synthesisUnavailable: SpeechSynthesisErrorCode
-
-        @JsValue("text-too-long")
-        val textTooLong: SpeechSynthesisErrorCode
-
-        @JsValue("voice-unavailable")
-        val voiceUnavailable: SpeechSynthesisErrorCode
-    }
+    companion object
 }
+
+inline val SpeechSynthesisErrorCode.Companion.audioBusy: SpeechSynthesisErrorCode
+    get() = unsafeCast("audio-busy")
+
+inline val SpeechSynthesisErrorCode.Companion.audioHardware: SpeechSynthesisErrorCode
+    get() = unsafeCast("audio-hardware")
+
+inline val SpeechSynthesisErrorCode.Companion.canceled: SpeechSynthesisErrorCode
+    get() = unsafeCast("canceled")
+
+inline val SpeechSynthesisErrorCode.Companion.interrupted: SpeechSynthesisErrorCode
+    get() = unsafeCast("interrupted")
+
+inline val SpeechSynthesisErrorCode.Companion.invalidArgument: SpeechSynthesisErrorCode
+    get() = unsafeCast("invalid-argument")
+
+inline val SpeechSynthesisErrorCode.Companion.languageUnavailable: SpeechSynthesisErrorCode
+    get() = unsafeCast("language-unavailable")
+
+inline val SpeechSynthesisErrorCode.Companion.network: SpeechSynthesisErrorCode
+    get() = unsafeCast("network")
+
+inline val SpeechSynthesisErrorCode.Companion.notAllowed: SpeechSynthesisErrorCode
+    get() = unsafeCast("not-allowed")
+
+inline val SpeechSynthesisErrorCode.Companion.synthesisFailed: SpeechSynthesisErrorCode
+    get() = unsafeCast("synthesis-failed")
+
+inline val SpeechSynthesisErrorCode.Companion.synthesisUnavailable: SpeechSynthesisErrorCode
+    get() = unsafeCast("synthesis-unavailable")
+
+inline val SpeechSynthesisErrorCode.Companion.textTooLong: SpeechSynthesisErrorCode
+    get() = unsafeCast("text-too-long")
+
+inline val SpeechSynthesisErrorCode.Companion.voiceUnavailable: SpeechSynthesisErrorCode
+    get() = unsafeCast("voice-unavailable")

--- a/kotlin-browser/src/commonMain/generated/web/transport/WebTransportCongestionControl.kt
+++ b/kotlin-browser/src/commonMain/generated/web/transport/WebTransportCongestionControl.kt
@@ -6,17 +6,17 @@
 
 package web.transport
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WebTransportCongestionControl {
-    companion object {
-        @JsValue("default")
-        val default: WebTransportCongestionControl
-
-        @JsValue("low-latency")
-        val lowLatency: WebTransportCongestionControl
-
-        @JsValue("throughput")
-        val throughput: WebTransportCongestionControl
-    }
+    companion object
 }
+
+inline val WebTransportCongestionControl.Companion.default: WebTransportCongestionControl
+    get() = unsafeCast("default")
+
+inline val WebTransportCongestionControl.Companion.lowLatency: WebTransportCongestionControl
+    get() = unsafeCast("low-latency")
+
+inline val WebTransportCongestionControl.Companion.throughput: WebTransportCongestionControl
+    get() = unsafeCast("throughput")

--- a/kotlin-browser/src/commonMain/generated/web/transport/WebTransportErrorSource.kt
+++ b/kotlin-browser/src/commonMain/generated/web/transport/WebTransportErrorSource.kt
@@ -6,14 +6,14 @@
 
 package web.transport
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WebTransportErrorSource {
-    companion object {
-        @JsValue("session")
-        val session: WebTransportErrorSource
-
-        @JsValue("stream")
-        val stream: WebTransportErrorSource
-    }
+    companion object
 }
+
+inline val WebTransportErrorSource.Companion.session: WebTransportErrorSource
+    get() = unsafeCast("session")
+
+inline val WebTransportErrorSource.Companion.stream: WebTransportErrorSource
+    get() = unsafeCast("stream")

--- a/kotlin-browser/src/commonMain/generated/web/uievents/TouchType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/uievents/TouchType.kt
@@ -6,14 +6,14 @@
 
 package web.uievents
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TouchType {
-    companion object {
-        @JsValue("direct")
-        val direct: TouchType
-
-        @JsValue("stylus")
-        val stylus: TouchType
-    }
+    companion object
 }
+
+inline val TouchType.Companion.direct: TouchType
+    get() = unsafeCast("direct")
+
+inline val TouchType.Companion.stylus: TouchType
+    get() = unsafeCast("stylus")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/AlignSetting.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/AlignSetting.kt
@@ -6,23 +6,23 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AlignSetting {
-    companion object {
-        @JsValue("center")
-        val center: AlignSetting
-
-        @JsValue("end")
-        val end: AlignSetting
-
-        @JsValue("left")
-        val left: AlignSetting
-
-        @JsValue("right")
-        val right: AlignSetting
-
-        @JsValue("start")
-        val start: AlignSetting
-    }
+    companion object
 }
+
+inline val AlignSetting.Companion.center: AlignSetting
+    get() = unsafeCast("center")
+
+inline val AlignSetting.Companion.end: AlignSetting
+    get() = unsafeCast("end")
+
+inline val AlignSetting.Companion.left: AlignSetting
+    get() = unsafeCast("left")
+
+inline val AlignSetting.Companion.right: AlignSetting
+    get() = unsafeCast("right")
+
+inline val AlignSetting.Companion.start: AlignSetting
+    get() = unsafeCast("start")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/AutoKeyword.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/AutoKeyword.kt
@@ -6,11 +6,11 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface AutoKeyword {
-    companion object {
-        @JsValue("auto")
-        val auto: AutoKeyword
-    }
+    companion object
 }
+
+inline val AutoKeyword.Companion.auto: AutoKeyword
+    get() = unsafeCast("auto")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/DirectionSetting.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/DirectionSetting.kt
@@ -6,17 +6,17 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DirectionSetting {
-    companion object {
-        @JsValue("")
-        val none: DirectionSetting
-
-        @JsValue("lr")
-        val lr: DirectionSetting
-
-        @JsValue("rl")
-        val rl: DirectionSetting
-    }
+    companion object
 }
+
+inline val DirectionSetting.Companion.none: DirectionSetting
+    get() = unsafeCast("")
+
+inline val DirectionSetting.Companion.lr: DirectionSetting
+    get() = unsafeCast("lr")
+
+inline val DirectionSetting.Companion.rl: DirectionSetting
+    get() = unsafeCast("rl")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/LineAlignSetting.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/LineAlignSetting.kt
@@ -6,17 +6,17 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LineAlignSetting {
-    companion object {
-        @JsValue("center")
-        val center: LineAlignSetting
-
-        @JsValue("end")
-        val end: LineAlignSetting
-
-        @JsValue("start")
-        val start: LineAlignSetting
-    }
+    companion object
 }
+
+inline val LineAlignSetting.Companion.center: LineAlignSetting
+    get() = unsafeCast("center")
+
+inline val LineAlignSetting.Companion.end: LineAlignSetting
+    get() = unsafeCast("end")
+
+inline val LineAlignSetting.Companion.start: LineAlignSetting
+    get() = unsafeCast("start")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/PositionAlignSetting.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/PositionAlignSetting.kt
@@ -6,20 +6,20 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PositionAlignSetting {
-    companion object {
-        @JsValue("auto")
-        val auto: PositionAlignSetting
-
-        @JsValue("center")
-        val center: PositionAlignSetting
-
-        @JsValue("line-left")
-        val lineLeft: PositionAlignSetting
-
-        @JsValue("line-right")
-        val lineRight: PositionAlignSetting
-    }
+    companion object
 }
+
+inline val PositionAlignSetting.Companion.auto: PositionAlignSetting
+    get() = unsafeCast("auto")
+
+inline val PositionAlignSetting.Companion.center: PositionAlignSetting
+    get() = unsafeCast("center")
+
+inline val PositionAlignSetting.Companion.lineLeft: PositionAlignSetting
+    get() = unsafeCast("line-left")
+
+inline val PositionAlignSetting.Companion.lineRight: PositionAlignSetting
+    get() = unsafeCast("line-right")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/ScrollSetting.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/ScrollSetting.kt
@@ -6,14 +6,14 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ScrollSetting {
-    companion object {
-        @JsValue("")
-        val none: ScrollSetting
-
-        @JsValue("up")
-        val up: ScrollSetting
-    }
+    companion object
 }
+
+inline val ScrollSetting.Companion.none: ScrollSetting
+    get() = unsafeCast("")
+
+inline val ScrollSetting.Companion.up: ScrollSetting
+    get() = unsafeCast("up")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/TextTrackKind.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/TextTrackKind.kt
@@ -6,23 +6,23 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TextTrackKind {
-    companion object {
-        @JsValue("captions")
-        val captions: TextTrackKind
-
-        @JsValue("chapters")
-        val chapters: TextTrackKind
-
-        @JsValue("descriptions")
-        val descriptions: TextTrackKind
-
-        @JsValue("metadata")
-        val metadata: TextTrackKind
-
-        @JsValue("subtitles")
-        val subtitles: TextTrackKind
-    }
+    companion object
 }
+
+inline val TextTrackKind.Companion.captions: TextTrackKind
+    get() = unsafeCast("captions")
+
+inline val TextTrackKind.Companion.chapters: TextTrackKind
+    get() = unsafeCast("chapters")
+
+inline val TextTrackKind.Companion.descriptions: TextTrackKind
+    get() = unsafeCast("descriptions")
+
+inline val TextTrackKind.Companion.metadata: TextTrackKind
+    get() = unsafeCast("metadata")
+
+inline val TextTrackKind.Companion.subtitles: TextTrackKind
+    get() = unsafeCast("subtitles")

--- a/kotlin-browser/src/commonMain/generated/web/vtt/TextTrackMode.kt
+++ b/kotlin-browser/src/commonMain/generated/web/vtt/TextTrackMode.kt
@@ -6,17 +6,17 @@
 
 package web.vtt
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TextTrackMode {
-    companion object {
-        @JsValue("disabled")
-        val disabled: TextTrackMode
-
-        @JsValue("hidden")
-        val hidden: TextTrackMode
-
-        @JsValue("showing")
-        val showing: TextTrackMode
-    }
+    companion object
 }
+
+inline val TextTrackMode.Companion.disabled: TextTrackMode
+    get() = unsafeCast("disabled")
+
+inline val TextTrackMode.Companion.hidden: TextTrackMode
+    get() = unsafeCast("hidden")
+
+inline val TextTrackMode.Companion.showing: TextTrackMode
+    get() = unsafeCast("showing")

--- a/kotlin-browser/src/commonMain/generated/web/wakelock/WakeLockType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/wakelock/WakeLockType.kt
@@ -6,11 +6,11 @@
 
 package web.wakelock
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WakeLockType {
-    companion object {
-        @JsValue("screen")
-        val screen: WakeLockType
-    }
+    companion object
 }
+
+inline val WakeLockType.Companion.screen: WakeLockType
+    get() = unsafeCast("screen")

--- a/kotlin-browser/src/commonMain/generated/web/window/WindowTarget.kt
+++ b/kotlin-browser/src/commonMain/generated/web/window/WindowTarget.kt
@@ -6,20 +6,20 @@
 
 package web.window
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WindowTarget {
-    companion object {
-        @JsValue("_self")
-        val _self: WindowTarget
-
-        @JsValue("_blank")
-        val _blank: WindowTarget
-
-        @JsValue("_parent")
-        val _parent: WindowTarget
-
-        @JsValue("_top")
-        val _top: WindowTarget
-    }
+    companion object
 }
+
+inline val WindowTarget.Companion._self: WindowTarget
+    get() = unsafeCast("_self")
+
+inline val WindowTarget.Companion._blank: WindowTarget
+    get() = unsafeCast("_blank")
+
+inline val WindowTarget.Companion._parent: WindowTarget
+    get() = unsafeCast("_parent")
+
+inline val WindowTarget.Companion._top: WindowTarget
+    get() = unsafeCast("_top")

--- a/kotlin-browser/src/commonMain/generated/web/workers/WorkerType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/workers/WorkerType.kt
@@ -6,14 +6,14 @@
 
 package web.workers
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WorkerType {
-    companion object {
-        @JsValue("classic")
-        val classic: WorkerType
-
-        @JsValue("module")
-        val module: WorkerType
-    }
+    companion object
 }
+
+inline val WorkerType.Companion.classic: WorkerType
+    get() = unsafeCast("classic")
+
+inline val WorkerType.Companion.module: WorkerType
+    get() = unsafeCast("module")

--- a/kotlin-browser/src/commonMain/generated/web/xhr/XMLHttpRequestResponseType.kt
+++ b/kotlin-browser/src/commonMain/generated/web/xhr/XMLHttpRequestResponseType.kt
@@ -6,26 +6,26 @@
 
 package web.xhr
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface XMLHttpRequestResponseType {
-    companion object {
-        @JsValue("")
-        val none: XMLHttpRequestResponseType
-
-        @JsValue("arraybuffer")
-        val arraybuffer: XMLHttpRequestResponseType
-
-        @JsValue("blob")
-        val blob: XMLHttpRequestResponseType
-
-        @JsValue("document")
-        val document: XMLHttpRequestResponseType
-
-        @JsValue("json")
-        val json: XMLHttpRequestResponseType
-
-        @JsValue("text")
-        val text: XMLHttpRequestResponseType
-    }
+    companion object
 }
+
+inline val XMLHttpRequestResponseType.Companion.none: XMLHttpRequestResponseType
+    get() = unsafeCast("")
+
+inline val XMLHttpRequestResponseType.Companion.arraybuffer: XMLHttpRequestResponseType
+    get() = unsafeCast("arraybuffer")
+
+inline val XMLHttpRequestResponseType.Companion.blob: XMLHttpRequestResponseType
+    get() = unsafeCast("blob")
+
+inline val XMLHttpRequestResponseType.Companion.document: XMLHttpRequestResponseType
+    get() = unsafeCast("document")
+
+inline val XMLHttpRequestResponseType.Companion.json: XMLHttpRequestResponseType
+    get() = unsafeCast("json")
+
+inline val XMLHttpRequestResponseType.Companion.text: XMLHttpRequestResponseType
+    get() = unsafeCast("text")

--- a/kotlin-js/src/commonMain/generated/js/atomic/WaitStatus.kt
+++ b/kotlin-js/src/commonMain/generated/js/atomic/WaitStatus.kt
@@ -6,26 +6,24 @@
 
 package js.atomic
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WaitStatus {
-
-    companion object {
-
-        @JsValue("ok")
-        val ok: ok
-
-        @JsValue("not-equal")
-        val notEqual: notEqual
-
-        @JsValue("timed-out")
-        val timedOut: timedOut
-    }
-
     sealed interface ok : WaitAsyncStatus
     sealed interface notEqual : WaitSyncStatus
     sealed interface timedOut : WaitAsyncStatus, WaitSyncStatus
+
+    companion object
 }
+
+inline val WaitStatus.Companion.ok: WaitStatus.ok
+    get() = unsafeCast("ok")
+
+inline val WaitStatus.Companion.notEqual: WaitStatus.notEqual
+    get() = unsafeCast("not-equal")
+
+inline val WaitStatus.Companion.timedOut: WaitStatus.timedOut
+    get() = unsafeCast("timed-out")
 
 sealed external interface WaitAsyncStatus : WaitStatus
 sealed external interface WaitSyncStatus : WaitStatus

--- a/kotlin-js/src/commonMain/generated/js/decorators/DecoratorContextKind.kt
+++ b/kotlin-js/src/commonMain/generated/js/decorators/DecoratorContextKind.kt
@@ -6,33 +6,33 @@
 
 package js.decorators
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DecoratorContextKind {
-    companion object {
-        @JsValue("class")
-        val `class`: `class`
-
-        @JsValue("method")
-        val method: method
-
-        @JsValue("getter")
-        val getter: getter
-
-        @JsValue("setter")
-        val setter: setter
-
-        @JsValue("accessor")
-        val accessor: accessor
-
-        @JsValue("field")
-        val field: field
-    }
-
     sealed interface `class` : DecoratorContextKind
     sealed interface method : DecoratorContextKind
     sealed interface getter : DecoratorContextKind
     sealed interface setter : DecoratorContextKind
     sealed interface accessor : DecoratorContextKind
     sealed interface field : DecoratorContextKind
+
+    companion object
 }
+
+inline val DecoratorContextKind.Companion.`class`: DecoratorContextKind.`class`
+    get() = unsafeCast("class")
+
+inline val DecoratorContextKind.Companion.method: DecoratorContextKind.method
+    get() = unsafeCast("method")
+
+inline val DecoratorContextKind.Companion.getter: DecoratorContextKind.getter
+    get() = unsafeCast("getter")
+
+inline val DecoratorContextKind.Companion.setter: DecoratorContextKind.setter
+    get() = unsafeCast("setter")
+
+inline val DecoratorContextKind.Companion.accessor: DecoratorContextKind.accessor
+    get() = unsafeCast("accessor")
+
+inline val DecoratorContextKind.Companion.field: DecoratorContextKind.field
+    get() = unsafeCast("field")

--- a/kotlin-js/src/commonMain/generated/js/intl/CaseFirst.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/CaseFirst.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CaseFirst {
-    companion object {
-        @JsValue("upper")
-        val upper: CaseFirst
-
-        @JsValue("lower")
-        val lower: CaseFirst
-
-        @JsValue("false")
-        val `false`: CaseFirst
-    }
+    companion object
 }
+
+inline val CaseFirst.Companion.upper: CaseFirst
+    get() = unsafeCast("upper")
+
+inline val CaseFirst.Companion.lower: CaseFirst
+    get() = unsafeCast("lower")
+
+inline val CaseFirst.Companion.`false`: CaseFirst
+    get() = unsafeCast("false")

--- a/kotlin-js/src/commonMain/generated/js/intl/Collation.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/Collation.kt
@@ -6,59 +6,59 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Collation {
-    companion object {
-        @JsValue("big5han")
-        val big5han: Collation
-
-        @JsValue("compat")
-        val compat: Collation
-
-        @JsValue("dict")
-        val dict: Collation
-
-        @JsValue("direct")
-        val direct: Collation
-
-        @JsValue("ducet")
-        val ducet: Collation
-
-        @JsValue("emoji")
-        val emoji: Collation
-
-        @JsValue("eor")
-        val eor: Collation
-
-        @JsValue("gb2312")
-        val gb2312: Collation
-
-        @JsValue("phonebk")
-        val phonebk: Collation
-
-        @JsValue("phonetic")
-        val phonetic: Collation
-
-        @JsValue("pinyin")
-        val pinyin: Collation
-
-        @JsValue("reformed")
-        val reformed: Collation
-
-        @JsValue("searchjl")
-        val searchjl: Collation
-
-        @JsValue("stroke")
-        val stroke: Collation
-
-        @JsValue("trad")
-        val trad: Collation
-
-        @JsValue("unihan")
-        val unihan: Collation
-
-        @JsValue("zhuyin")
-        val zhuyin: Collation
-    }
+    companion object
 }
+
+inline val Collation.Companion.big5han: Collation
+    get() = unsafeCast("big5han")
+
+inline val Collation.Companion.compat: Collation
+    get() = unsafeCast("compat")
+
+inline val Collation.Companion.dict: Collation
+    get() = unsafeCast("dict")
+
+inline val Collation.Companion.direct: Collation
+    get() = unsafeCast("direct")
+
+inline val Collation.Companion.ducet: Collation
+    get() = unsafeCast("ducet")
+
+inline val Collation.Companion.emoji: Collation
+    get() = unsafeCast("emoji")
+
+inline val Collation.Companion.eor: Collation
+    get() = unsafeCast("eor")
+
+inline val Collation.Companion.gb2312: Collation
+    get() = unsafeCast("gb2312")
+
+inline val Collation.Companion.phonebk: Collation
+    get() = unsafeCast("phonebk")
+
+inline val Collation.Companion.phonetic: Collation
+    get() = unsafeCast("phonetic")
+
+inline val Collation.Companion.pinyin: Collation
+    get() = unsafeCast("pinyin")
+
+inline val Collation.Companion.reformed: Collation
+    get() = unsafeCast("reformed")
+
+inline val Collation.Companion.searchjl: Collation
+    get() = unsafeCast("searchjl")
+
+inline val Collation.Companion.stroke: Collation
+    get() = unsafeCast("stroke")
+
+inline val Collation.Companion.trad: Collation
+    get() = unsafeCast("trad")
+
+inline val Collation.Companion.unihan: Collation
+    get() = unsafeCast("unihan")
+
+inline val Collation.Companion.zhuyin: Collation
+    get() = unsafeCast("zhuyin")

--- a/kotlin-js/src/commonMain/generated/js/intl/CollatorUsage.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/CollatorUsage.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CollatorUsage {
-    companion object {
-        @JsValue("sort")
-        val sort: CollatorUsage
-
-        @JsValue("search")
-        val search: CollatorUsage
-    }
+    companion object
 }
+
+inline val CollatorUsage.Companion.sort: CollatorUsage
+    get() = unsafeCast("sort")
+
+inline val CollatorUsage.Companion.search: CollatorUsage
+    get() = unsafeCast("search")

--- a/kotlin-js/src/commonMain/generated/js/intl/CompactDisplay.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/CompactDisplay.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CompactDisplay {
-    companion object {
-        @JsValue("short")
-        val short: CompactDisplay
-
-        @JsValue("long")
-        val long: CompactDisplay
-    }
+    companion object
 }
+
+inline val CompactDisplay.Companion.short: CompactDisplay
+    get() = unsafeCast("short")
+
+inline val CompactDisplay.Companion.long: CompactDisplay
+    get() = unsafeCast("long")

--- a/kotlin-js/src/commonMain/generated/js/intl/CurrencySign.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/CurrencySign.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CurrencySign {
-    companion object {
-        @JsValue("standard")
-        val standard: CurrencySign
-
-        @JsValue("accounting")
-        val accounting: CurrencySign
-    }
+    companion object
 }
+
+inline val CurrencySign.Companion.standard: CurrencySign
+    get() = unsafeCast("standard")
+
+inline val CurrencySign.Companion.accounting: CurrencySign
+    get() = unsafeCast("accounting")

--- a/kotlin-js/src/commonMain/generated/js/intl/DateStyle.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DateStyle.kt
@@ -6,20 +6,20 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DateStyle {
-    companion object {
-        @JsValue("full")
-        val full: DateStyle
-
-        @JsValue("long")
-        val long: DateStyle
-
-        @JsValue("medium")
-        val medium: DateStyle
-
-        @JsValue("short")
-        val short: DateStyle
-    }
+    companion object
 }
+
+inline val DateStyle.Companion.full: DateStyle
+    get() = unsafeCast("full")
+
+inline val DateStyle.Companion.long: DateStyle
+    get() = unsafeCast("long")
+
+inline val DateStyle.Companion.medium: DateStyle
+    get() = unsafeCast("medium")
+
+inline val DateStyle.Companion.short: DateStyle
+    get() = unsafeCast("short")

--- a/kotlin-js/src/commonMain/generated/js/intl/DayFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DayFormat.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DayFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: DayFormat
-
-        @JsValue("2-digit")
-        val twoDigit: DayFormat
-    }
+    companion object
 }
+
+inline val DayFormat.Companion.numeric: DayFormat
+    get() = unsafeCast("numeric")
+
+inline val DayFormat.Companion.twoDigit: DayFormat
+    get() = unsafeCast("2-digit")

--- a/kotlin-js/src/commonMain/generated/js/intl/DayPeriod.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DayPeriod.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DayPeriod {
-    companion object {
-        @JsValue("narrow")
-        val narrow: DayPeriod
-
-        @JsValue("short")
-        val short: DayPeriod
-
-        @JsValue("long")
-        val long: DayPeriod
-    }
+    companion object
 }
+
+inline val DayPeriod.Companion.narrow: DayPeriod
+    get() = unsafeCast("narrow")
+
+inline val DayPeriod.Companion.short: DayPeriod
+    get() = unsafeCast("short")
+
+inline val DayPeriod.Companion.long: DayPeriod
+    get() = unsafeCast("long")

--- a/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesFallback.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesFallback.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DisplayNamesFallback {
-    companion object {
-        @JsValue("code")
-        val code: DisplayNamesFallback
-
-        @JsValue("none")
-        val none: DisplayNamesFallback
-    }
+    companion object
 }
+
+inline val DisplayNamesFallback.Companion.code: DisplayNamesFallback
+    get() = unsafeCast("code")
+
+inline val DisplayNamesFallback.Companion.none: DisplayNamesFallback
+    get() = unsafeCast("none")

--- a/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesLanguageDisplay.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesLanguageDisplay.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DisplayNamesLanguageDisplay {
-    companion object {
-        @JsValue("dialect")
-        val dialect: DisplayNamesLanguageDisplay
-
-        @JsValue("standard")
-        val standard: DisplayNamesLanguageDisplay
-    }
+    companion object
 }
+
+inline val DisplayNamesLanguageDisplay.Companion.dialect: DisplayNamesLanguageDisplay
+    get() = unsafeCast("dialect")
+
+inline val DisplayNamesLanguageDisplay.Companion.standard: DisplayNamesLanguageDisplay
+    get() = unsafeCast("standard")

--- a/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesType.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/DisplayNamesType.kt
@@ -6,26 +6,26 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface DisplayNamesType {
-    companion object {
-        @JsValue("language")
-        val language: DisplayNamesType
-
-        @JsValue("region")
-        val region: DisplayNamesType
-
-        @JsValue("script")
-        val script: DisplayNamesType
-
-        @JsValue("calendar")
-        val calendar: DisplayNamesType
-
-        @JsValue("dateTimeField")
-        val dateTimeField: DisplayNamesType
-
-        @JsValue("currency")
-        val currency: DisplayNamesType
-    }
+    companion object
 }
+
+inline val DisplayNamesType.Companion.language: DisplayNamesType
+    get() = unsafeCast("language")
+
+inline val DisplayNamesType.Companion.region: DisplayNamesType
+    get() = unsafeCast("region")
+
+inline val DisplayNamesType.Companion.script: DisplayNamesType
+    get() = unsafeCast("script")
+
+inline val DisplayNamesType.Companion.calendar: DisplayNamesType
+    get() = unsafeCast("calendar")
+
+inline val DisplayNamesType.Companion.dateTimeField: DisplayNamesType
+    get() = unsafeCast("dateTimeField")
+
+inline val DisplayNamesType.Companion.currency: DisplayNamesType
+    get() = unsafeCast("currency")

--- a/kotlin-js/src/commonMain/generated/js/intl/EraFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/EraFormat.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EraFormat {
-    companion object {
-        @JsValue("long")
-        val long: EraFormat
-
-        @JsValue("short")
-        val short: EraFormat
-
-        @JsValue("narrow")
-        val narrow: EraFormat
-    }
+    companion object
 }
+
+inline val EraFormat.Companion.long: EraFormat
+    get() = unsafeCast("long")
+
+inline val EraFormat.Companion.short: EraFormat
+    get() = unsafeCast("short")
+
+inline val EraFormat.Companion.narrow: EraFormat
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/FormatMatcher.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/FormatMatcher.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FormatMatcher {
-    companion object {
-        @JsValue("best fit")
-        val bestFit: FormatMatcher
-
-        @JsValue("basic")
-        val basic: FormatMatcher
-    }
+    companion object
 }
+
+inline val FormatMatcher.Companion.bestFit: FormatMatcher
+    get() = unsafeCast("best fit")
+
+inline val FormatMatcher.Companion.basic: FormatMatcher
+    get() = unsafeCast("basic")

--- a/kotlin-js/src/commonMain/generated/js/intl/Granularity.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/Granularity.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Granularity {
-    companion object {
-        @JsValue("grapheme")
-        val grapheme: Granularity
-
-        @JsValue("word")
-        val word: Granularity
-
-        @JsValue("sentence")
-        val sentence: Granularity
-    }
+    companion object
 }
+
+inline val Granularity.Companion.grapheme: Granularity
+    get() = unsafeCast("grapheme")
+
+inline val Granularity.Companion.word: Granularity
+    get() = unsafeCast("word")
+
+inline val Granularity.Companion.sentence: Granularity
+    get() = unsafeCast("sentence")

--- a/kotlin-js/src/commonMain/generated/js/intl/HourCycle.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/HourCycle.kt
@@ -6,20 +6,20 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface HourCycle {
-    companion object {
-        @JsValue("h11")
-        val h11: HourCycle
-
-        @JsValue("h12")
-        val h12: HourCycle
-
-        @JsValue("h23")
-        val h23: HourCycle
-
-        @JsValue("h24")
-        val h24: HourCycle
-    }
+    companion object
 }
+
+inline val HourCycle.Companion.h11: HourCycle
+    get() = unsafeCast("h11")
+
+inline val HourCycle.Companion.h12: HourCycle
+    get() = unsafeCast("h12")
+
+inline val HourCycle.Companion.h23: HourCycle
+    get() = unsafeCast("h23")
+
+inline val HourCycle.Companion.h24: HourCycle
+    get() = unsafeCast("h24")

--- a/kotlin-js/src/commonMain/generated/js/intl/HourFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/HourFormat.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface HourFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: HourFormat
-
-        @JsValue("2-digit")
-        val twoDigit: HourFormat
-    }
+    companion object
 }
+
+inline val HourFormat.Companion.numeric: HourFormat
+    get() = unsafeCast("numeric")
+
+inline val HourFormat.Companion.twoDigit: HourFormat
+    get() = unsafeCast("2-digit")

--- a/kotlin-js/src/commonMain/generated/js/intl/LDMLPluralRule.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/LDMLPluralRule.kt
@@ -6,26 +6,26 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LDMLPluralRule {
-    companion object {
-        @JsValue("zero")
-        val zero: LDMLPluralRule
-
-        @JsValue("one")
-        val one: LDMLPluralRule
-
-        @JsValue("two")
-        val two: LDMLPluralRule
-
-        @JsValue("few")
-        val few: LDMLPluralRule
-
-        @JsValue("many")
-        val many: LDMLPluralRule
-
-        @JsValue("other")
-        val other: LDMLPluralRule
-    }
+    companion object
 }
+
+inline val LDMLPluralRule.Companion.zero: LDMLPluralRule
+    get() = unsafeCast("zero")
+
+inline val LDMLPluralRule.Companion.one: LDMLPluralRule
+    get() = unsafeCast("one")
+
+inline val LDMLPluralRule.Companion.two: LDMLPluralRule
+    get() = unsafeCast("two")
+
+inline val LDMLPluralRule.Companion.few: LDMLPluralRule
+    get() = unsafeCast("few")
+
+inline val LDMLPluralRule.Companion.many: LDMLPluralRule
+    get() = unsafeCast("many")
+
+inline val LDMLPluralRule.Companion.other: LDMLPluralRule
+    get() = unsafeCast("other")

--- a/kotlin-js/src/commonMain/generated/js/intl/ListFormatLocaleMatcher.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/ListFormatLocaleMatcher.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ListFormatLocaleMatcher {
-    companion object {
-        @JsValue("lookup")
-        val lookup: ListFormatLocaleMatcher
-
-        @JsValue("best fit")
-        val bestFit: ListFormatLocaleMatcher
-    }
+    companion object
 }
+
+inline val ListFormatLocaleMatcher.Companion.lookup: ListFormatLocaleMatcher
+    get() = unsafeCast("lookup")
+
+inline val ListFormatLocaleMatcher.Companion.bestFit: ListFormatLocaleMatcher
+    get() = unsafeCast("best fit")

--- a/kotlin-js/src/commonMain/generated/js/intl/ListFormatStyle.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/ListFormatStyle.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ListFormatStyle {
-    companion object {
-        @JsValue("long")
-        val long: ListFormatStyle
-
-        @JsValue("short")
-        val short: ListFormatStyle
-
-        @JsValue("narrow")
-        val narrow: ListFormatStyle
-    }
+    companion object
 }
+
+inline val ListFormatStyle.Companion.long: ListFormatStyle
+    get() = unsafeCast("long")
+
+inline val ListFormatStyle.Companion.short: ListFormatStyle
+    get() = unsafeCast("short")
+
+inline val ListFormatStyle.Companion.narrow: ListFormatStyle
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/ListFormatType.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/ListFormatType.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ListFormatType {
-    companion object {
-        @JsValue("conjunction")
-        val conjunction: ListFormatType
-
-        @JsValue("disjunction")
-        val disjunction: ListFormatType
-
-        @JsValue("unit")
-        val unit: ListFormatType
-    }
+    companion object
 }
+
+inline val ListFormatType.Companion.conjunction: ListFormatType
+    get() = unsafeCast("conjunction")
+
+inline val ListFormatType.Companion.disjunction: ListFormatType
+    get() = unsafeCast("disjunction")
+
+inline val ListFormatType.Companion.unit: ListFormatType
+    get() = unsafeCast("unit")

--- a/kotlin-js/src/commonMain/generated/js/intl/LocaleMatcher.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/LocaleMatcher.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LocaleMatcher {
-    companion object {
-        @JsValue("lookup")
-        val lookup: LocaleMatcher
-
-        @JsValue("best fit")
-        val bestFit: LocaleMatcher
-    }
+    companion object
 }
+
+inline val LocaleMatcher.Companion.lookup: LocaleMatcher
+    get() = unsafeCast("lookup")
+
+inline val LocaleMatcher.Companion.bestFit: LocaleMatcher
+    get() = unsafeCast("best fit")

--- a/kotlin-js/src/commonMain/generated/js/intl/MinuteFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/MinuteFormat.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MinuteFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: MinuteFormat
-
-        @JsValue("2-digit")
-        val twoDigit: MinuteFormat
-    }
+    companion object
 }
+
+inline val MinuteFormat.Companion.numeric: MinuteFormat
+    get() = unsafeCast("numeric")
+
+inline val MinuteFormat.Companion.twoDigit: MinuteFormat
+    get() = unsafeCast("2-digit")

--- a/kotlin-js/src/commonMain/generated/js/intl/MonthFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/MonthFormat.kt
@@ -6,23 +6,23 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface MonthFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: MonthFormat
-
-        @JsValue("2-digit")
-        val twoDigit: MonthFormat
-
-        @JsValue("long")
-        val long: MonthFormat
-
-        @JsValue("short")
-        val short: MonthFormat
-
-        @JsValue("narrow")
-        val narrow: MonthFormat
-    }
+    companion object
 }
+
+inline val MonthFormat.Companion.numeric: MonthFormat
+    get() = unsafeCast("numeric")
+
+inline val MonthFormat.Companion.twoDigit: MonthFormat
+    get() = unsafeCast("2-digit")
+
+inline val MonthFormat.Companion.long: MonthFormat
+    get() = unsafeCast("long")
+
+inline val MonthFormat.Companion.short: MonthFormat
+    get() = unsafeCast("short")
+
+inline val MonthFormat.Companion.narrow: MonthFormat
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/Notation.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/Notation.kt
@@ -6,20 +6,20 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Notation {
-    companion object {
-        @JsValue("standard")
-        val standard: Notation
-
-        @JsValue("scientific")
-        val scientific: Notation
-
-        @JsValue("engineering")
-        val engineering: Notation
-
-        @JsValue("compact")
-        val compact: Notation
-    }
+    companion object
 }
+
+inline val Notation.Companion.standard: Notation
+    get() = unsafeCast("standard")
+
+inline val Notation.Companion.scientific: Notation
+    get() = unsafeCast("scientific")
+
+inline val Notation.Companion.engineering: Notation
+    get() = unsafeCast("engineering")
+
+inline val Notation.Companion.compact: Notation
+    get() = unsafeCast("compact")

--- a/kotlin-js/src/commonMain/generated/js/intl/PartSource.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/PartSource.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PartSource {
-    companion object {
-        @JsValue("startRange")
-        val startRange: PartSource
-
-        @JsValue("endRange")
-        val endRange: PartSource
-
-        @JsValue("shared")
-        val shared: PartSource
-    }
+    companion object
 }
+
+inline val PartSource.Companion.startRange: PartSource
+    get() = unsafeCast("startRange")
+
+inline val PartSource.Companion.endRange: PartSource
+    get() = unsafeCast("endRange")
+
+inline val PartSource.Companion.shared: PartSource
+    get() = unsafeCast("shared")

--- a/kotlin-js/src/commonMain/generated/js/intl/PluralRuleType.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/PluralRuleType.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PluralRuleType {
-    companion object {
-        @JsValue("cardinal")
-        val cardinal: PluralRuleType
-
-        @JsValue("ordinal")
-        val ordinal: PluralRuleType
-    }
+    companion object
 }
+
+inline val PluralRuleType.Companion.cardinal: PluralRuleType
+    get() = unsafeCast("cardinal")
+
+inline val PluralRuleType.Companion.ordinal: PluralRuleType
+    get() = unsafeCast("ordinal")

--- a/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatNumeric.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatNumeric.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RelativeTimeFormatNumeric {
-    companion object {
-        @JsValue("always")
-        val always: RelativeTimeFormatNumeric
-
-        @JsValue("auto")
-        val auto: RelativeTimeFormatNumeric
-    }
+    companion object
 }
+
+inline val RelativeTimeFormatNumeric.Companion.always: RelativeTimeFormatNumeric
+    get() = unsafeCast("always")
+
+inline val RelativeTimeFormatNumeric.Companion.auto: RelativeTimeFormatNumeric
+    get() = unsafeCast("auto")

--- a/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatStyle.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatStyle.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RelativeTimeFormatStyle {
-    companion object {
-        @JsValue("long")
-        val long: RelativeTimeFormatStyle
-
-        @JsValue("short")
-        val short: RelativeTimeFormatStyle
-
-        @JsValue("narrow")
-        val narrow: RelativeTimeFormatStyle
-    }
+    companion object
 }
+
+inline val RelativeTimeFormatStyle.Companion.long: RelativeTimeFormatStyle
+    get() = unsafeCast("long")
+
+inline val RelativeTimeFormatStyle.Companion.short: RelativeTimeFormatStyle
+    get() = unsafeCast("short")
+
+inline val RelativeTimeFormatStyle.Companion.narrow: RelativeTimeFormatStyle
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatUnit.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatUnit.kt
@@ -6,56 +6,56 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RelativeTimeFormatUnit {
-    companion object {
-        @JsValue("year")
-        val year: RelativeTimeFormatUnit
-
-        @JsValue("years")
-        val years: RelativeTimeFormatUnit
-
-        @JsValue("quarter")
-        val quarter: RelativeTimeFormatUnit
-
-        @JsValue("quarters")
-        val quarters: RelativeTimeFormatUnit
-
-        @JsValue("month")
-        val month: RelativeTimeFormatUnit
-
-        @JsValue("months")
-        val months: RelativeTimeFormatUnit
-
-        @JsValue("week")
-        val week: RelativeTimeFormatUnit
-
-        @JsValue("weeks")
-        val weeks: RelativeTimeFormatUnit
-
-        @JsValue("day")
-        val day: RelativeTimeFormatUnit
-
-        @JsValue("days")
-        val days: RelativeTimeFormatUnit
-
-        @JsValue("hour")
-        val hour: RelativeTimeFormatUnit
-
-        @JsValue("hours")
-        val hours: RelativeTimeFormatUnit
-
-        @JsValue("minute")
-        val minute: RelativeTimeFormatUnit
-
-        @JsValue("minutes")
-        val minutes: RelativeTimeFormatUnit
-
-        @JsValue("second")
-        val second: RelativeTimeFormatUnit
-
-        @JsValue("seconds")
-        val seconds: RelativeTimeFormatUnit
-    }
+    companion object
 }
+
+inline val RelativeTimeFormatUnit.Companion.year: RelativeTimeFormatUnit
+    get() = unsafeCast("year")
+
+inline val RelativeTimeFormatUnit.Companion.years: RelativeTimeFormatUnit
+    get() = unsafeCast("years")
+
+inline val RelativeTimeFormatUnit.Companion.quarter: RelativeTimeFormatUnit
+    get() = unsafeCast("quarter")
+
+inline val RelativeTimeFormatUnit.Companion.quarters: RelativeTimeFormatUnit
+    get() = unsafeCast("quarters")
+
+inline val RelativeTimeFormatUnit.Companion.month: RelativeTimeFormatUnit
+    get() = unsafeCast("month")
+
+inline val RelativeTimeFormatUnit.Companion.months: RelativeTimeFormatUnit
+    get() = unsafeCast("months")
+
+inline val RelativeTimeFormatUnit.Companion.week: RelativeTimeFormatUnit
+    get() = unsafeCast("week")
+
+inline val RelativeTimeFormatUnit.Companion.weeks: RelativeTimeFormatUnit
+    get() = unsafeCast("weeks")
+
+inline val RelativeTimeFormatUnit.Companion.day: RelativeTimeFormatUnit
+    get() = unsafeCast("day")
+
+inline val RelativeTimeFormatUnit.Companion.days: RelativeTimeFormatUnit
+    get() = unsafeCast("days")
+
+inline val RelativeTimeFormatUnit.Companion.hour: RelativeTimeFormatUnit
+    get() = unsafeCast("hour")
+
+inline val RelativeTimeFormatUnit.Companion.hours: RelativeTimeFormatUnit
+    get() = unsafeCast("hours")
+
+inline val RelativeTimeFormatUnit.Companion.minute: RelativeTimeFormatUnit
+    get() = unsafeCast("minute")
+
+inline val RelativeTimeFormatUnit.Companion.minutes: RelativeTimeFormatUnit
+    get() = unsafeCast("minutes")
+
+inline val RelativeTimeFormatUnit.Companion.second: RelativeTimeFormatUnit
+    get() = unsafeCast("second")
+
+inline val RelativeTimeFormatUnit.Companion.seconds: RelativeTimeFormatUnit
+    get() = unsafeCast("seconds")

--- a/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatUnitSingular.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RelativeTimeFormatUnitSingular.kt
@@ -6,32 +6,32 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RelativeTimeFormatUnitSingular {
-    companion object {
-        @JsValue("year")
-        val year: RelativeTimeFormatUnitSingular
-
-        @JsValue("quarter")
-        val quarter: RelativeTimeFormatUnitSingular
-
-        @JsValue("month")
-        val month: RelativeTimeFormatUnitSingular
-
-        @JsValue("week")
-        val week: RelativeTimeFormatUnitSingular
-
-        @JsValue("day")
-        val day: RelativeTimeFormatUnitSingular
-
-        @JsValue("hour")
-        val hour: RelativeTimeFormatUnitSingular
-
-        @JsValue("minute")
-        val minute: RelativeTimeFormatUnitSingular
-
-        @JsValue("second")
-        val second: RelativeTimeFormatUnitSingular
-    }
+    companion object
 }
+
+inline val RelativeTimeFormatUnitSingular.Companion.year: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("year")
+
+inline val RelativeTimeFormatUnitSingular.Companion.quarter: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("quarter")
+
+inline val RelativeTimeFormatUnitSingular.Companion.month: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("month")
+
+inline val RelativeTimeFormatUnitSingular.Companion.week: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("week")
+
+inline val RelativeTimeFormatUnitSingular.Companion.day: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("day")
+
+inline val RelativeTimeFormatUnitSingular.Companion.hour: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("hour")
+
+inline val RelativeTimeFormatUnitSingular.Companion.minute: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("minute")
+
+inline val RelativeTimeFormatUnitSingular.Companion.second: RelativeTimeFormatUnitSingular
+    get() = unsafeCast("second")

--- a/kotlin-js/src/commonMain/generated/js/intl/RoundingMode.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RoundingMode.kt
@@ -6,35 +6,35 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RoundingMode {
-    companion object {
-        @JsValue("ceil")
-        val ceil: RoundingMode
-
-        @JsValue("floor")
-        val floor: RoundingMode
-
-        @JsValue("expand")
-        val expand: RoundingMode
-
-        @JsValue("trunc")
-        val trunc: RoundingMode
-
-        @JsValue("halfCeil")
-        val halfCeil: RoundingMode
-
-        @JsValue("halfFloor")
-        val halfFloor: RoundingMode
-
-        @JsValue("halfExpand")
-        val halfExpand: RoundingMode
-
-        @JsValue("halfTrunc")
-        val halfTrunc: RoundingMode
-
-        @JsValue("halfEven")
-        val halfEven: RoundingMode
-    }
+    companion object
 }
+
+inline val RoundingMode.Companion.ceil: RoundingMode
+    get() = unsafeCast("ceil")
+
+inline val RoundingMode.Companion.floor: RoundingMode
+    get() = unsafeCast("floor")
+
+inline val RoundingMode.Companion.expand: RoundingMode
+    get() = unsafeCast("expand")
+
+inline val RoundingMode.Companion.trunc: RoundingMode
+    get() = unsafeCast("trunc")
+
+inline val RoundingMode.Companion.halfCeil: RoundingMode
+    get() = unsafeCast("halfCeil")
+
+inline val RoundingMode.Companion.halfFloor: RoundingMode
+    get() = unsafeCast("halfFloor")
+
+inline val RoundingMode.Companion.halfExpand: RoundingMode
+    get() = unsafeCast("halfExpand")
+
+inline val RoundingMode.Companion.halfTrunc: RoundingMode
+    get() = unsafeCast("halfTrunc")
+
+inline val RoundingMode.Companion.halfEven: RoundingMode
+    get() = unsafeCast("halfEven")

--- a/kotlin-js/src/commonMain/generated/js/intl/RoundingPriority.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/RoundingPriority.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RoundingPriority {
-    companion object {
-        @JsValue("auto")
-        val auto: RoundingPriority
-
-        @JsValue("morePrecision")
-        val morePrecision: RoundingPriority
-
-        @JsValue("lessPrecision")
-        val lessPrecision: RoundingPriority
-    }
+    companion object
 }
+
+inline val RoundingPriority.Companion.auto: RoundingPriority
+    get() = unsafeCast("auto")
+
+inline val RoundingPriority.Companion.morePrecision: RoundingPriority
+    get() = unsafeCast("morePrecision")
+
+inline val RoundingPriority.Companion.lessPrecision: RoundingPriority
+    get() = unsafeCast("lessPrecision")

--- a/kotlin-js/src/commonMain/generated/js/intl/SecondFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/SecondFormat.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface SecondFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: SecondFormat
-
-        @JsValue("2-digit")
-        val twoDigit: SecondFormat
-    }
+    companion object
 }
+
+inline val SecondFormat.Companion.numeric: SecondFormat
+    get() = unsafeCast("numeric")
+
+inline val SecondFormat.Companion.twoDigit: SecondFormat
+    get() = unsafeCast("2-digit")

--- a/kotlin-js/src/commonMain/generated/js/intl/Sensitivity.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/Sensitivity.kt
@@ -6,20 +6,20 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Sensitivity {
-    companion object {
-        @JsValue("base")
-        val base: Sensitivity
-
-        @JsValue("accent")
-        val accent: Sensitivity
-
-        @JsValue("case")
-        val case: Sensitivity
-
-        @JsValue("variant")
-        val variant: Sensitivity
-    }
+    companion object
 }
+
+inline val Sensitivity.Companion.base: Sensitivity
+    get() = unsafeCast("base")
+
+inline val Sensitivity.Companion.accent: Sensitivity
+    get() = unsafeCast("accent")
+
+inline val Sensitivity.Companion.case: Sensitivity
+    get() = unsafeCast("case")
+
+inline val Sensitivity.Companion.variant: Sensitivity
+    get() = unsafeCast("variant")

--- a/kotlin-js/src/commonMain/generated/js/intl/TimeStyle.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/TimeStyle.kt
@@ -6,20 +6,20 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TimeStyle {
-    companion object {
-        @JsValue("full")
-        val full: TimeStyle
-
-        @JsValue("long")
-        val long: TimeStyle
-
-        @JsValue("medium")
-        val medium: TimeStyle
-
-        @JsValue("short")
-        val short: TimeStyle
-    }
+    companion object
 }
+
+inline val TimeStyle.Companion.full: TimeStyle
+    get() = unsafeCast("full")
+
+inline val TimeStyle.Companion.long: TimeStyle
+    get() = unsafeCast("long")
+
+inline val TimeStyle.Companion.medium: TimeStyle
+    get() = unsafeCast("medium")
+
+inline val TimeStyle.Companion.short: TimeStyle
+    get() = unsafeCast("short")

--- a/kotlin-js/src/commonMain/generated/js/intl/TimeZoneNameFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/TimeZoneNameFormat.kt
@@ -6,26 +6,26 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TimeZoneNameFormat {
-    companion object {
-        @JsValue("short")
-        val short: TimeZoneNameFormat
-
-        @JsValue("long")
-        val long: TimeZoneNameFormat
-
-        @JsValue("shortOffset")
-        val shortOffset: TimeZoneNameFormat
-
-        @JsValue("longOffset")
-        val longOffset: TimeZoneNameFormat
-
-        @JsValue("shortGeneric")
-        val shortGeneric: TimeZoneNameFormat
-
-        @JsValue("longGeneric")
-        val longGeneric: TimeZoneNameFormat
-    }
+    companion object
 }
+
+inline val TimeZoneNameFormat.Companion.short: TimeZoneNameFormat
+    get() = unsafeCast("short")
+
+inline val TimeZoneNameFormat.Companion.long: TimeZoneNameFormat
+    get() = unsafeCast("long")
+
+inline val TimeZoneNameFormat.Companion.shortOffset: TimeZoneNameFormat
+    get() = unsafeCast("shortOffset")
+
+inline val TimeZoneNameFormat.Companion.longOffset: TimeZoneNameFormat
+    get() = unsafeCast("longOffset")
+
+inline val TimeZoneNameFormat.Companion.shortGeneric: TimeZoneNameFormat
+    get() = unsafeCast("shortGeneric")
+
+inline val TimeZoneNameFormat.Companion.longGeneric: TimeZoneNameFormat
+    get() = unsafeCast("longGeneric")

--- a/kotlin-js/src/commonMain/generated/js/intl/TrailingZeroDisplay.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/TrailingZeroDisplay.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TrailingZeroDisplay {
-    companion object {
-        @JsValue("auto")
-        val auto: TrailingZeroDisplay
-
-        @JsValue("stripIfInteger")
-        val stripIfInteger: TrailingZeroDisplay
-    }
+    companion object
 }
+
+inline val TrailingZeroDisplay.Companion.auto: TrailingZeroDisplay
+    get() = unsafeCast("auto")
+
+inline val TrailingZeroDisplay.Companion.stripIfInteger: TrailingZeroDisplay
+    get() = unsafeCast("stripIfInteger")

--- a/kotlin-js/src/commonMain/generated/js/intl/UnitDisplay.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/UnitDisplay.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface UnitDisplay {
-    companion object {
-        @JsValue("short")
-        val short: UnitDisplay
-
-        @JsValue("long")
-        val long: UnitDisplay
-
-        @JsValue("narrow")
-        val narrow: UnitDisplay
-    }
+    companion object
 }
+
+inline val UnitDisplay.Companion.short: UnitDisplay
+    get() = unsafeCast("short")
+
+inline val UnitDisplay.Companion.long: UnitDisplay
+    get() = unsafeCast("long")
+
+inline val UnitDisplay.Companion.narrow: UnitDisplay
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/WeekdayFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/WeekdayFormat.kt
@@ -6,17 +6,17 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface WeekdayFormat {
-    companion object {
-        @JsValue("long")
-        val long: WeekdayFormat
-
-        @JsValue("short")
-        val short: WeekdayFormat
-
-        @JsValue("narrow")
-        val narrow: WeekdayFormat
-    }
+    companion object
 }
+
+inline val WeekdayFormat.Companion.long: WeekdayFormat
+    get() = unsafeCast("long")
+
+inline val WeekdayFormat.Companion.short: WeekdayFormat
+    get() = unsafeCast("short")
+
+inline val WeekdayFormat.Companion.narrow: WeekdayFormat
+    get() = unsafeCast("narrow")

--- a/kotlin-js/src/commonMain/generated/js/intl/YearFormat.kt
+++ b/kotlin-js/src/commonMain/generated/js/intl/YearFormat.kt
@@ -6,14 +6,14 @@
 
 package js.intl
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface YearFormat {
-    companion object {
-        @JsValue("numeric")
-        val numeric: YearFormat
-
-        @JsValue("2-digit")
-        val twoDigit: YearFormat
-    }
+    companion object
 }
+
+inline val YearFormat.Companion.numeric: YearFormat
+    get() = unsafeCast("numeric")
+
+inline val YearFormat.Companion.twoDigit: YearFormat
+    get() = unsafeCast("2-digit")

--- a/kotlin-js/src/commonMain/generated/js/symbol/PrimitiveHint.kt
+++ b/kotlin-js/src/commonMain/generated/js/symbol/PrimitiveHint.kt
@@ -6,17 +6,17 @@
 
 package js.symbol
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PrimitiveHint {
-    companion object {
-        @JsValue("number")
-        val number: PrimitiveHint
-
-        @JsValue("string")
-        val string: PrimitiveHint
-
-        @JsValue("default")
-        val default: PrimitiveHint
-    }
+    companion object
 }
+
+inline val PrimitiveHint.Companion.number: PrimitiveHint
+    get() = unsafeCast("number")
+
+inline val PrimitiveHint.Companion.string: PrimitiveHint
+    get() = unsafeCast("string")
+
+inline val PrimitiveHint.Companion.default: PrimitiveHint
+    get() = unsafeCast("default")

--- a/kotlin-js/src/commonMain/generated/js/temporal/Disambiguation.kt
+++ b/kotlin-js/src/commonMain/generated/js/temporal/Disambiguation.kt
@@ -6,20 +6,20 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Disambiguation {
-    companion object {
-        @JsValue("compatible")
-        val compatible: Disambiguation
-
-        @JsValue("earlier")
-        val earlier: Disambiguation
-
-        @JsValue("later")
-        val later: Disambiguation
-
-        @JsValue("reject")
-        val reject: Disambiguation
-    }
+    companion object
 }
+
+inline val Disambiguation.Companion.compatible: Disambiguation
+    get() = unsafeCast("compatible")
+
+inline val Disambiguation.Companion.earlier: Disambiguation
+    get() = unsafeCast("earlier")
+
+inline val Disambiguation.Companion.later: Disambiguation
+    get() = unsafeCast("later")
+
+inline val Disambiguation.Companion.reject: Disambiguation
+    get() = unsafeCast("reject")

--- a/kotlin-js/src/commonMain/generated/js/temporal/Overflow.kt
+++ b/kotlin-js/src/commonMain/generated/js/temporal/Overflow.kt
@@ -6,14 +6,14 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Overflow {
-    companion object {
-        @JsValue("constrain")
-        val constrain: Overflow
-
-        @JsValue("reject")
-        val reject: Overflow
-    }
+    companion object
 }
+
+inline val Overflow.Companion.constrain: Overflow
+    get() = unsafeCast("constrain")
+
+inline val Overflow.Companion.reject: Overflow
+    get() = unsafeCast("reject")

--- a/kotlin-js/src/commonMain/generated/js/temporal/RoundingMode.kt
+++ b/kotlin-js/src/commonMain/generated/js/temporal/RoundingMode.kt
@@ -6,35 +6,35 @@
 
 package js.temporal
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RoundingMode {
-    companion object {
-        @JsValue("ceil")
-        val ceil: RoundingMode
-
-        @JsValue("floor")
-        val floor: RoundingMode
-
-        @JsValue("expand")
-        val expand: RoundingMode
-
-        @JsValue("trunc")
-        val trunc: RoundingMode
-
-        @JsValue("halfCeil")
-        val halfCeil: RoundingMode
-
-        @JsValue("halfFloor")
-        val halfFloor: RoundingMode
-
-        @JsValue("halfExpand")
-        val halfExpand: RoundingMode
-
-        @JsValue("halfTrunc")
-        val halfTrunc: RoundingMode
-
-        @JsValue("halfEven")
-        val halfEven: RoundingMode
-    }
+    companion object
 }
+
+inline val RoundingMode.Companion.ceil: RoundingMode
+    get() = unsafeCast("ceil")
+
+inline val RoundingMode.Companion.floor: RoundingMode
+    get() = unsafeCast("floor")
+
+inline val RoundingMode.Companion.expand: RoundingMode
+    get() = unsafeCast("expand")
+
+inline val RoundingMode.Companion.trunc: RoundingMode
+    get() = unsafeCast("trunc")
+
+inline val RoundingMode.Companion.halfCeil: RoundingMode
+    get() = unsafeCast("halfCeil")
+
+inline val RoundingMode.Companion.halfFloor: RoundingMode
+    get() = unsafeCast("halfFloor")
+
+inline val RoundingMode.Companion.halfExpand: RoundingMode
+    get() = unsafeCast("halfExpand")
+
+inline val RoundingMode.Companion.halfTrunc: RoundingMode
+    get() = unsafeCast("halfTrunc")
+
+inline val RoundingMode.Companion.halfEven: RoundingMode
+    get() = unsafeCast("halfEven")

--- a/kotlin-js/src/commonMain/generated/js/typedarrays/Alphabet.kt
+++ b/kotlin-js/src/commonMain/generated/js/typedarrays/Alphabet.kt
@@ -6,14 +6,14 @@
 
 package js.typedarrays
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface Alphabet {
-    companion object {
-        @JsValue("base64")
-        val base64: Alphabet
-
-        @JsValue("base64url")
-        val base64url: Alphabet
-    }
+    companion object
 }
+
+inline val Alphabet.Companion.base64: Alphabet
+    get() = unsafeCast("base64")
+
+inline val Alphabet.Companion.base64url: Alphabet
+    get() = unsafeCast("base64url")

--- a/kotlin-js/src/commonMain/generated/js/typedarrays/LastChunkHandling.kt
+++ b/kotlin-js/src/commonMain/generated/js/typedarrays/LastChunkHandling.kt
@@ -6,17 +6,17 @@
 
 package js.typedarrays
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface LastChunkHandling {
-    companion object {
-        @JsValue("loose")
-        val loose: LastChunkHandling
-
-        @JsValue("strict")
-        val strict: LastChunkHandling
-
-        @JsValue("stop-before-partial")
-        val stopBeforePartial: LastChunkHandling
-    }
+    companion object
 }
+
+inline val LastChunkHandling.Companion.loose: LastChunkHandling
+    get() = unsafeCast("loose")
+
+inline val LastChunkHandling.Companion.strict: LastChunkHandling
+    get() = unsafeCast("strict")
+
+inline val LastChunkHandling.Companion.stopBeforePartial: LastChunkHandling
+    get() = unsafeCast("stop-before-partial")

--- a/kotlin-js/src/jsTest/kotlin/js/intl/DateStyleTest.kt
+++ b/kotlin-js/src/jsTest/kotlin/js/intl/DateStyleTest.kt
@@ -1,6 +1,5 @@
 package js.intl
 
-import js.intl.DateStyle.Companion.full
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,6 +11,6 @@ class DateStyleTest {
 
     @Test
     fun staticImport() {
-        assertEquals<Any>("full", full)
+        assertEquals<Any>("full", DateStyle.full)
     }
 }

--- a/kotlin-web/src/commonMain/generated/web/assembly/ImportExportKind.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/ImportExportKind.kt
@@ -6,20 +6,20 @@
 
 package web.assembly
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ImportExportKind {
-    companion object {
-        @JsValue("function")
-        val function: ImportExportKind
-
-        @JsValue("global")
-        val global: ImportExportKind
-
-        @JsValue("memory")
-        val memory: ImportExportKind
-
-        @JsValue("table")
-        val table: ImportExportKind
-    }
+    companion object
 }
+
+inline val ImportExportKind.Companion.function: ImportExportKind
+    get() = unsafeCast("function")
+
+inline val ImportExportKind.Companion.global: ImportExportKind
+    get() = unsafeCast("global")
+
+inline val ImportExportKind.Companion.memory: ImportExportKind
+    get() = unsafeCast("memory")
+
+inline val ImportExportKind.Companion.table: ImportExportKind
+    get() = unsafeCast("table")

--- a/kotlin-web/src/commonMain/generated/web/assembly/TableKind.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/TableKind.kt
@@ -6,14 +6,14 @@
 
 package web.assembly
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface TableKind {
-    companion object {
-        @JsValue("anyfunc")
-        val anyfunc: TableKind
-
-        @JsValue("externref")
-        val externref: TableKind
-    }
+    companion object
 }
+
+inline val TableKind.Companion.anyfunc: TableKind
+    get() = unsafeCast("anyfunc")
+
+inline val TableKind.Companion.externref: TableKind
+    get() = unsafeCast("externref")

--- a/kotlin-web/src/commonMain/generated/web/assembly/ValueType.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/ValueType.kt
@@ -8,29 +8,29 @@ package web.assembly
 
 import js.core.*
 import js.function.JsFunction
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ValueType<T : JsAny?> {
-    companion object {
-        @JsValue("anyfunc")
-        val anyfunc: ValueType<JsFunction<*, *>>
-
-        @JsValue("externref")
-        val externref: ValueType<JsAny?>
-
-        @JsValue("f32")
-        val f32: ValueType<JsFloat>
-
-        @JsValue("f64")
-        val f64: ValueType<JsDouble>
-
-        @JsValue("i32")
-        val i32: ValueType<JsInt>
-
-        @JsValue("i64")
-        val i64: ValueType<BigInt>
-
-        @JsValue("v128")
-        val v128: ValueType<Void>
-    }
+    companion object
 }
+
+inline val ValueType.Companion.anyfunc: ValueType<JsFunction<*, *>>
+    get() = unsafeCast("anyfunc")
+
+inline val ValueType.Companion.externref: ValueType<JsAny?>
+    get() = unsafeCast("externref")
+
+inline val ValueType.Companion.f32: ValueType<JsFloat>
+    get() = unsafeCast("f32")
+
+inline val ValueType.Companion.f64: ValueType<JsDouble>
+    get() = unsafeCast("f64")
+
+inline val ValueType.Companion.i32: ValueType<JsInt>
+    get() = unsafeCast("i32")
+
+inline val ValueType.Companion.i64: ValueType<BigInt>
+    get() = unsafeCast("i64")
+
+inline val ValueType.Companion.v128: ValueType<Void>
+    get() = unsafeCast("v128")

--- a/kotlin-web/src/commonMain/generated/web/blob/EndingType.kt
+++ b/kotlin-web/src/commonMain/generated/web/blob/EndingType.kt
@@ -6,14 +6,14 @@
 
 package web.blob
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface EndingType {
-    companion object {
-        @JsValue("native")
-        val native: EndingType
-
-        @JsValue("transparent")
-        val transparent: EndingType
-    }
+    companion object
 }
+
+inline val EndingType.Companion.native: EndingType
+    get() = unsafeCast("native")
+
+inline val EndingType.Companion.transparent: EndingType
+    get() = unsafeCast("transparent")

--- a/kotlin-web/src/commonMain/generated/web/compression/CompressionFormat.kt
+++ b/kotlin-web/src/commonMain/generated/web/compression/CompressionFormat.kt
@@ -6,17 +6,17 @@
 
 package web.compression
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CompressionFormat {
-    companion object {
-        @JsValue("deflate")
-        val deflate: CompressionFormat
-
-        @JsValue("deflate-raw")
-        val deflateRaw: CompressionFormat
-
-        @JsValue("gzip")
-        val gzip: CompressionFormat
-    }
+    companion object
 }
+
+inline val CompressionFormat.Companion.deflate: CompressionFormat
+    get() = unsafeCast("deflate")
+
+inline val CompressionFormat.Companion.deflateRaw: CompressionFormat
+    get() = unsafeCast("deflate-raw")
+
+inline val CompressionFormat.Companion.gzip: CompressionFormat
+    get() = unsafeCast("gzip")

--- a/kotlin-web/src/commonMain/generated/web/crypto/KeyFormat.kt
+++ b/kotlin-web/src/commonMain/generated/web/crypto/KeyFormat.kt
@@ -6,25 +6,25 @@
 
 package web.crypto
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface KeyFormat {
-    companion object {
-        @JsValue("jwk")
-        val jwk: jwk
-
-        @JsValue("pkcs8")
-        val pkcs8: pkcs8
-
-        @JsValue("raw")
-        val raw: raw
-
-        @JsValue("spki")
-        val spki: spki
-    }
-
     sealed interface jwk : KeyFormat
     sealed interface pkcs8 : KeyFormat
     sealed interface raw : KeyFormat
     sealed interface spki : KeyFormat
+
+    companion object
 }
+
+inline val KeyFormat.Companion.jwk: KeyFormat.jwk
+    get() = unsafeCast("jwk")
+
+inline val KeyFormat.Companion.pkcs8: KeyFormat.pkcs8
+    get() = unsafeCast("pkcs8")
+
+inline val KeyFormat.Companion.raw: KeyFormat.raw
+    get() = unsafeCast("raw")
+
+inline val KeyFormat.Companion.spki: KeyFormat.spki
+    get() = unsafeCast("spki")

--- a/kotlin-web/src/commonMain/generated/web/crypto/KeyType.kt
+++ b/kotlin-web/src/commonMain/generated/web/crypto/KeyType.kt
@@ -6,17 +6,17 @@
 
 package web.crypto
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface KeyType {
-    companion object {
-        @JsValue("private")
-        val private: KeyType
-
-        @JsValue("public")
-        val public: KeyType
-
-        @JsValue("secret")
-        val secret: KeyType
-    }
+    companion object
 }
+
+inline val KeyType.Companion.private: KeyType
+    get() = unsafeCast("private")
+
+inline val KeyType.Companion.public: KeyType
+    get() = unsafeCast("public")
+
+inline val KeyType.Companion.secret: KeyType
+    get() = unsafeCast("secret")

--- a/kotlin-web/src/commonMain/generated/web/crypto/KeyUsage.kt
+++ b/kotlin-web/src/commonMain/generated/web/crypto/KeyUsage.kt
@@ -6,32 +6,32 @@
 
 package web.crypto
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface KeyUsage {
-    companion object {
-        @JsValue("decrypt")
-        val decrypt: KeyUsage
-
-        @JsValue("deriveBits")
-        val deriveBits: KeyUsage
-
-        @JsValue("deriveKey")
-        val deriveKey: KeyUsage
-
-        @JsValue("encrypt")
-        val encrypt: KeyUsage
-
-        @JsValue("sign")
-        val sign: KeyUsage
-
-        @JsValue("unwrapKey")
-        val unwrapKey: KeyUsage
-
-        @JsValue("verify")
-        val verify: KeyUsage
-
-        @JsValue("wrapKey")
-        val wrapKey: KeyUsage
-    }
+    companion object
 }
+
+inline val KeyUsage.Companion.decrypt: KeyUsage
+    get() = unsafeCast("decrypt")
+
+inline val KeyUsage.Companion.deriveBits: KeyUsage
+    get() = unsafeCast("deriveBits")
+
+inline val KeyUsage.Companion.deriveKey: KeyUsage
+    get() = unsafeCast("deriveKey")
+
+inline val KeyUsage.Companion.encrypt: KeyUsage
+    get() = unsafeCast("encrypt")
+
+inline val KeyUsage.Companion.sign: KeyUsage
+    get() = unsafeCast("sign")
+
+inline val KeyUsage.Companion.unwrapKey: KeyUsage
+    get() = unsafeCast("unwrapKey")
+
+inline val KeyUsage.Companion.verify: KeyUsage
+    get() = unsafeCast("verify")
+
+inline val KeyUsage.Companion.wrapKey: KeyUsage
+    get() = unsafeCast("wrapKey")

--- a/kotlin-web/src/commonMain/generated/web/errors/DOMException.kt
+++ b/kotlin-web/src/commonMain/generated/web/errors/DOMException.kt
@@ -4,8 +4,8 @@ package web.errors
 
 import js.errors.JsError
 import js.errors.JsErrorName
+import js.reflect.unsafeCast
 import js.serialization.Serializable
-import seskar.js.JsValue
 import kotlin.js.definedExternally
 
 /**
@@ -28,191 +28,191 @@ open external class DOMException(
     val name: JsErrorName = definedExternally,
 ) : JsError,
     Serializable {
-    companion object {
-        /**
-         * The index is not in the allowed range. For example, this can be thrown by the `Range` object
-         */
-        @JsValue("IndexSizeError")
-        val IndexSizeError: JsErrorName
-
-        /**
-         * The node tree hierarchy is not correct
-         */
-        @JsValue("HierarchyRequestError")
-        val HierarchyRequestError: JsErrorName
-
-        /**
-         * The object is in the wrong `Document`
-         */
-        @JsValue("WrongDocumentError")
-        val WrongDocumentError: JsErrorName
-
-        /**
-         * The string contains invalid characters
-         */
-        @JsValue("InvalidCharacterError")
-        val InvalidCharacterError: JsErrorName
-
-        /**
-         * The object cannot be modified
-         */
-        @JsValue("NoModificationAllowedError")
-        val NoModificationAllowedError: JsErrorName
-
-        /**
-         * The object cannot be found here
-         */
-        @JsValue("NotFoundError")
-        val NotFoundError: JsErrorName
-
-        /**
-         * The operation is not supported
-         */
-        @JsValue("NotSupportedError")
-        val NotSupportedError: JsErrorName
-
-        /**
-         * The object is in an invalid state
-         */
-        @JsValue("InvalidStateError")
-        val InvalidStateError: JsErrorName
-
-        /**
-         * The attribute is in use
-         */
-        @JsValue("InUseAttributeError")
-        val InUseAttributeError: JsErrorName
-
-        /**
-         * The string did not match the expected pattern
-         */
-        @JsValue("SyntaxError")
-        val SyntaxError: JsErrorName
-
-        /**
-         * The object cannot be modified in this way
-         */
-        @JsValue("InvalidModificationError")
-        val InvalidModificationError: JsErrorName
-
-        /**
-         * The operation is not allowed by Namespaces in XML
-         */
-        @JsValue("NamespaceError")
-        val NamespaceError: JsErrorName
-
-        /**
-         * The object does not support the operation or argument
-         */
-        @JsValue("InvalidAccessError")
-        val InvalidAccessError: JsErrorName
-
-        /**
-         * The operation is insecure
-         */
-        @JsValue("SecurityError")
-        val SecurityError: JsErrorName
-
-        /**
-         * A network error occurred
-         */
-        @JsValue("NetworkError")
-        val NetworkError: JsErrorName
-
-        /**
-         * The operation was aborted
-         */
-        @JsValue("AbortError")
-        val AbortError: JsErrorName
-
-        /**
-         * The given URL does not match another URL
-         */
-        @JsValue("URLMismatchError")
-        val URLMismatchError: JsErrorName
-
-        /**
-         * The quota has been exceeded
-         */
-        @JsValue("QuotaExceededError")
-        val QuotaExceededError: JsErrorName
-
-        /**
-         * The operation timed out
-         */
-        @JsValue("TimeoutError")
-        val TimeoutError: JsErrorName
-
-        /**
-         * The node is incorrect or has an incorrect ancestor for this operation
-         */
-        @JsValue("InvalidNodeTypeError")
-        val InvalidNodeTypeError: JsErrorName
-
-        /**
-         * The object can not be cloned
-         */
-        @JsValue("DataCloneError")
-        val DataCloneError: JsErrorName
-
-        /**
-         * The encoding or decoding operation failed
-         */
-        @JsValue("EncodingError")
-        val EncodingError: JsErrorName
-
-        /**
-         * The input/output read operation failed
-         */
-        @JsValue("NotReadableError")
-        val NotReadableError: JsErrorName
-
-        /**
-         * The operation failed for an unknown transient reason (e.g., out of memory)
-         */
-        @JsValue("UnknownError")
-        val UnknownError: JsErrorName
-
-        /**
-         * A mutation operation in a transaction failed because a constraint was not satisfied
-         */
-        @JsValue("ConstraintError")
-        val ConstraintError: JsErrorName
-
-        /**
-         * Provided data is inadequate
-         */
-        @JsValue("DataError")
-        val DataError: JsErrorName
-
-        /**
-         * A request was placed against a transaction that is currently not active or is finished
-         */
-        @JsValue("TransactionInactiveError")
-        val TransactionInactiveError: JsErrorName
-
-        /**
-         * The mutating operation was attempted in a "readonly" transaction
-         */
-        @JsValue("ReadOnlyError")
-        val ReadOnlyError: JsErrorName
-
-        /**
-         * An attempt was made to open a database using a lower version than the existing version
-         */
-        @JsValue("VersionError")
-        val VersionError: JsErrorName
-
-        /**
-         * The operation failed for an operation-specific reason
-         */
-        @JsValue("OperationError")
-        val OperationError: JsErrorName
-
-        /**
-         * The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission
-         */
-        @JsValue("NotAllowedError")
-        val NotAllowedError: JsErrorName
-    }
+    companion object
 }
+
+/**
+ * The index is not in the allowed range. For example, this can be thrown by the `Range` object
+ */
+inline val DOMException.Companion.IndexSizeError: JsErrorName
+    get() = unsafeCast("IndexSizeError")
+
+/**
+ * The node tree hierarchy is not correct
+ */
+inline val DOMException.Companion.HierarchyRequestError: JsErrorName
+    get() = unsafeCast("HierarchyRequestError")
+
+/**
+ * The object is in the wrong `Document`
+ */
+inline val DOMException.Companion.WrongDocumentError: JsErrorName
+    get() = unsafeCast("WrongDocumentError")
+
+/**
+ * The string contains invalid characters
+ */
+inline val DOMException.Companion.InvalidCharacterError: JsErrorName
+    get() = unsafeCast("InvalidCharacterError")
+
+/**
+ * The object cannot be modified
+ */
+inline val DOMException.Companion.NoModificationAllowedError: JsErrorName
+    get() = unsafeCast("NoModificationAllowedError")
+
+/**
+ * The object cannot be found here
+ */
+inline val DOMException.Companion.NotFoundError: JsErrorName
+    get() = unsafeCast("NotFoundError")
+
+/**
+ * The operation is not supported
+ */
+inline val DOMException.Companion.NotSupportedError: JsErrorName
+    get() = unsafeCast("NotSupportedError")
+
+/**
+ * The object is in an invalid state
+ */
+inline val DOMException.Companion.InvalidStateError: JsErrorName
+    get() = unsafeCast("InvalidStateError")
+
+/**
+ * The attribute is in use
+ */
+inline val DOMException.Companion.InUseAttributeError: JsErrorName
+    get() = unsafeCast("InUseAttributeError")
+
+/**
+ * The string did not match the expected pattern
+ */
+inline val DOMException.Companion.SyntaxError: JsErrorName
+    get() = unsafeCast("SyntaxError")
+
+/**
+ * The object cannot be modified in this way
+ */
+inline val DOMException.Companion.InvalidModificationError: JsErrorName
+    get() = unsafeCast("InvalidModificationError")
+
+/**
+ * The operation is not allowed by Namespaces in XML
+ */
+inline val DOMException.Companion.NamespaceError: JsErrorName
+    get() = unsafeCast("NamespaceError")
+
+/**
+ * The object does not support the operation or argument
+ */
+inline val DOMException.Companion.InvalidAccessError: JsErrorName
+    get() = unsafeCast("InvalidAccessError")
+
+/**
+ * The operation is insecure
+ */
+inline val DOMException.Companion.SecurityError: JsErrorName
+    get() = unsafeCast("SecurityError")
+
+/**
+ * A network error occurred
+ */
+inline val DOMException.Companion.NetworkError: JsErrorName
+    get() = unsafeCast("NetworkError")
+
+/**
+ * The operation was aborted
+ */
+inline val DOMException.Companion.AbortError: JsErrorName
+    get() = unsafeCast("AbortError")
+
+/**
+ * The given URL does not match another URL
+ */
+inline val DOMException.Companion.URLMismatchError: JsErrorName
+    get() = unsafeCast("URLMismatchError")
+
+/**
+ * The quota has been exceeded
+ */
+inline val DOMException.Companion.QuotaExceededError: JsErrorName
+    get() = unsafeCast("QuotaExceededError")
+
+/**
+ * The operation timed out
+ */
+inline val DOMException.Companion.TimeoutError: JsErrorName
+    get() = unsafeCast("TimeoutError")
+
+/**
+ * The node is incorrect or has an incorrect ancestor for this operation
+ */
+inline val DOMException.Companion.InvalidNodeTypeError: JsErrorName
+    get() = unsafeCast("InvalidNodeTypeError")
+
+/**
+ * The object can not be cloned
+ */
+inline val DOMException.Companion.DataCloneError: JsErrorName
+    get() = unsafeCast("DataCloneError")
+
+/**
+ * The encoding or decoding operation failed
+ */
+inline val DOMException.Companion.EncodingError: JsErrorName
+    get() = unsafeCast("EncodingError")
+
+/**
+ * The input/output read operation failed
+ */
+inline val DOMException.Companion.NotReadableError: JsErrorName
+    get() = unsafeCast("NotReadableError")
+
+/**
+ * The operation failed for an unknown transient reason (e.g., out of memory)
+ */
+inline val DOMException.Companion.UnknownError: JsErrorName
+    get() = unsafeCast("UnknownError")
+
+/**
+ * A mutation operation in a transaction failed because a constraint was not satisfied
+ */
+inline val DOMException.Companion.ConstraintError: JsErrorName
+    get() = unsafeCast("ConstraintError")
+
+/**
+ * Provided data is inadequate
+ */
+inline val DOMException.Companion.DataError: JsErrorName
+    get() = unsafeCast("DataError")
+
+/**
+ * A request was placed against a transaction that is currently not active or is finished
+ */
+inline val DOMException.Companion.TransactionInactiveError: JsErrorName
+    get() = unsafeCast("TransactionInactiveError")
+
+/**
+ * The mutating operation was attempted in a "readonly" transaction
+ */
+inline val DOMException.Companion.ReadOnlyError: JsErrorName
+    get() = unsafeCast("ReadOnlyError")
+
+/**
+ * An attempt was made to open a database using a lower version than the existing version
+ */
+inline val DOMException.Companion.VersionError: JsErrorName
+    get() = unsafeCast("VersionError")
+
+/**
+ * The operation failed for an operation-specific reason
+ */
+inline val DOMException.Companion.OperationError: JsErrorName
+    get() = unsafeCast("OperationError")
+
+/**
+ * The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission
+ */
+inline val DOMException.Companion.NotAllowedError: JsErrorName
+    get() = unsafeCast("NotAllowedError")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUAddressMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUAddressMode.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUAddressMode {
-    companion object {
-        @JsValue("clamp-to-edge")
-        val clampToEdge: GPUAddressMode
-
-        @JsValue("mirror-repeat")
-        val mirrorRepeat: GPUAddressMode
-
-        @JsValue("repeat")
-        val repeat: GPUAddressMode
-    }
+    companion object
 }
+
+inline val GPUAddressMode.Companion.clampToEdge: GPUAddressMode
+    get() = unsafeCast("clamp-to-edge")
+
+inline val GPUAddressMode.Companion.mirrorRepeat: GPUAddressMode
+    get() = unsafeCast("mirror-repeat")
+
+inline val GPUAddressMode.Companion.repeat: GPUAddressMode
+    get() = unsafeCast("repeat")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUAutoLayoutMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUAutoLayoutMode.kt
@@ -6,11 +6,11 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUAutoLayoutMode {
-    companion object {
-        @JsValue("auto")
-        val auto: GPUAutoLayoutMode
-    }
+    companion object
 }
+
+inline val GPUAutoLayoutMode.Companion.auto: GPUAutoLayoutMode
+    get() = unsafeCast("auto")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUBlendFactor.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUBlendFactor.kt
@@ -6,47 +6,47 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUBlendFactor {
-    companion object {
-        @JsValue("constant")
-        val constant: GPUBlendFactor
-
-        @JsValue("dst")
-        val dst: GPUBlendFactor
-
-        @JsValue("dst-alpha")
-        val dstAlpha: GPUBlendFactor
-
-        @JsValue("one")
-        val one: GPUBlendFactor
-
-        @JsValue("one-minus-constant")
-        val oneMinusConstant: GPUBlendFactor
-
-        @JsValue("one-minus-dst")
-        val oneMinusDst: GPUBlendFactor
-
-        @JsValue("one-minus-dst-alpha")
-        val oneMinusDstAlpha: GPUBlendFactor
-
-        @JsValue("one-minus-src")
-        val oneMinusSrc: GPUBlendFactor
-
-        @JsValue("one-minus-src-alpha")
-        val oneMinusSrcAlpha: GPUBlendFactor
-
-        @JsValue("src")
-        val src: GPUBlendFactor
-
-        @JsValue("src-alpha")
-        val srcAlpha: GPUBlendFactor
-
-        @JsValue("src-alpha-saturated")
-        val srcAlphaSaturated: GPUBlendFactor
-
-        @JsValue("zero")
-        val zero: GPUBlendFactor
-    }
+    companion object
 }
+
+inline val GPUBlendFactor.Companion.constant: GPUBlendFactor
+    get() = unsafeCast("constant")
+
+inline val GPUBlendFactor.Companion.dst: GPUBlendFactor
+    get() = unsafeCast("dst")
+
+inline val GPUBlendFactor.Companion.dstAlpha: GPUBlendFactor
+    get() = unsafeCast("dst-alpha")
+
+inline val GPUBlendFactor.Companion.one: GPUBlendFactor
+    get() = unsafeCast("one")
+
+inline val GPUBlendFactor.Companion.oneMinusConstant: GPUBlendFactor
+    get() = unsafeCast("one-minus-constant")
+
+inline val GPUBlendFactor.Companion.oneMinusDst: GPUBlendFactor
+    get() = unsafeCast("one-minus-dst")
+
+inline val GPUBlendFactor.Companion.oneMinusDstAlpha: GPUBlendFactor
+    get() = unsafeCast("one-minus-dst-alpha")
+
+inline val GPUBlendFactor.Companion.oneMinusSrc: GPUBlendFactor
+    get() = unsafeCast("one-minus-src")
+
+inline val GPUBlendFactor.Companion.oneMinusSrcAlpha: GPUBlendFactor
+    get() = unsafeCast("one-minus-src-alpha")
+
+inline val GPUBlendFactor.Companion.src: GPUBlendFactor
+    get() = unsafeCast("src")
+
+inline val GPUBlendFactor.Companion.srcAlpha: GPUBlendFactor
+    get() = unsafeCast("src-alpha")
+
+inline val GPUBlendFactor.Companion.srcAlphaSaturated: GPUBlendFactor
+    get() = unsafeCast("src-alpha-saturated")
+
+inline val GPUBlendFactor.Companion.zero: GPUBlendFactor
+    get() = unsafeCast("zero")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUBlendOperation.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUBlendOperation.kt
@@ -6,23 +6,23 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUBlendOperation {
-    companion object {
-        @JsValue("add")
-        val add: GPUBlendOperation
-
-        @JsValue("max")
-        val max: GPUBlendOperation
-
-        @JsValue("min")
-        val min: GPUBlendOperation
-
-        @JsValue("reverse-subtract")
-        val reverseSubtract: GPUBlendOperation
-
-        @JsValue("subtract")
-        val subtract: GPUBlendOperation
-    }
+    companion object
 }
+
+inline val GPUBlendOperation.Companion.add: GPUBlendOperation
+    get() = unsafeCast("add")
+
+inline val GPUBlendOperation.Companion.max: GPUBlendOperation
+    get() = unsafeCast("max")
+
+inline val GPUBlendOperation.Companion.min: GPUBlendOperation
+    get() = unsafeCast("min")
+
+inline val GPUBlendOperation.Companion.reverseSubtract: GPUBlendOperation
+    get() = unsafeCast("reverse-subtract")
+
+inline val GPUBlendOperation.Companion.subtract: GPUBlendOperation
+    get() = unsafeCast("subtract")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUBufferBindingType.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUBufferBindingType.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUBufferBindingType {
-    companion object {
-        @JsValue("read-only-storage")
-        val readOnlyStorage: GPUBufferBindingType
-
-        @JsValue("storage")
-        val storage: GPUBufferBindingType
-
-        @JsValue("uniform")
-        val uniform: GPUBufferBindingType
-    }
+    companion object
 }
+
+inline val GPUBufferBindingType.Companion.readOnlyStorage: GPUBufferBindingType
+    get() = unsafeCast("read-only-storage")
+
+inline val GPUBufferBindingType.Companion.storage: GPUBufferBindingType
+    get() = unsafeCast("storage")
+
+inline val GPUBufferBindingType.Companion.uniform: GPUBufferBindingType
+    get() = unsafeCast("uniform")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUBufferMapState.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUBufferMapState.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUBufferMapState {
-    companion object {
-        @JsValue("mapped")
-        val mapped: GPUBufferMapState
-
-        @JsValue("pending")
-        val pending: GPUBufferMapState
-
-        @JsValue("unmapped")
-        val unmapped: GPUBufferMapState
-    }
+    companion object
 }
+
+inline val GPUBufferMapState.Companion.mapped: GPUBufferMapState
+    get() = unsafeCast("mapped")
+
+inline val GPUBufferMapState.Companion.pending: GPUBufferMapState
+    get() = unsafeCast("pending")
+
+inline val GPUBufferMapState.Companion.unmapped: GPUBufferMapState
+    get() = unsafeCast("unmapped")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUCanvasAlphaMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUCanvasAlphaMode.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUCanvasAlphaMode {
-    companion object {
-        @JsValue("opaque")
-        val opaque: GPUCanvasAlphaMode
-
-        @JsValue("premultiplied")
-        val premultiplied: GPUCanvasAlphaMode
-    }
+    companion object
 }
+
+inline val GPUCanvasAlphaMode.Companion.opaque: GPUCanvasAlphaMode
+    get() = unsafeCast("opaque")
+
+inline val GPUCanvasAlphaMode.Companion.premultiplied: GPUCanvasAlphaMode
+    get() = unsafeCast("premultiplied")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUCanvasToneMappingMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUCanvasToneMappingMode.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUCanvasToneMappingMode {
-    companion object {
-        @JsValue("extended")
-        val extended: GPUCanvasToneMappingMode
-
-        @JsValue("standard")
-        val standard: GPUCanvasToneMappingMode
-    }
+    companion object
 }
+
+inline val GPUCanvasToneMappingMode.Companion.extended: GPUCanvasToneMappingMode
+    get() = unsafeCast("extended")
+
+inline val GPUCanvasToneMappingMode.Companion.standard: GPUCanvasToneMappingMode
+    get() = unsafeCast("standard")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUCompareFunction.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUCompareFunction.kt
@@ -6,32 +6,32 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUCompareFunction {
-    companion object {
-        @JsValue("always")
-        val always: GPUCompareFunction
-
-        @JsValue("equal")
-        val equal: GPUCompareFunction
-
-        @JsValue("greater")
-        val greater: GPUCompareFunction
-
-        @JsValue("greater-equal")
-        val greaterEqual: GPUCompareFunction
-
-        @JsValue("less")
-        val less: GPUCompareFunction
-
-        @JsValue("less-equal")
-        val lessEqual: GPUCompareFunction
-
-        @JsValue("never")
-        val never: GPUCompareFunction
-
-        @JsValue("not-equal")
-        val notEqual: GPUCompareFunction
-    }
+    companion object
 }
+
+inline val GPUCompareFunction.Companion.always: GPUCompareFunction
+    get() = unsafeCast("always")
+
+inline val GPUCompareFunction.Companion.equal: GPUCompareFunction
+    get() = unsafeCast("equal")
+
+inline val GPUCompareFunction.Companion.greater: GPUCompareFunction
+    get() = unsafeCast("greater")
+
+inline val GPUCompareFunction.Companion.greaterEqual: GPUCompareFunction
+    get() = unsafeCast("greater-equal")
+
+inline val GPUCompareFunction.Companion.less: GPUCompareFunction
+    get() = unsafeCast("less")
+
+inline val GPUCompareFunction.Companion.lessEqual: GPUCompareFunction
+    get() = unsafeCast("less-equal")
+
+inline val GPUCompareFunction.Companion.never: GPUCompareFunction
+    get() = unsafeCast("never")
+
+inline val GPUCompareFunction.Companion.notEqual: GPUCompareFunction
+    get() = unsafeCast("not-equal")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUCompilationMessageType.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUCompilationMessageType.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUCompilationMessageType {
-    companion object {
-        @JsValue("error")
-        val error: GPUCompilationMessageType
-
-        @JsValue("info")
-        val info: GPUCompilationMessageType
-
-        @JsValue("warning")
-        val warning: GPUCompilationMessageType
-    }
+    companion object
 }
+
+inline val GPUCompilationMessageType.Companion.error: GPUCompilationMessageType
+    get() = unsafeCast("error")
+
+inline val GPUCompilationMessageType.Companion.info: GPUCompilationMessageType
+    get() = unsafeCast("info")
+
+inline val GPUCompilationMessageType.Companion.warning: GPUCompilationMessageType
+    get() = unsafeCast("warning")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUCullMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUCullMode.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUCullMode {
-    companion object {
-        @JsValue("back")
-        val back: GPUCullMode
-
-        @JsValue("front")
-        val front: GPUCullMode
-
-        @JsValue("none")
-        val none: GPUCullMode
-    }
+    companion object
 }
+
+inline val GPUCullMode.Companion.back: GPUCullMode
+    get() = unsafeCast("back")
+
+inline val GPUCullMode.Companion.front: GPUCullMode
+    get() = unsafeCast("front")
+
+inline val GPUCullMode.Companion.none: GPUCullMode
+    get() = unsafeCast("none")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUDeviceLostReason.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUDeviceLostReason.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUDeviceLostReason {
-    companion object {
-        @JsValue("destroyed")
-        val destroyed: GPUDeviceLostReason
-
-        @JsValue("unknown")
-        val unknown: GPUDeviceLostReason
-    }
+    companion object
 }
+
+inline val GPUDeviceLostReason.Companion.destroyed: GPUDeviceLostReason
+    get() = unsafeCast("destroyed")
+
+inline val GPUDeviceLostReason.Companion.unknown: GPUDeviceLostReason
+    get() = unsafeCast("unknown")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUErrorFilter.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUErrorFilter.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUErrorFilter {
-    companion object {
-        @JsValue("internal")
-        val internal: GPUErrorFilter
-
-        @JsValue("out-of-memory")
-        val outOfMemory: GPUErrorFilter
-
-        @JsValue("validation")
-        val validation: GPUErrorFilter
-    }
+    companion object
 }
+
+inline val GPUErrorFilter.Companion.internal: GPUErrorFilter
+    get() = unsafeCast("internal")
+
+inline val GPUErrorFilter.Companion.outOfMemory: GPUErrorFilter
+    get() = unsafeCast("out-of-memory")
+
+inline val GPUErrorFilter.Companion.validation: GPUErrorFilter
+    get() = unsafeCast("validation")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUFeatureName.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUFeatureName.kt
@@ -6,41 +6,41 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUFeatureName {
-    companion object {
-        @JsValue("bgra8unorm-storage")
-        val bgra8unormStorage: GPUFeatureName
-
-        @JsValue("depth-clip-control")
-        val depthClipControl: GPUFeatureName
-
-        @JsValue("depth32float-stencil8")
-        val depth32floatStencil8: GPUFeatureName
-
-        @JsValue("float32-filterable")
-        val float32Filterable: GPUFeatureName
-
-        @JsValue("indirect-first-instance")
-        val indirectFirstInstance: GPUFeatureName
-
-        @JsValue("rg11b10ufloat-renderable")
-        val rg11b10ufloatRenderable: GPUFeatureName
-
-        @JsValue("shader-f16")
-        val shaderF16: GPUFeatureName
-
-        @JsValue("texture-compression-astc")
-        val textureCompressionAstc: GPUFeatureName
-
-        @JsValue("texture-compression-bc")
-        val textureCompressionBc: GPUFeatureName
-
-        @JsValue("texture-compression-etc2")
-        val textureCompressionEtc2: GPUFeatureName
-
-        @JsValue("timestamp-query")
-        val timestampQuery: GPUFeatureName
-    }
+    companion object
 }
+
+inline val GPUFeatureName.Companion.bgra8unormStorage: GPUFeatureName
+    get() = unsafeCast("bgra8unorm-storage")
+
+inline val GPUFeatureName.Companion.depthClipControl: GPUFeatureName
+    get() = unsafeCast("depth-clip-control")
+
+inline val GPUFeatureName.Companion.depth32floatStencil8: GPUFeatureName
+    get() = unsafeCast("depth32float-stencil8")
+
+inline val GPUFeatureName.Companion.float32Filterable: GPUFeatureName
+    get() = unsafeCast("float32-filterable")
+
+inline val GPUFeatureName.Companion.indirectFirstInstance: GPUFeatureName
+    get() = unsafeCast("indirect-first-instance")
+
+inline val GPUFeatureName.Companion.rg11b10ufloatRenderable: GPUFeatureName
+    get() = unsafeCast("rg11b10ufloat-renderable")
+
+inline val GPUFeatureName.Companion.shaderF16: GPUFeatureName
+    get() = unsafeCast("shader-f16")
+
+inline val GPUFeatureName.Companion.textureCompressionAstc: GPUFeatureName
+    get() = unsafeCast("texture-compression-astc")
+
+inline val GPUFeatureName.Companion.textureCompressionBc: GPUFeatureName
+    get() = unsafeCast("texture-compression-bc")
+
+inline val GPUFeatureName.Companion.textureCompressionEtc2: GPUFeatureName
+    get() = unsafeCast("texture-compression-etc2")
+
+inline val GPUFeatureName.Companion.timestampQuery: GPUFeatureName
+    get() = unsafeCast("timestamp-query")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUFilterMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUFilterMode.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUFilterMode {
-    companion object {
-        @JsValue("linear")
-        val linear: GPUFilterMode
-
-        @JsValue("nearest")
-        val nearest: GPUFilterMode
-    }
+    companion object
 }
+
+inline val GPUFilterMode.Companion.linear: GPUFilterMode
+    get() = unsafeCast("linear")
+
+inline val GPUFilterMode.Companion.nearest: GPUFilterMode
+    get() = unsafeCast("nearest")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUFrontFace.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUFrontFace.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUFrontFace {
-    companion object {
-        @JsValue("ccw")
-        val ccw: GPUFrontFace
-
-        @JsValue("cw")
-        val cw: GPUFrontFace
-    }
+    companion object
 }
+
+inline val GPUFrontFace.Companion.ccw: GPUFrontFace
+    get() = unsafeCast("ccw")
+
+inline val GPUFrontFace.Companion.cw: GPUFrontFace
+    get() = unsafeCast("cw")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUIndexFormat.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUIndexFormat.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUIndexFormat {
-    companion object {
-        @JsValue("uint16")
-        val uint16: GPUIndexFormat
-
-        @JsValue("uint32")
-        val uint32: GPUIndexFormat
-    }
+    companion object
 }
+
+inline val GPUIndexFormat.Companion.uint16: GPUIndexFormat
+    get() = unsafeCast("uint16")
+
+inline val GPUIndexFormat.Companion.uint32: GPUIndexFormat
+    get() = unsafeCast("uint32")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPULoadOp.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPULoadOp.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPULoadOp {
-    companion object {
-        @JsValue("clear")
-        val clear: GPULoadOp
-
-        @JsValue("load")
-        val load: GPULoadOp
-    }
+    companion object
 }
+
+inline val GPULoadOp.Companion.clear: GPULoadOp
+    get() = unsafeCast("clear")
+
+inline val GPULoadOp.Companion.load: GPULoadOp
+    get() = unsafeCast("load")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUMipmapFilterMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUMipmapFilterMode.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUMipmapFilterMode {
-    companion object {
-        @JsValue("linear")
-        val linear: GPUMipmapFilterMode
-
-        @JsValue("nearest")
-        val nearest: GPUMipmapFilterMode
-    }
+    companion object
 }
+
+inline val GPUMipmapFilterMode.Companion.linear: GPUMipmapFilterMode
+    get() = unsafeCast("linear")
+
+inline val GPUMipmapFilterMode.Companion.nearest: GPUMipmapFilterMode
+    get() = unsafeCast("nearest")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUPipelineErrorReason.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUPipelineErrorReason.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUPipelineErrorReason {
-    companion object {
-        @JsValue("internal")
-        val internal: GPUPipelineErrorReason
-
-        @JsValue("validation")
-        val validation: GPUPipelineErrorReason
-    }
+    companion object
 }
+
+inline val GPUPipelineErrorReason.Companion.internal: GPUPipelineErrorReason
+    get() = unsafeCast("internal")
+
+inline val GPUPipelineErrorReason.Companion.validation: GPUPipelineErrorReason
+    get() = unsafeCast("validation")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUPowerPreference.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUPowerPreference.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUPowerPreference {
-    companion object {
-        @JsValue("high-performance")
-        val highPerformance: GPUPowerPreference
-
-        @JsValue("low-power")
-        val lowPower: GPUPowerPreference
-    }
+    companion object
 }
+
+inline val GPUPowerPreference.Companion.highPerformance: GPUPowerPreference
+    get() = unsafeCast("high-performance")
+
+inline val GPUPowerPreference.Companion.lowPower: GPUPowerPreference
+    get() = unsafeCast("low-power")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUPrimitiveTopology.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUPrimitiveTopology.kt
@@ -6,23 +6,23 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUPrimitiveTopology {
-    companion object {
-        @JsValue("line-list")
-        val lineList: GPUPrimitiveTopology
-
-        @JsValue("line-strip")
-        val lineStrip: GPUPrimitiveTopology
-
-        @JsValue("point-list")
-        val pointList: GPUPrimitiveTopology
-
-        @JsValue("triangle-list")
-        val triangleList: GPUPrimitiveTopology
-
-        @JsValue("triangle-strip")
-        val triangleStrip: GPUPrimitiveTopology
-    }
+    companion object
 }
+
+inline val GPUPrimitiveTopology.Companion.lineList: GPUPrimitiveTopology
+    get() = unsafeCast("line-list")
+
+inline val GPUPrimitiveTopology.Companion.lineStrip: GPUPrimitiveTopology
+    get() = unsafeCast("line-strip")
+
+inline val GPUPrimitiveTopology.Companion.pointList: GPUPrimitiveTopology
+    get() = unsafeCast("point-list")
+
+inline val GPUPrimitiveTopology.Companion.triangleList: GPUPrimitiveTopology
+    get() = unsafeCast("triangle-list")
+
+inline val GPUPrimitiveTopology.Companion.triangleStrip: GPUPrimitiveTopology
+    get() = unsafeCast("triangle-strip")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUQueryType.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUQueryType.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUQueryType {
-    companion object {
-        @JsValue("occlusion")
-        val occlusion: GPUQueryType
-
-        @JsValue("timestamp")
-        val timestamp: GPUQueryType
-    }
+    companion object
 }
+
+inline val GPUQueryType.Companion.occlusion: GPUQueryType
+    get() = unsafeCast("occlusion")
+
+inline val GPUQueryType.Companion.timestamp: GPUQueryType
+    get() = unsafeCast("timestamp")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUSamplerBindingType.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUSamplerBindingType.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUSamplerBindingType {
-    companion object {
-        @JsValue("comparison")
-        val comparison: GPUSamplerBindingType
-
-        @JsValue("filtering")
-        val filtering: GPUSamplerBindingType
-
-        @JsValue("non-filtering")
-        val nonFiltering: GPUSamplerBindingType
-    }
+    companion object
 }
+
+inline val GPUSamplerBindingType.Companion.comparison: GPUSamplerBindingType
+    get() = unsafeCast("comparison")
+
+inline val GPUSamplerBindingType.Companion.filtering: GPUSamplerBindingType
+    get() = unsafeCast("filtering")
+
+inline val GPUSamplerBindingType.Companion.nonFiltering: GPUSamplerBindingType
+    get() = unsafeCast("non-filtering")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUStencilOperation.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUStencilOperation.kt
@@ -6,32 +6,32 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUStencilOperation {
-    companion object {
-        @JsValue("decrement-clamp")
-        val decrementClamp: GPUStencilOperation
-
-        @JsValue("decrement-wrap")
-        val decrementWrap: GPUStencilOperation
-
-        @JsValue("increment-clamp")
-        val incrementClamp: GPUStencilOperation
-
-        @JsValue("increment-wrap")
-        val incrementWrap: GPUStencilOperation
-
-        @JsValue("invert")
-        val invert: GPUStencilOperation
-
-        @JsValue("keep")
-        val keep: GPUStencilOperation
-
-        @JsValue("replace")
-        val replace: GPUStencilOperation
-
-        @JsValue("zero")
-        val zero: GPUStencilOperation
-    }
+    companion object
 }
+
+inline val GPUStencilOperation.Companion.decrementClamp: GPUStencilOperation
+    get() = unsafeCast("decrement-clamp")
+
+inline val GPUStencilOperation.Companion.decrementWrap: GPUStencilOperation
+    get() = unsafeCast("decrement-wrap")
+
+inline val GPUStencilOperation.Companion.incrementClamp: GPUStencilOperation
+    get() = unsafeCast("increment-clamp")
+
+inline val GPUStencilOperation.Companion.incrementWrap: GPUStencilOperation
+    get() = unsafeCast("increment-wrap")
+
+inline val GPUStencilOperation.Companion.invert: GPUStencilOperation
+    get() = unsafeCast("invert")
+
+inline val GPUStencilOperation.Companion.keep: GPUStencilOperation
+    get() = unsafeCast("keep")
+
+inline val GPUStencilOperation.Companion.replace: GPUStencilOperation
+    get() = unsafeCast("replace")
+
+inline val GPUStencilOperation.Companion.zero: GPUStencilOperation
+    get() = unsafeCast("zero")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUStorageTextureAccess.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUStorageTextureAccess.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUStorageTextureAccess {
-    companion object {
-        @JsValue("read-only")
-        val readOnly: GPUStorageTextureAccess
-
-        @JsValue("read-write")
-        val readWrite: GPUStorageTextureAccess
-
-        @JsValue("write-only")
-        val writeOnly: GPUStorageTextureAccess
-    }
+    companion object
 }
+
+inline val GPUStorageTextureAccess.Companion.readOnly: GPUStorageTextureAccess
+    get() = unsafeCast("read-only")
+
+inline val GPUStorageTextureAccess.Companion.readWrite: GPUStorageTextureAccess
+    get() = unsafeCast("read-write")
+
+inline val GPUStorageTextureAccess.Companion.writeOnly: GPUStorageTextureAccess
+    get() = unsafeCast("write-only")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUStoreOp.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUStoreOp.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUStoreOp {
-    companion object {
-        @JsValue("discard")
-        val discard: GPUStoreOp
-
-        @JsValue("store")
-        val store: GPUStoreOp
-    }
+    companion object
 }
+
+inline val GPUStoreOp.Companion.discard: GPUStoreOp
+    get() = unsafeCast("discard")
+
+inline val GPUStoreOp.Companion.store: GPUStoreOp
+    get() = unsafeCast("store")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureAspect.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureAspect.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUTextureAspect {
-    companion object {
-        @JsValue("all")
-        val all: GPUTextureAspect
-
-        @JsValue("depth-only")
-        val depthOnly: GPUTextureAspect
-
-        @JsValue("stencil-only")
-        val stencilOnly: GPUTextureAspect
-    }
+    companion object
 }
+
+inline val GPUTextureAspect.Companion.all: GPUTextureAspect
+    get() = unsafeCast("all")
+
+inline val GPUTextureAspect.Companion.depthOnly: GPUTextureAspect
+    get() = unsafeCast("depth-only")
+
+inline val GPUTextureAspect.Companion.stencilOnly: GPUTextureAspect
+    get() = unsafeCast("stencil-only")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureDimension.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureDimension.kt
@@ -6,17 +6,17 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUTextureDimension {
-    companion object {
-        @JsValue("1d")
-        val _1d: GPUTextureDimension
-
-        @JsValue("2d")
-        val _2d: GPUTextureDimension
-
-        @JsValue("3d")
-        val _3d: GPUTextureDimension
-    }
+    companion object
 }
+
+inline val GPUTextureDimension.Companion._1d: GPUTextureDimension
+    get() = unsafeCast("1d")
+
+inline val GPUTextureDimension.Companion._2d: GPUTextureDimension
+    get() = unsafeCast("2d")
+
+inline val GPUTextureDimension.Companion._3d: GPUTextureDimension
+    get() = unsafeCast("3d")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureFormat.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureFormat.kt
@@ -6,293 +6,293 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUTextureFormat {
-    companion object {
-        @JsValue("astc-10x10-unorm")
-        val astc10x10Unorm: GPUTextureFormat
-
-        @JsValue("astc-10x10-unorm-srgb")
-        val astc10x10UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-10x5-unorm")
-        val astc10x5Unorm: GPUTextureFormat
-
-        @JsValue("astc-10x5-unorm-srgb")
-        val astc10x5UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-10x6-unorm")
-        val astc10x6Unorm: GPUTextureFormat
-
-        @JsValue("astc-10x6-unorm-srgb")
-        val astc10x6UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-10x8-unorm")
-        val astc10x8Unorm: GPUTextureFormat
-
-        @JsValue("astc-10x8-unorm-srgb")
-        val astc10x8UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-12x10-unorm")
-        val astc12x10Unorm: GPUTextureFormat
-
-        @JsValue("astc-12x10-unorm-srgb")
-        val astc12x10UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-12x12-unorm")
-        val astc12x12Unorm: GPUTextureFormat
-
-        @JsValue("astc-12x12-unorm-srgb")
-        val astc12x12UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-4x4-unorm")
-        val astc4x4Unorm: GPUTextureFormat
-
-        @JsValue("astc-4x4-unorm-srgb")
-        val astc4x4UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-5x4-unorm")
-        val astc5x4Unorm: GPUTextureFormat
-
-        @JsValue("astc-5x4-unorm-srgb")
-        val astc5x4UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-5x5-unorm")
-        val astc5x5Unorm: GPUTextureFormat
-
-        @JsValue("astc-5x5-unorm-srgb")
-        val astc5x5UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-6x5-unorm")
-        val astc6x5Unorm: GPUTextureFormat
-
-        @JsValue("astc-6x5-unorm-srgb")
-        val astc6x5UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-6x6-unorm")
-        val astc6x6Unorm: GPUTextureFormat
-
-        @JsValue("astc-6x6-unorm-srgb")
-        val astc6x6UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-8x5-unorm")
-        val astc8x5Unorm: GPUTextureFormat
-
-        @JsValue("astc-8x5-unorm-srgb")
-        val astc8x5UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-8x6-unorm")
-        val astc8x6Unorm: GPUTextureFormat
-
-        @JsValue("astc-8x6-unorm-srgb")
-        val astc8x6UnormSrgb: GPUTextureFormat
-
-        @JsValue("astc-8x8-unorm")
-        val astc8x8Unorm: GPUTextureFormat
-
-        @JsValue("astc-8x8-unorm-srgb")
-        val astc8x8UnormSrgb: GPUTextureFormat
-
-        @JsValue("bc1-rgba-unorm")
-        val bc1RgbaUnorm: GPUTextureFormat
-
-        @JsValue("bc1-rgba-unorm-srgb")
-        val bc1RgbaUnormSrgb: GPUTextureFormat
-
-        @JsValue("bc2-rgba-unorm")
-        val bc2RgbaUnorm: GPUTextureFormat
-
-        @JsValue("bc2-rgba-unorm-srgb")
-        val bc2RgbaUnormSrgb: GPUTextureFormat
-
-        @JsValue("bc3-rgba-unorm")
-        val bc3RgbaUnorm: GPUTextureFormat
-
-        @JsValue("bc3-rgba-unorm-srgb")
-        val bc3RgbaUnormSrgb: GPUTextureFormat
-
-        @JsValue("bc4-r-snorm")
-        val bc4RSnorm: GPUTextureFormat
-
-        @JsValue("bc4-r-unorm")
-        val bc4RUnorm: GPUTextureFormat
-
-        @JsValue("bc5-rg-snorm")
-        val bc5RgSnorm: GPUTextureFormat
-
-        @JsValue("bc5-rg-unorm")
-        val bc5RgUnorm: GPUTextureFormat
-
-        @JsValue("bc6h-rgb-float")
-        val bc6hRgbFloat: GPUTextureFormat
-
-        @JsValue("bc6h-rgb-ufloat")
-        val bc6hRgbUfloat: GPUTextureFormat
-
-        @JsValue("bc7-rgba-unorm")
-        val bc7RgbaUnorm: GPUTextureFormat
-
-        @JsValue("bc7-rgba-unorm-srgb")
-        val bc7RgbaUnormSrgb: GPUTextureFormat
-
-        @JsValue("bgra8unorm")
-        val bgra8unorm: GPUTextureFormat
-
-        @JsValue("bgra8unorm-srgb")
-        val bgra8unormSrgb: GPUTextureFormat
-
-        @JsValue("depth16unorm")
-        val depth16unorm: GPUTextureFormat
-
-        @JsValue("depth24plus")
-        val depth24plus: GPUTextureFormat
-
-        @JsValue("depth24plus-stencil8")
-        val depth24plusStencil8: GPUTextureFormat
-
-        @JsValue("depth32float")
-        val depth32float: GPUTextureFormat
-
-        @JsValue("depth32float-stencil8")
-        val depth32floatStencil8: GPUTextureFormat
-
-        @JsValue("eac-r11snorm")
-        val eacR11snorm: GPUTextureFormat
-
-        @JsValue("eac-r11unorm")
-        val eacR11unorm: GPUTextureFormat
-
-        @JsValue("eac-rg11snorm")
-        val eacRg11snorm: GPUTextureFormat
-
-        @JsValue("eac-rg11unorm")
-        val eacRg11unorm: GPUTextureFormat
-
-        @JsValue("etc2-rgb8a1unorm")
-        val etc2Rgb8a1unorm: GPUTextureFormat
-
-        @JsValue("etc2-rgb8a1unorm-srgb")
-        val etc2Rgb8a1unormSrgb: GPUTextureFormat
-
-        @JsValue("etc2-rgb8unorm")
-        val etc2Rgb8unorm: GPUTextureFormat
-
-        @JsValue("etc2-rgb8unorm-srgb")
-        val etc2Rgb8unormSrgb: GPUTextureFormat
-
-        @JsValue("etc2-rgba8unorm")
-        val etc2Rgba8unorm: GPUTextureFormat
-
-        @JsValue("etc2-rgba8unorm-srgb")
-        val etc2Rgba8unormSrgb: GPUTextureFormat
-
-        @JsValue("r16float")
-        val r16float: GPUTextureFormat
-
-        @JsValue("r16sint")
-        val r16sint: GPUTextureFormat
-
-        @JsValue("r16uint")
-        val r16uint: GPUTextureFormat
-
-        @JsValue("r32float")
-        val r32float: GPUTextureFormat
-
-        @JsValue("r32sint")
-        val r32sint: GPUTextureFormat
-
-        @JsValue("r32uint")
-        val r32uint: GPUTextureFormat
-
-        @JsValue("r8sint")
-        val r8sint: GPUTextureFormat
-
-        @JsValue("r8snorm")
-        val r8snorm: GPUTextureFormat
-
-        @JsValue("r8uint")
-        val r8uint: GPUTextureFormat
-
-        @JsValue("r8unorm")
-        val r8unorm: GPUTextureFormat
-
-        @JsValue("rg11b10ufloat")
-        val rg11b10ufloat: GPUTextureFormat
-
-        @JsValue("rg16float")
-        val rg16float: GPUTextureFormat
-
-        @JsValue("rg16sint")
-        val rg16sint: GPUTextureFormat
-
-        @JsValue("rg16uint")
-        val rg16uint: GPUTextureFormat
-
-        @JsValue("rg32float")
-        val rg32float: GPUTextureFormat
-
-        @JsValue("rg32sint")
-        val rg32sint: GPUTextureFormat
-
-        @JsValue("rg32uint")
-        val rg32uint: GPUTextureFormat
-
-        @JsValue("rg8sint")
-        val rg8sint: GPUTextureFormat
-
-        @JsValue("rg8snorm")
-        val rg8snorm: GPUTextureFormat
-
-        @JsValue("rg8uint")
-        val rg8uint: GPUTextureFormat
-
-        @JsValue("rg8unorm")
-        val rg8unorm: GPUTextureFormat
-
-        @JsValue("rgb10a2uint")
-        val rgb10a2uint: GPUTextureFormat
-
-        @JsValue("rgb10a2unorm")
-        val rgb10a2unorm: GPUTextureFormat
-
-        @JsValue("rgb9e5ufloat")
-        val rgb9e5ufloat: GPUTextureFormat
-
-        @JsValue("rgba16float")
-        val rgba16float: GPUTextureFormat
-
-        @JsValue("rgba16sint")
-        val rgba16sint: GPUTextureFormat
-
-        @JsValue("rgba16uint")
-        val rgba16uint: GPUTextureFormat
-
-        @JsValue("rgba32float")
-        val rgba32float: GPUTextureFormat
-
-        @JsValue("rgba32sint")
-        val rgba32sint: GPUTextureFormat
-
-        @JsValue("rgba32uint")
-        val rgba32uint: GPUTextureFormat
-
-        @JsValue("rgba8sint")
-        val rgba8sint: GPUTextureFormat
-
-        @JsValue("rgba8snorm")
-        val rgba8snorm: GPUTextureFormat
-
-        @JsValue("rgba8uint")
-        val rgba8uint: GPUTextureFormat
-
-        @JsValue("rgba8unorm")
-        val rgba8unorm: GPUTextureFormat
-
-        @JsValue("rgba8unorm-srgb")
-        val rgba8unormSrgb: GPUTextureFormat
-
-        @JsValue("stencil8")
-        val stencil8: GPUTextureFormat
-    }
+    companion object
 }
+
+inline val GPUTextureFormat.Companion.astc10x10Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-10x10-unorm")
+
+inline val GPUTextureFormat.Companion.astc10x10UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-10x10-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc10x5Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-10x5-unorm")
+
+inline val GPUTextureFormat.Companion.astc10x5UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-10x5-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc10x6Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-10x6-unorm")
+
+inline val GPUTextureFormat.Companion.astc10x6UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-10x6-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc10x8Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-10x8-unorm")
+
+inline val GPUTextureFormat.Companion.astc10x8UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-10x8-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc12x10Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-12x10-unorm")
+
+inline val GPUTextureFormat.Companion.astc12x10UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-12x10-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc12x12Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-12x12-unorm")
+
+inline val GPUTextureFormat.Companion.astc12x12UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-12x12-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc4x4Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-4x4-unorm")
+
+inline val GPUTextureFormat.Companion.astc4x4UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-4x4-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc5x4Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-5x4-unorm")
+
+inline val GPUTextureFormat.Companion.astc5x4UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-5x4-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc5x5Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-5x5-unorm")
+
+inline val GPUTextureFormat.Companion.astc5x5UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-5x5-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc6x5Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-6x5-unorm")
+
+inline val GPUTextureFormat.Companion.astc6x5UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-6x5-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc6x6Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-6x6-unorm")
+
+inline val GPUTextureFormat.Companion.astc6x6UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-6x6-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc8x5Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-8x5-unorm")
+
+inline val GPUTextureFormat.Companion.astc8x5UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-8x5-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc8x6Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-8x6-unorm")
+
+inline val GPUTextureFormat.Companion.astc8x6UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-8x6-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.astc8x8Unorm: GPUTextureFormat
+    get() = unsafeCast("astc-8x8-unorm")
+
+inline val GPUTextureFormat.Companion.astc8x8UnormSrgb: GPUTextureFormat
+    get() = unsafeCast("astc-8x8-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.bc1RgbaUnorm: GPUTextureFormat
+    get() = unsafeCast("bc1-rgba-unorm")
+
+inline val GPUTextureFormat.Companion.bc1RgbaUnormSrgb: GPUTextureFormat
+    get() = unsafeCast("bc1-rgba-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.bc2RgbaUnorm: GPUTextureFormat
+    get() = unsafeCast("bc2-rgba-unorm")
+
+inline val GPUTextureFormat.Companion.bc2RgbaUnormSrgb: GPUTextureFormat
+    get() = unsafeCast("bc2-rgba-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.bc3RgbaUnorm: GPUTextureFormat
+    get() = unsafeCast("bc3-rgba-unorm")
+
+inline val GPUTextureFormat.Companion.bc3RgbaUnormSrgb: GPUTextureFormat
+    get() = unsafeCast("bc3-rgba-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.bc4RSnorm: GPUTextureFormat
+    get() = unsafeCast("bc4-r-snorm")
+
+inline val GPUTextureFormat.Companion.bc4RUnorm: GPUTextureFormat
+    get() = unsafeCast("bc4-r-unorm")
+
+inline val GPUTextureFormat.Companion.bc5RgSnorm: GPUTextureFormat
+    get() = unsafeCast("bc5-rg-snorm")
+
+inline val GPUTextureFormat.Companion.bc5RgUnorm: GPUTextureFormat
+    get() = unsafeCast("bc5-rg-unorm")
+
+inline val GPUTextureFormat.Companion.bc6hRgbFloat: GPUTextureFormat
+    get() = unsafeCast("bc6h-rgb-float")
+
+inline val GPUTextureFormat.Companion.bc6hRgbUfloat: GPUTextureFormat
+    get() = unsafeCast("bc6h-rgb-ufloat")
+
+inline val GPUTextureFormat.Companion.bc7RgbaUnorm: GPUTextureFormat
+    get() = unsafeCast("bc7-rgba-unorm")
+
+inline val GPUTextureFormat.Companion.bc7RgbaUnormSrgb: GPUTextureFormat
+    get() = unsafeCast("bc7-rgba-unorm-srgb")
+
+inline val GPUTextureFormat.Companion.bgra8unorm: GPUTextureFormat
+    get() = unsafeCast("bgra8unorm")
+
+inline val GPUTextureFormat.Companion.bgra8unormSrgb: GPUTextureFormat
+    get() = unsafeCast("bgra8unorm-srgb")
+
+inline val GPUTextureFormat.Companion.depth16unorm: GPUTextureFormat
+    get() = unsafeCast("depth16unorm")
+
+inline val GPUTextureFormat.Companion.depth24plus: GPUTextureFormat
+    get() = unsafeCast("depth24plus")
+
+inline val GPUTextureFormat.Companion.depth24plusStencil8: GPUTextureFormat
+    get() = unsafeCast("depth24plus-stencil8")
+
+inline val GPUTextureFormat.Companion.depth32float: GPUTextureFormat
+    get() = unsafeCast("depth32float")
+
+inline val GPUTextureFormat.Companion.depth32floatStencil8: GPUTextureFormat
+    get() = unsafeCast("depth32float-stencil8")
+
+inline val GPUTextureFormat.Companion.eacR11snorm: GPUTextureFormat
+    get() = unsafeCast("eac-r11snorm")
+
+inline val GPUTextureFormat.Companion.eacR11unorm: GPUTextureFormat
+    get() = unsafeCast("eac-r11unorm")
+
+inline val GPUTextureFormat.Companion.eacRg11snorm: GPUTextureFormat
+    get() = unsafeCast("eac-rg11snorm")
+
+inline val GPUTextureFormat.Companion.eacRg11unorm: GPUTextureFormat
+    get() = unsafeCast("eac-rg11unorm")
+
+inline val GPUTextureFormat.Companion.etc2Rgb8a1unorm: GPUTextureFormat
+    get() = unsafeCast("etc2-rgb8a1unorm")
+
+inline val GPUTextureFormat.Companion.etc2Rgb8a1unormSrgb: GPUTextureFormat
+    get() = unsafeCast("etc2-rgb8a1unorm-srgb")
+
+inline val GPUTextureFormat.Companion.etc2Rgb8unorm: GPUTextureFormat
+    get() = unsafeCast("etc2-rgb8unorm")
+
+inline val GPUTextureFormat.Companion.etc2Rgb8unormSrgb: GPUTextureFormat
+    get() = unsafeCast("etc2-rgb8unorm-srgb")
+
+inline val GPUTextureFormat.Companion.etc2Rgba8unorm: GPUTextureFormat
+    get() = unsafeCast("etc2-rgba8unorm")
+
+inline val GPUTextureFormat.Companion.etc2Rgba8unormSrgb: GPUTextureFormat
+    get() = unsafeCast("etc2-rgba8unorm-srgb")
+
+inline val GPUTextureFormat.Companion.r16float: GPUTextureFormat
+    get() = unsafeCast("r16float")
+
+inline val GPUTextureFormat.Companion.r16sint: GPUTextureFormat
+    get() = unsafeCast("r16sint")
+
+inline val GPUTextureFormat.Companion.r16uint: GPUTextureFormat
+    get() = unsafeCast("r16uint")
+
+inline val GPUTextureFormat.Companion.r32float: GPUTextureFormat
+    get() = unsafeCast("r32float")
+
+inline val GPUTextureFormat.Companion.r32sint: GPUTextureFormat
+    get() = unsafeCast("r32sint")
+
+inline val GPUTextureFormat.Companion.r32uint: GPUTextureFormat
+    get() = unsafeCast("r32uint")
+
+inline val GPUTextureFormat.Companion.r8sint: GPUTextureFormat
+    get() = unsafeCast("r8sint")
+
+inline val GPUTextureFormat.Companion.r8snorm: GPUTextureFormat
+    get() = unsafeCast("r8snorm")
+
+inline val GPUTextureFormat.Companion.r8uint: GPUTextureFormat
+    get() = unsafeCast("r8uint")
+
+inline val GPUTextureFormat.Companion.r8unorm: GPUTextureFormat
+    get() = unsafeCast("r8unorm")
+
+inline val GPUTextureFormat.Companion.rg11b10ufloat: GPUTextureFormat
+    get() = unsafeCast("rg11b10ufloat")
+
+inline val GPUTextureFormat.Companion.rg16float: GPUTextureFormat
+    get() = unsafeCast("rg16float")
+
+inline val GPUTextureFormat.Companion.rg16sint: GPUTextureFormat
+    get() = unsafeCast("rg16sint")
+
+inline val GPUTextureFormat.Companion.rg16uint: GPUTextureFormat
+    get() = unsafeCast("rg16uint")
+
+inline val GPUTextureFormat.Companion.rg32float: GPUTextureFormat
+    get() = unsafeCast("rg32float")
+
+inline val GPUTextureFormat.Companion.rg32sint: GPUTextureFormat
+    get() = unsafeCast("rg32sint")
+
+inline val GPUTextureFormat.Companion.rg32uint: GPUTextureFormat
+    get() = unsafeCast("rg32uint")
+
+inline val GPUTextureFormat.Companion.rg8sint: GPUTextureFormat
+    get() = unsafeCast("rg8sint")
+
+inline val GPUTextureFormat.Companion.rg8snorm: GPUTextureFormat
+    get() = unsafeCast("rg8snorm")
+
+inline val GPUTextureFormat.Companion.rg8uint: GPUTextureFormat
+    get() = unsafeCast("rg8uint")
+
+inline val GPUTextureFormat.Companion.rg8unorm: GPUTextureFormat
+    get() = unsafeCast("rg8unorm")
+
+inline val GPUTextureFormat.Companion.rgb10a2uint: GPUTextureFormat
+    get() = unsafeCast("rgb10a2uint")
+
+inline val GPUTextureFormat.Companion.rgb10a2unorm: GPUTextureFormat
+    get() = unsafeCast("rgb10a2unorm")
+
+inline val GPUTextureFormat.Companion.rgb9e5ufloat: GPUTextureFormat
+    get() = unsafeCast("rgb9e5ufloat")
+
+inline val GPUTextureFormat.Companion.rgba16float: GPUTextureFormat
+    get() = unsafeCast("rgba16float")
+
+inline val GPUTextureFormat.Companion.rgba16sint: GPUTextureFormat
+    get() = unsafeCast("rgba16sint")
+
+inline val GPUTextureFormat.Companion.rgba16uint: GPUTextureFormat
+    get() = unsafeCast("rgba16uint")
+
+inline val GPUTextureFormat.Companion.rgba32float: GPUTextureFormat
+    get() = unsafeCast("rgba32float")
+
+inline val GPUTextureFormat.Companion.rgba32sint: GPUTextureFormat
+    get() = unsafeCast("rgba32sint")
+
+inline val GPUTextureFormat.Companion.rgba32uint: GPUTextureFormat
+    get() = unsafeCast("rgba32uint")
+
+inline val GPUTextureFormat.Companion.rgba8sint: GPUTextureFormat
+    get() = unsafeCast("rgba8sint")
+
+inline val GPUTextureFormat.Companion.rgba8snorm: GPUTextureFormat
+    get() = unsafeCast("rgba8snorm")
+
+inline val GPUTextureFormat.Companion.rgba8uint: GPUTextureFormat
+    get() = unsafeCast("rgba8uint")
+
+inline val GPUTextureFormat.Companion.rgba8unorm: GPUTextureFormat
+    get() = unsafeCast("rgba8unorm")
+
+inline val GPUTextureFormat.Companion.rgba8unormSrgb: GPUTextureFormat
+    get() = unsafeCast("rgba8unorm-srgb")
+
+inline val GPUTextureFormat.Companion.stencil8: GPUTextureFormat
+    get() = unsafeCast("stencil8")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureSampleType.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureSampleType.kt
@@ -6,23 +6,23 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUTextureSampleType {
-    companion object {
-        @JsValue("depth")
-        val depth: GPUTextureSampleType
-
-        @JsValue("float")
-        val float: GPUTextureSampleType
-
-        @JsValue("sint")
-        val sint: GPUTextureSampleType
-
-        @JsValue("uint")
-        val uint: GPUTextureSampleType
-
-        @JsValue("unfilterable-float")
-        val unfilterableFloat: GPUTextureSampleType
-    }
+    companion object
 }
+
+inline val GPUTextureSampleType.Companion.depth: GPUTextureSampleType
+    get() = unsafeCast("depth")
+
+inline val GPUTextureSampleType.Companion.float: GPUTextureSampleType
+    get() = unsafeCast("float")
+
+inline val GPUTextureSampleType.Companion.sint: GPUTextureSampleType
+    get() = unsafeCast("sint")
+
+inline val GPUTextureSampleType.Companion.uint: GPUTextureSampleType
+    get() = unsafeCast("uint")
+
+inline val GPUTextureSampleType.Companion.unfilterableFloat: GPUTextureSampleType
+    get() = unsafeCast("unfilterable-float")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureViewDimension.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUTextureViewDimension.kt
@@ -6,26 +6,26 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUTextureViewDimension {
-    companion object {
-        @JsValue("1d")
-        val _1d: GPUTextureViewDimension
-
-        @JsValue("2d")
-        val _2d: GPUTextureViewDimension
-
-        @JsValue("2d-array")
-        val _2dArray: GPUTextureViewDimension
-
-        @JsValue("3d")
-        val _3d: GPUTextureViewDimension
-
-        @JsValue("cube")
-        val cube: GPUTextureViewDimension
-
-        @JsValue("cube-array")
-        val cubeArray: GPUTextureViewDimension
-    }
+    companion object
 }
+
+inline val GPUTextureViewDimension.Companion._1d: GPUTextureViewDimension
+    get() = unsafeCast("1d")
+
+inline val GPUTextureViewDimension.Companion._2d: GPUTextureViewDimension
+    get() = unsafeCast("2d")
+
+inline val GPUTextureViewDimension.Companion._2dArray: GPUTextureViewDimension
+    get() = unsafeCast("2d-array")
+
+inline val GPUTextureViewDimension.Companion._3d: GPUTextureViewDimension
+    get() = unsafeCast("3d")
+
+inline val GPUTextureViewDimension.Companion.cube: GPUTextureViewDimension
+    get() = unsafeCast("cube")
+
+inline val GPUTextureViewDimension.Companion.cubeArray: GPUTextureViewDimension
+    get() = unsafeCast("cube-array")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUVertexFormat.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUVertexFormat.kt
@@ -6,101 +6,101 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUVertexFormat {
-    companion object {
-        @JsValue("float16x2")
-        val float16x2: GPUVertexFormat
-
-        @JsValue("float16x4")
-        val float16x4: GPUVertexFormat
-
-        @JsValue("float32")
-        val float32: GPUVertexFormat
-
-        @JsValue("float32x2")
-        val float32x2: GPUVertexFormat
-
-        @JsValue("float32x3")
-        val float32x3: GPUVertexFormat
-
-        @JsValue("float32x4")
-        val float32x4: GPUVertexFormat
-
-        @JsValue("sint16x2")
-        val sint16x2: GPUVertexFormat
-
-        @JsValue("sint16x4")
-        val sint16x4: GPUVertexFormat
-
-        @JsValue("sint32")
-        val sint32: GPUVertexFormat
-
-        @JsValue("sint32x2")
-        val sint32x2: GPUVertexFormat
-
-        @JsValue("sint32x3")
-        val sint32x3: GPUVertexFormat
-
-        @JsValue("sint32x4")
-        val sint32x4: GPUVertexFormat
-
-        @JsValue("sint8x2")
-        val sint8x2: GPUVertexFormat
-
-        @JsValue("sint8x4")
-        val sint8x4: GPUVertexFormat
-
-        @JsValue("snorm16x2")
-        val snorm16x2: GPUVertexFormat
-
-        @JsValue("snorm16x4")
-        val snorm16x4: GPUVertexFormat
-
-        @JsValue("snorm8x2")
-        val snorm8x2: GPUVertexFormat
-
-        @JsValue("snorm8x4")
-        val snorm8x4: GPUVertexFormat
-
-        @JsValue("uint16x2")
-        val uint16x2: GPUVertexFormat
-
-        @JsValue("uint16x4")
-        val uint16x4: GPUVertexFormat
-
-        @JsValue("uint32")
-        val uint32: GPUVertexFormat
-
-        @JsValue("uint32x2")
-        val uint32x2: GPUVertexFormat
-
-        @JsValue("uint32x3")
-        val uint32x3: GPUVertexFormat
-
-        @JsValue("uint32x4")
-        val uint32x4: GPUVertexFormat
-
-        @JsValue("uint8x2")
-        val uint8x2: GPUVertexFormat
-
-        @JsValue("uint8x4")
-        val uint8x4: GPUVertexFormat
-
-        @JsValue("unorm10-10-10-2")
-        val unorm1010102: GPUVertexFormat
-
-        @JsValue("unorm16x2")
-        val unorm16x2: GPUVertexFormat
-
-        @JsValue("unorm16x4")
-        val unorm16x4: GPUVertexFormat
-
-        @JsValue("unorm8x2")
-        val unorm8x2: GPUVertexFormat
-
-        @JsValue("unorm8x4")
-        val unorm8x4: GPUVertexFormat
-    }
+    companion object
 }
+
+inline val GPUVertexFormat.Companion.float16x2: GPUVertexFormat
+    get() = unsafeCast("float16x2")
+
+inline val GPUVertexFormat.Companion.float16x4: GPUVertexFormat
+    get() = unsafeCast("float16x4")
+
+inline val GPUVertexFormat.Companion.float32: GPUVertexFormat
+    get() = unsafeCast("float32")
+
+inline val GPUVertexFormat.Companion.float32x2: GPUVertexFormat
+    get() = unsafeCast("float32x2")
+
+inline val GPUVertexFormat.Companion.float32x3: GPUVertexFormat
+    get() = unsafeCast("float32x3")
+
+inline val GPUVertexFormat.Companion.float32x4: GPUVertexFormat
+    get() = unsafeCast("float32x4")
+
+inline val GPUVertexFormat.Companion.sint16x2: GPUVertexFormat
+    get() = unsafeCast("sint16x2")
+
+inline val GPUVertexFormat.Companion.sint16x4: GPUVertexFormat
+    get() = unsafeCast("sint16x4")
+
+inline val GPUVertexFormat.Companion.sint32: GPUVertexFormat
+    get() = unsafeCast("sint32")
+
+inline val GPUVertexFormat.Companion.sint32x2: GPUVertexFormat
+    get() = unsafeCast("sint32x2")
+
+inline val GPUVertexFormat.Companion.sint32x3: GPUVertexFormat
+    get() = unsafeCast("sint32x3")
+
+inline val GPUVertexFormat.Companion.sint32x4: GPUVertexFormat
+    get() = unsafeCast("sint32x4")
+
+inline val GPUVertexFormat.Companion.sint8x2: GPUVertexFormat
+    get() = unsafeCast("sint8x2")
+
+inline val GPUVertexFormat.Companion.sint8x4: GPUVertexFormat
+    get() = unsafeCast("sint8x4")
+
+inline val GPUVertexFormat.Companion.snorm16x2: GPUVertexFormat
+    get() = unsafeCast("snorm16x2")
+
+inline val GPUVertexFormat.Companion.snorm16x4: GPUVertexFormat
+    get() = unsafeCast("snorm16x4")
+
+inline val GPUVertexFormat.Companion.snorm8x2: GPUVertexFormat
+    get() = unsafeCast("snorm8x2")
+
+inline val GPUVertexFormat.Companion.snorm8x4: GPUVertexFormat
+    get() = unsafeCast("snorm8x4")
+
+inline val GPUVertexFormat.Companion.uint16x2: GPUVertexFormat
+    get() = unsafeCast("uint16x2")
+
+inline val GPUVertexFormat.Companion.uint16x4: GPUVertexFormat
+    get() = unsafeCast("uint16x4")
+
+inline val GPUVertexFormat.Companion.uint32: GPUVertexFormat
+    get() = unsafeCast("uint32")
+
+inline val GPUVertexFormat.Companion.uint32x2: GPUVertexFormat
+    get() = unsafeCast("uint32x2")
+
+inline val GPUVertexFormat.Companion.uint32x3: GPUVertexFormat
+    get() = unsafeCast("uint32x3")
+
+inline val GPUVertexFormat.Companion.uint32x4: GPUVertexFormat
+    get() = unsafeCast("uint32x4")
+
+inline val GPUVertexFormat.Companion.uint8x2: GPUVertexFormat
+    get() = unsafeCast("uint8x2")
+
+inline val GPUVertexFormat.Companion.uint8x4: GPUVertexFormat
+    get() = unsafeCast("uint8x4")
+
+inline val GPUVertexFormat.Companion.unorm1010102: GPUVertexFormat
+    get() = unsafeCast("unorm10-10-10-2")
+
+inline val GPUVertexFormat.Companion.unorm16x2: GPUVertexFormat
+    get() = unsafeCast("unorm16x2")
+
+inline val GPUVertexFormat.Companion.unorm16x4: GPUVertexFormat
+    get() = unsafeCast("unorm16x4")
+
+inline val GPUVertexFormat.Companion.unorm8x2: GPUVertexFormat
+    get() = unsafeCast("unorm8x2")
+
+inline val GPUVertexFormat.Companion.unorm8x4: GPUVertexFormat
+    get() = unsafeCast("unorm8x4")

--- a/kotlin-web/src/commonMain/generated/web/gpu/GPUVertexStepMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/gpu/GPUVertexStepMode.kt
@@ -6,14 +6,14 @@
 
 package web.gpu
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface GPUVertexStepMode {
-    companion object {
-        @JsValue("instance")
-        val instance: GPUVertexStepMode
-
-        @JsValue("vertex")
-        val vertex: GPUVertexStepMode
-    }
+    companion object
 }
+
+inline val GPUVertexStepMode.Companion.instance: GPUVertexStepMode
+    get() = unsafeCast("instance")
+
+inline val GPUVertexStepMode.Companion.vertex: GPUVertexStepMode
+    get() = unsafeCast("vertex")

--- a/kotlin-web/src/commonMain/generated/web/http/CrossOrigin.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/CrossOrigin.kt
@@ -6,17 +6,17 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface CrossOrigin {
-    companion object {
-        @JsValue("anonymous")
-        val anonymous: CrossOrigin
-
-        @JsValue("use-credentials")
-        val useCredentials: CrossOrigin
-
-        @JsValue("")
-        val none: CrossOrigin
-    }
+    companion object
 }
+
+inline val CrossOrigin.Companion.anonymous: CrossOrigin
+    get() = unsafeCast("anonymous")
+
+inline val CrossOrigin.Companion.useCredentials: CrossOrigin
+    get() = unsafeCast("use-credentials")
+
+inline val CrossOrigin.Companion.none: CrossOrigin
+    get() = unsafeCast("")

--- a/kotlin-web/src/commonMain/generated/web/http/FetchPriority.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/FetchPriority.kt
@@ -6,17 +6,17 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface FetchPriority {
-    companion object {
-        @JsValue("auto")
-        val auto: FetchPriority
-
-        @JsValue("high")
-        val high: FetchPriority
-
-        @JsValue("low")
-        val low: FetchPriority
-    }
+    companion object
 }
+
+inline val FetchPriority.Companion.auto: FetchPriority
+    get() = unsafeCast("auto")
+
+inline val FetchPriority.Companion.high: FetchPriority
+    get() = unsafeCast("high")
+
+inline val FetchPriority.Companion.low: FetchPriority
+    get() = unsafeCast("low")

--- a/kotlin-web/src/commonMain/generated/web/http/ReferrerPolicy.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/ReferrerPolicy.kt
@@ -6,35 +6,35 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ReferrerPolicy {
-    companion object {
-        @JsValue("")
-        val none: ReferrerPolicy
-
-        @JsValue("no-referrer")
-        val noReferrer: ReferrerPolicy
-
-        @JsValue("no-referrer-when-downgrade")
-        val noReferrerWhenDowngrade: ReferrerPolicy
-
-        @JsValue("origin")
-        val origin: ReferrerPolicy
-
-        @JsValue("origin-when-cross-origin")
-        val originWhenCrossOrigin: ReferrerPolicy
-
-        @JsValue("same-origin")
-        val sameOrigin: ReferrerPolicy
-
-        @JsValue("strict-origin")
-        val strictOrigin: ReferrerPolicy
-
-        @JsValue("strict-origin-when-cross-origin")
-        val strictOriginWhenCrossOrigin: ReferrerPolicy
-
-        @JsValue("unsafe-url")
-        val unsafeUrl: ReferrerPolicy
-    }
+    companion object
 }
+
+inline val ReferrerPolicy.Companion.none: ReferrerPolicy
+    get() = unsafeCast("")
+
+inline val ReferrerPolicy.Companion.noReferrer: ReferrerPolicy
+    get() = unsafeCast("no-referrer")
+
+inline val ReferrerPolicy.Companion.noReferrerWhenDowngrade: ReferrerPolicy
+    get() = unsafeCast("no-referrer-when-downgrade")
+
+inline val ReferrerPolicy.Companion.origin: ReferrerPolicy
+    get() = unsafeCast("origin")
+
+inline val ReferrerPolicy.Companion.originWhenCrossOrigin: ReferrerPolicy
+    get() = unsafeCast("origin-when-cross-origin")
+
+inline val ReferrerPolicy.Companion.sameOrigin: ReferrerPolicy
+    get() = unsafeCast("same-origin")
+
+inline val ReferrerPolicy.Companion.strictOrigin: ReferrerPolicy
+    get() = unsafeCast("strict-origin")
+
+inline val ReferrerPolicy.Companion.strictOriginWhenCrossOrigin: ReferrerPolicy
+    get() = unsafeCast("strict-origin-when-cross-origin")
+
+inline val ReferrerPolicy.Companion.unsafeUrl: ReferrerPolicy
+    get() = unsafeCast("unsafe-url")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestCache.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestCache.kt
@@ -6,26 +6,26 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestCache {
-    companion object {
-        @JsValue("default")
-        val default: RequestCache
-
-        @JsValue("force-cache")
-        val forceCache: RequestCache
-
-        @JsValue("no-cache")
-        val noCache: RequestCache
-
-        @JsValue("no-store")
-        val noStore: RequestCache
-
-        @JsValue("only-if-cached")
-        val onlyIfCached: RequestCache
-
-        @JsValue("reload")
-        val reload: RequestCache
-    }
+    companion object
 }
+
+inline val RequestCache.Companion.default: RequestCache
+    get() = unsafeCast("default")
+
+inline val RequestCache.Companion.forceCache: RequestCache
+    get() = unsafeCast("force-cache")
+
+inline val RequestCache.Companion.noCache: RequestCache
+    get() = unsafeCast("no-cache")
+
+inline val RequestCache.Companion.noStore: RequestCache
+    get() = unsafeCast("no-store")
+
+inline val RequestCache.Companion.onlyIfCached: RequestCache
+    get() = unsafeCast("only-if-cached")
+
+inline val RequestCache.Companion.reload: RequestCache
+    get() = unsafeCast("reload")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestCredentials.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestCredentials.kt
@@ -6,17 +6,17 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestCredentials {
-    companion object {
-        @JsValue("include")
-        val include: RequestCredentials
-
-        @JsValue("omit")
-        val omit: RequestCredentials
-
-        @JsValue("same-origin")
-        val sameOrigin: RequestCredentials
-    }
+    companion object
 }
+
+inline val RequestCredentials.Companion.include: RequestCredentials
+    get() = unsafeCast("include")
+
+inline val RequestCredentials.Companion.omit: RequestCredentials
+    get() = unsafeCast("omit")
+
+inline val RequestCredentials.Companion.sameOrigin: RequestCredentials
+    get() = unsafeCast("same-origin")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestDestination.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestDestination.kt
@@ -6,68 +6,68 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestDestination {
-    companion object {
-        @JsValue("")
-        val none: RequestDestination
-
-        @JsValue("audio")
-        val audio: RequestDestination
-
-        @JsValue("audioworklet")
-        val audioworklet: RequestDestination
-
-        @JsValue("document")
-        val document: RequestDestination
-
-        @JsValue("embed")
-        val embed: RequestDestination
-
-        @JsValue("font")
-        val font: RequestDestination
-
-        @JsValue("frame")
-        val frame: RequestDestination
-
-        @JsValue("iframe")
-        val iframe: RequestDestination
-
-        @JsValue("image")
-        val image: RequestDestination
-
-        @JsValue("manifest")
-        val manifest: RequestDestination
-
-        @JsValue("object")
-        val `object`: RequestDestination
-
-        @JsValue("paintworklet")
-        val paintworklet: RequestDestination
-
-        @JsValue("report")
-        val report: RequestDestination
-
-        @JsValue("script")
-        val script: RequestDestination
-
-        @JsValue("sharedworker")
-        val sharedworker: RequestDestination
-
-        @JsValue("style")
-        val style: RequestDestination
-
-        @JsValue("track")
-        val track: RequestDestination
-
-        @JsValue("video")
-        val video: RequestDestination
-
-        @JsValue("worker")
-        val worker: RequestDestination
-
-        @JsValue("xslt")
-        val xslt: RequestDestination
-    }
+    companion object
 }
+
+inline val RequestDestination.Companion.none: RequestDestination
+    get() = unsafeCast("")
+
+inline val RequestDestination.Companion.audio: RequestDestination
+    get() = unsafeCast("audio")
+
+inline val RequestDestination.Companion.audioworklet: RequestDestination
+    get() = unsafeCast("audioworklet")
+
+inline val RequestDestination.Companion.document: RequestDestination
+    get() = unsafeCast("document")
+
+inline val RequestDestination.Companion.embed: RequestDestination
+    get() = unsafeCast("embed")
+
+inline val RequestDestination.Companion.font: RequestDestination
+    get() = unsafeCast("font")
+
+inline val RequestDestination.Companion.frame: RequestDestination
+    get() = unsafeCast("frame")
+
+inline val RequestDestination.Companion.iframe: RequestDestination
+    get() = unsafeCast("iframe")
+
+inline val RequestDestination.Companion.image: RequestDestination
+    get() = unsafeCast("image")
+
+inline val RequestDestination.Companion.manifest: RequestDestination
+    get() = unsafeCast("manifest")
+
+inline val RequestDestination.Companion.`object`: RequestDestination
+    get() = unsafeCast("object")
+
+inline val RequestDestination.Companion.paintworklet: RequestDestination
+    get() = unsafeCast("paintworklet")
+
+inline val RequestDestination.Companion.report: RequestDestination
+    get() = unsafeCast("report")
+
+inline val RequestDestination.Companion.script: RequestDestination
+    get() = unsafeCast("script")
+
+inline val RequestDestination.Companion.sharedworker: RequestDestination
+    get() = unsafeCast("sharedworker")
+
+inline val RequestDestination.Companion.style: RequestDestination
+    get() = unsafeCast("style")
+
+inline val RequestDestination.Companion.track: RequestDestination
+    get() = unsafeCast("track")
+
+inline val RequestDestination.Companion.video: RequestDestination
+    get() = unsafeCast("video")
+
+inline val RequestDestination.Companion.worker: RequestDestination
+    get() = unsafeCast("worker")
+
+inline val RequestDestination.Companion.xslt: RequestDestination
+    get() = unsafeCast("xslt")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestMethod.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestMethod.kt
@@ -6,29 +6,29 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestMethod {
-    companion object {
-        @JsValue("DELETE")
-        val DELETE: RequestMethod
-
-        @JsValue("GET")
-        val GET: RequestMethod
-
-        @JsValue("HEAD")
-        val HEAD: RequestMethod
-
-        @JsValue("OPTIONS")
-        val OPTIONS: RequestMethod
-
-        @JsValue("PATCH")
-        val PATCH: RequestMethod
-
-        @JsValue("POST")
-        val POST: RequestMethod
-
-        @JsValue("PUT")
-        val PUT: RequestMethod
-    }
+    companion object
 }
+
+inline val RequestMethod.Companion.DELETE: RequestMethod
+    get() = unsafeCast("DELETE")
+
+inline val RequestMethod.Companion.GET: RequestMethod
+    get() = unsafeCast("GET")
+
+inline val RequestMethod.Companion.HEAD: RequestMethod
+    get() = unsafeCast("HEAD")
+
+inline val RequestMethod.Companion.OPTIONS: RequestMethod
+    get() = unsafeCast("OPTIONS")
+
+inline val RequestMethod.Companion.PATCH: RequestMethod
+    get() = unsafeCast("PATCH")
+
+inline val RequestMethod.Companion.POST: RequestMethod
+    get() = unsafeCast("POST")
+
+inline val RequestMethod.Companion.PUT: RequestMethod
+    get() = unsafeCast("PUT")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestMode.kt
@@ -6,20 +6,20 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestMode {
-    companion object {
-        @JsValue("cors")
-        val cors: RequestMode
-
-        @JsValue("navigate")
-        val navigate: RequestMode
-
-        @JsValue("no-cors")
-        val noCors: RequestMode
-
-        @JsValue("same-origin")
-        val sameOrigin: RequestMode
-    }
+    companion object
 }
+
+inline val RequestMode.Companion.cors: RequestMode
+    get() = unsafeCast("cors")
+
+inline val RequestMode.Companion.navigate: RequestMode
+    get() = unsafeCast("navigate")
+
+inline val RequestMode.Companion.noCors: RequestMode
+    get() = unsafeCast("no-cors")
+
+inline val RequestMode.Companion.sameOrigin: RequestMode
+    get() = unsafeCast("same-origin")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestPriority.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestPriority.kt
@@ -6,17 +6,17 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestPriority {
-    companion object {
-        @JsValue("auto")
-        val auto: RequestPriority
-
-        @JsValue("high")
-        val high: RequestPriority
-
-        @JsValue("low")
-        val low: RequestPriority
-    }
+    companion object
 }
+
+inline val RequestPriority.Companion.auto: RequestPriority
+    get() = unsafeCast("auto")
+
+inline val RequestPriority.Companion.high: RequestPriority
+    get() = unsafeCast("high")
+
+inline val RequestPriority.Companion.low: RequestPriority
+    get() = unsafeCast("low")

--- a/kotlin-web/src/commonMain/generated/web/http/RequestRedirect.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/RequestRedirect.kt
@@ -6,17 +6,17 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface RequestRedirect {
-    companion object {
-        @JsValue("error")
-        val error: RequestRedirect
-
-        @JsValue("follow")
-        val follow: RequestRedirect
-
-        @JsValue("manual")
-        val manual: RequestRedirect
-    }
+    companion object
 }
+
+inline val RequestRedirect.Companion.error: RequestRedirect
+    get() = unsafeCast("error")
+
+inline val RequestRedirect.Companion.follow: RequestRedirect
+    get() = unsafeCast("follow")
+
+inline val RequestRedirect.Companion.manual: RequestRedirect
+    get() = unsafeCast("manual")

--- a/kotlin-web/src/commonMain/generated/web/http/ResponseType.kt
+++ b/kotlin-web/src/commonMain/generated/web/http/ResponseType.kt
@@ -6,26 +6,26 @@
 
 package web.http
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ResponseType {
-    companion object {
-        @JsValue("basic")
-        val basic: ResponseType
-
-        @JsValue("cors")
-        val cors: ResponseType
-
-        @JsValue("default")
-        val default: ResponseType
-
-        @JsValue("error")
-        val error: ResponseType
-
-        @JsValue("opaque")
-        val opaque: ResponseType
-
-        @JsValue("opaqueredirect")
-        val opaqueredirect: ResponseType
-    }
+    companion object
 }
+
+inline val ResponseType.Companion.basic: ResponseType
+    get() = unsafeCast("basic")
+
+inline val ResponseType.Companion.cors: ResponseType
+    get() = unsafeCast("cors")
+
+inline val ResponseType.Companion.default: ResponseType
+    get() = unsafeCast("default")
+
+inline val ResponseType.Companion.error: ResponseType
+    get() = unsafeCast("error")
+
+inline val ResponseType.Companion.opaque: ResponseType
+    get() = unsafeCast("opaque")
+
+inline val ResponseType.Companion.opaqueredirect: ResponseType
+    get() = unsafeCast("opaqueredirect")

--- a/kotlin-web/src/commonMain/generated/web/images/ColorSpaceConversion.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/ColorSpaceConversion.kt
@@ -6,14 +6,14 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ColorSpaceConversion {
-    companion object {
-        @JsValue("default")
-        val default: ColorSpaceConversion
-
-        @JsValue("none")
-        val none: ColorSpaceConversion
-    }
+    companion object
 }
+
+inline val ColorSpaceConversion.Companion.default: ColorSpaceConversion
+    get() = unsafeCast("default")
+
+inline val ColorSpaceConversion.Companion.none: ColorSpaceConversion
+    get() = unsafeCast("none")

--- a/kotlin-web/src/commonMain/generated/web/images/ImageOrientation.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/ImageOrientation.kt
@@ -6,17 +6,17 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ImageOrientation {
-    companion object {
-        @JsValue("flipY")
-        val flipY: ImageOrientation
-
-        @JsValue("from-image")
-        val fromImage: ImageOrientation
-
-        @JsValue("none")
-        val none: ImageOrientation
-    }
+    companion object
 }
+
+inline val ImageOrientation.Companion.flipY: ImageOrientation
+    get() = unsafeCast("flipY")
+
+inline val ImageOrientation.Companion.fromImage: ImageOrientation
+    get() = unsafeCast("from-image")
+
+inline val ImageOrientation.Companion.none: ImageOrientation
+    get() = unsafeCast("none")

--- a/kotlin-web/src/commonMain/generated/web/images/PredefinedColorSpace.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/PredefinedColorSpace.kt
@@ -6,14 +6,14 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PredefinedColorSpace {
-    companion object {
-        @JsValue("display-p3")
-        val displayP3: PredefinedColorSpace
-
-        @JsValue("srgb")
-        val srgb: PredefinedColorSpace
-    }
+    companion object
 }
+
+inline val PredefinedColorSpace.Companion.displayP3: PredefinedColorSpace
+    get() = unsafeCast("display-p3")
+
+inline val PredefinedColorSpace.Companion.srgb: PredefinedColorSpace
+    get() = unsafeCast("srgb")

--- a/kotlin-web/src/commonMain/generated/web/images/PremultiplyAlpha.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/PremultiplyAlpha.kt
@@ -6,17 +6,17 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface PremultiplyAlpha {
-    companion object {
-        @JsValue("default")
-        val default: PremultiplyAlpha
-
-        @JsValue("none")
-        val none: PremultiplyAlpha
-
-        @JsValue("premultiply")
-        val premultiply: PremultiplyAlpha
-    }
+    companion object
 }
+
+inline val PremultiplyAlpha.Companion.default: PremultiplyAlpha
+    get() = unsafeCast("default")
+
+inline val PremultiplyAlpha.Companion.none: PremultiplyAlpha
+    get() = unsafeCast("none")
+
+inline val PremultiplyAlpha.Companion.premultiply: PremultiplyAlpha
+    get() = unsafeCast("premultiply")

--- a/kotlin-web/src/commonMain/generated/web/images/ResizeQuality.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/ResizeQuality.kt
@@ -6,20 +6,20 @@
 
 package web.images
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ResizeQuality {
-    companion object {
-        @JsValue("high")
-        val high: ResizeQuality
-
-        @JsValue("low")
-        val low: ResizeQuality
-
-        @JsValue("medium")
-        val medium: ResizeQuality
-
-        @JsValue("pixelated")
-        val pixelated: ResizeQuality
-    }
+    companion object
 }
+
+inline val ResizeQuality.Companion.high: ResizeQuality
+    get() = unsafeCast("high")
+
+inline val ResizeQuality.Companion.low: ResizeQuality
+    get() = unsafeCast("low")
+
+inline val ResizeQuality.Companion.medium: ResizeQuality
+    get() = unsafeCast("medium")
+
+inline val ResizeQuality.Companion.pixelated: ResizeQuality
+    get() = unsafeCast("pixelated")

--- a/kotlin-web/src/commonMain/generated/web/performance/NavigationTimingType.kt
+++ b/kotlin-web/src/commonMain/generated/web/performance/NavigationTimingType.kt
@@ -6,20 +6,20 @@
 
 package web.performance
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface NavigationTimingType {
-    companion object {
-        @JsValue("back_forward")
-        val back_forward: NavigationTimingType
-
-        @JsValue("navigate")
-        val navigate: NavigationTimingType
-
-        @JsValue("prerender")
-        val prerender: NavigationTimingType
-
-        @JsValue("reload")
-        val reload: NavigationTimingType
-    }
+    companion object
 }
+
+inline val NavigationTimingType.Companion.back_forward: NavigationTimingType
+    get() = unsafeCast("back_forward")
+
+inline val NavigationTimingType.Companion.navigate: NavigationTimingType
+    get() = unsafeCast("navigate")
+
+inline val NavigationTimingType.Companion.prerender: NavigationTimingType
+    get() = unsafeCast("prerender")
+
+inline val NavigationTimingType.Companion.reload: NavigationTimingType
+    get() = unsafeCast("reload")

--- a/kotlin-web/src/commonMain/generated/web/sockets/BinaryType.kt
+++ b/kotlin-web/src/commonMain/generated/web/sockets/BinaryType.kt
@@ -6,14 +6,14 @@
 
 package web.sockets
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface BinaryType {
-    companion object {
-        @JsValue("arraybuffer")
-        val arraybuffer: BinaryType
-
-        @JsValue("blob")
-        val blob: BinaryType
-    }
+    companion object
 }
+
+inline val BinaryType.Companion.arraybuffer: BinaryType
+    get() = unsafeCast("arraybuffer")
+
+inline val BinaryType.Companion.blob: BinaryType
+    get() = unsafeCast("blob")

--- a/kotlin-web/src/commonMain/generated/web/streams/ReadableStreamReaderMode.kt
+++ b/kotlin-web/src/commonMain/generated/web/streams/ReadableStreamReaderMode.kt
@@ -6,11 +6,11 @@
 
 package web.streams
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ReadableStreamReaderMode {
-    companion object {
-        @JsValue("byob")
-        val byob: ReadableStreamReaderMode
-    }
+    companion object
 }
+
+inline val ReadableStreamReaderMode.Companion.byob: ReadableStreamReaderMode
+    get() = unsafeCast("byob")

--- a/kotlin-web/src/commonMain/generated/web/streams/ReadableStreamType.kt
+++ b/kotlin-web/src/commonMain/generated/web/streams/ReadableStreamType.kt
@@ -6,11 +6,11 @@
 
 package web.streams
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
 sealed external interface ReadableStreamType {
-    companion object {
-        @JsValue("bytes")
-        val bytes: ReadableStreamType
-    }
+    companion object
 }
+
+inline val ReadableStreamType.Companion.bytes: ReadableStreamType
+    get() = unsafeCast("bytes")

--- a/kotlin-web/src/jsTest/kotlin/js/intl/DateStyleTest.kt
+++ b/kotlin-web/src/jsTest/kotlin/js/intl/DateStyleTest.kt
@@ -1,6 +1,5 @@
 package js.intl
 
-import js.intl.DateStyle.Companion.full
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,6 +11,6 @@ class DateStyleTest {
 
     @Test
     fun staticImport() {
-        assertEquals<Any>("full", full)
+        assertEquals<Any>("full", DateStyle.full)
     }
 }


### PR DESCRIPTION
Wasm-compatible unions conversion for `js`, `web` and `browser` modules ([https://github.com/JetBrains/kotlin-wrappers/issues/2449](https://github.com/JetBrains/kotlin-wrappers/issues/2449)).