### PR TITLE
Web. Remove callbacks from `BaseAudioContext.decodeAudioData`

### DIFF
--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/FunctionTypes.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/FunctionTypes.kt
@@ -64,9 +64,6 @@ private fun convertFunctionType(
 
         name == "RemotePlaybackAvailabilityCallback" -> "web.remoteplayback"
 
-        name == "DecodeSuccessCallback" -> "web.audio"
-        name == "DecodeErrorCallback" -> "web.audio"
-
         name == "ErrorCallback" -> "web.fs"
         name == "FileCallback" -> "web.fs"
         name.startsWith("FileSystem") -> "web.fs"

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
@@ -293,8 +293,6 @@ private val WEB_AUDIO_TYPES = listOf(
     "StereoPannerOptions",
     "WaveShaperOptions",
     "PeriodicWaveConstraints",
-    "DecodeSuccessCallback",
-    "DecodeErrorCallback",
     "BiquadFilterOptions",
     "ChannelMergerOptions",
     "ChannelSplitterOptions",

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Patches.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Patches.kt
@@ -174,6 +174,7 @@ internal fun String.applyPatches(): String {
         .splitUnion("number | KeyframeAnimationOptions")
         .splitUnion("number | KeyframeEffectOptions")
         .patchDomGeometry()
+        .patchDecodeAudioData()
         .replace(GET_CONTEXT_REGEX, "")
         .replace("quality?: any", "quality?: number")
         .replace("clearWatch(watchId: number)", "clearWatch(watchId: $GEOLOCATION_WATCH_ID)")
@@ -427,6 +428,14 @@ private fun String.patchQuerySelectors(): String =
             "\"$MATHML_NAMESPACE\"",
             "MATHML_NAMESPACE"
         )
+
+private fun String.patchDecodeAudioData(): String =
+    patchInterface("BaseAudioContext") {
+        it.replace(
+            "decodeAudioData(audioData: ArrayBuffer, successCallback?: DecodeSuccessCallback | null, errorCallback?: DecodeErrorCallback | null): Promise<AudioBuffer>;",
+            "decodeAudioData(audioData: ArrayBuffer): Promise<AudioBuffer>;"
+        )
+    }
 
 private fun String.applyInlineUnionPatches(): String =
     UNION_DATA_LIST.fold(this) { acc, data ->

--- a/kotlin-browser/src/commonMain/generated/web/audio/BaseAudioContext.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/BaseAudioContext.kt
@@ -214,18 +214,10 @@ private constructor() :
      */
     @JsAsync
     @Suppress("WRONG_EXTERNAL_DECLARATION")
-    suspend fun decodeAudioData(
-        audioData: ArrayBuffer,
-        successCallback: DecodeSuccessCallback? = definedExternally,
-        errorCallback: DecodeErrorCallback? = definedExternally,
-    ): AudioBuffer
+    suspend fun decodeAudioData(audioData: ArrayBuffer): AudioBuffer
 
     @JsName("decodeAudioData")
-    fun decodeAudioDataAsync(
-        audioData: ArrayBuffer,
-        successCallback: DecodeSuccessCallback? = definedExternally,
-        errorCallback: DecodeErrorCallback? = definedExternally,
-    ): Promise<AudioBuffer>
+    fun decodeAudioDataAsync(audioData: ArrayBuffer): Promise<AudioBuffer>
 }
 
 /**

--- a/kotlin-browser/src/commonMain/generated/web/audio/DecodeErrorCallback.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/DecodeErrorCallback.kt
@@ -1,9 +1,0 @@
-// Automatically generated - do not modify!
-
-package web.audio
-
-import web.errors.DOMException
-
-typealias DecodeErrorCallback = (
-    error: DOMException,
-) -> Unit

--- a/kotlin-browser/src/commonMain/generated/web/audio/DecodeSuccessCallback.kt
+++ b/kotlin-browser/src/commonMain/generated/web/audio/DecodeSuccessCallback.kt
@@ -1,7 +1,0 @@
-// Automatically generated - do not modify!
-
-package web.audio
-
-typealias DecodeSuccessCallback = (
-    decodedData: AudioBuffer,
-) -> Unit


### PR DESCRIPTION
Web. Remove callbacks from `BaseAudioContext.decodeAudioData`. `DecodeSuccessCallback` and `DecodeErrorCallback` were also removed as they are no longer used.