### PR TITLE
Web. Remove `@JsValue` from `Ed25519` (#2449)

### DIFF
--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Ed25519.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Ed25519.kt
@@ -3,8 +3,10 @@ package karakum.browser
 internal const val ED25519 = "Ed25519"
 
 private val ED25519_BODY: String = """
-@JsValue("$ED25519")
-external object $ED25519
+sealed external interface ${ED25519}Algorithm
+
+inline val ${ED25519}: ${ED25519}Algorithm
+    get() = unsafeCast("$ED25519")
 """.trimIndent()
 
 internal fun Ed25519(): ConversionResult =

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Patches.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Patches.kt
@@ -101,7 +101,7 @@ internal fun String.applyPatches(): String {
             "// abort(reason?: any): AbortSignal; - To be re-added in the future",
             "abort(reason?: any): AbortSignal;",
         )
-        .replace(""""Ed25519" | { name: "Ed25519" }""", ED25519)
+        .replace(""""Ed25519" | { name: "Ed25519" }""", "${ED25519}Algorithm")
         .replace("    reason?: any;", "    reason?: JsError | undefined;")
         .replace("readonly reason: any;", "readonly reason: JsError | undefined;")
         .replace("(reason?: any)", "(reason?: JsError | undefined)")

--- a/kotlin-web/src/commonMain/generated/web/crypto/Ed25519.kt
+++ b/kotlin-web/src/commonMain/generated/web/crypto/Ed25519.kt
@@ -2,7 +2,9 @@
 
 package web.crypto
 
-import seskar.js.JsValue
+import js.reflect.unsafeCast
 
-@JsValue("Ed25519")
-external object Ed25519
+sealed external interface Ed25519Algorithm
+
+inline val Ed25519: Ed25519Algorithm
+    get() = unsafeCast("Ed25519")

--- a/kotlin-web/src/commonMain/generated/web/crypto/SubtleCrypto.kt
+++ b/kotlin-web/src/commonMain/generated/web/crypto/SubtleCrypto.kt
@@ -897,14 +897,14 @@ private constructor() {
     @JsAsync
     @Suppress("WRONG_EXTERNAL_DECLARATION")
     suspend fun generateKey(
-        algorithm: Ed25519,
+        algorithm: Ed25519Algorithm,
         extractable: Boolean,
         keyUsages: ReadonlyArray<KeyUsage /* "sign" | "verify" */>,
     ): CryptoKeyPair
 
     @JsName("generateKey")
     fun generateKeyAsync(
-        algorithm: Ed25519,
+        algorithm: Ed25519Algorithm,
         extractable: Boolean,
         keyUsages: ReadonlyArray<KeyUsage /* "sign" | "verify" */>,
     ): Promise<CryptoKeyPair>


### PR DESCRIPTION
Remove the remaining JsValue annotations from `browser` and `web` packages. [https://github.com/JetBrains/kotlin-wrappers/issues/2449](https://github.com/JetBrains/kotlin-wrappers/issues/2449)