### PR TITLE
Web. Remove remaining `@JsAsync` from the `web` module (#2449).

### DIFF
--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/BrowserExtensionsCollector.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/BrowserExtensionsCollector.kt
@@ -2,8 +2,8 @@ package karakum.browser
 
 import karakum.common.SuspendExtensionsCollector
 
-internal class BrowserSuspendExtensionsCollector(
-    parentName: String,
+internal class BrowserSuspendExtensionsCollector private constructor(
+    parentName: String?,
     parentTypeParameters: String?,
 ) : SuspendExtensionsCollector(parentName, parentTypeParameters) {
 
@@ -17,6 +17,22 @@ internal class BrowserSuspendExtensionsCollector(
 
             "Clients" -> extensions.replace("matchAllAsync()", "matchAllAsync<T>()")
             else -> extensions
+        }
+    }
+
+    companion object {
+        /**
+         * Returned collector will generate suspend extensions to the `parentName`.
+         */
+        fun forParent(parentName: String, parentTypeParameters: String?): BrowserSuspendExtensionsCollector {
+            return BrowserSuspendExtensionsCollector(parentName, parentTypeParameters)
+        }
+
+        /**
+         * Returned collector will generate regular suspend functions.
+         */
+        fun forGlobal(): BrowserSuspendExtensionsCollector {
+            return BrowserSuspendExtensionsCollector(null, null)
         }
     }
 }

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Events.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Events.kt
@@ -166,7 +166,7 @@ private fun event(
             .substringAfter("{\n")
             .trimIndent()
 
-        val initExtensionsCollector = BrowserSuspendExtensionsCollector(name, null)
+        val initExtensionsCollector = BrowserSuspendExtensionsCollector.forParent(name, null)
         val members = if (membersSource.isNotEmpty()) {
             membersSource
                 .splitToSequence(";\n")
@@ -209,7 +209,7 @@ private fun event(
 
     val typeProvider = TypeProvider(name)
 
-    val eventExtensionsCollector = BrowserSuspendExtensionsCollector(name, eventParent)
+    val eventExtensionsCollector = BrowserSuspendExtensionsCollector.forParent(name, eventParent)
     val eventMembers = eventSource.substringAfter(" {\n")
         .trimIndent()
         .splitToSequence(";\n")
@@ -267,7 +267,7 @@ private fun event(
     val companionSource = eventClassBody
         .substringAfter("\n", "")
 
-    val companionExtensionsCollector = BrowserSuspendExtensionsCollector(name, null)
+    val companionExtensionsCollector = BrowserSuspendExtensionsCollector.forParent(name, null)
     val companionMembers = if (companionSource.isNotEmpty()) {
         companionSource
             .splitToSequence(";\n")

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/browser/Html.kt
@@ -1033,7 +1033,7 @@ internal fun convertInterface(
         declaration = declaration.replaceFirst("<$typeParameters>", "<$newTypeParameters>")
     }
 
-    val extensionsCollector = BrowserSuspendExtensionsCollector(name, newTypeParameters)
+    val extensionsCollector = BrowserSuspendExtensionsCollector.forParent(name, newTypeParameters)
 
     var members = if (memberSource.isNotEmpty()) {
         var result = memberSource
@@ -1381,7 +1381,7 @@ internal fun convertInterface(
         else -> "sealed"
     }
 
-    val companionExtensionsCollector = BrowserSuspendExtensionsCollector("$name.Companion", null)
+    val companionExtensionsCollector = BrowserSuspendExtensionsCollector.forParent("$name.Companion", null)
     val idDeclaration = RenderingContextRegistry.getIdDeclaration(name)
     val companion = if (staticSource != null) {
         val companionContent = getCompanion(name, staticSource, companionExtensionsCollector)

--- a/build-logic/generatorlegacybuild/src/main/kotlin/karakum/common/withSuspendExtensions.kt
+++ b/build-logic/generatorlegacybuild/src/main/kotlin/karakum/common/withSuspendExtensions.kt
@@ -29,7 +29,6 @@ internal fun withSuspendExtensions(
         functionSignature = functionSignature,
         parameters = parameters,
         returnType = suspendReturnType,
-        optionalPromise = optionality.isNotEmpty(),
         docs = comment
     )
 

--- a/kotlin-web/src/commonMain/generated/web/assembly/compile.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/compile.kt
@@ -7,19 +7,20 @@ package web.assembly
 import js.buffer.BufferSource
 import js.import.JsQualifier
 import js.promise.Promise
-import seskar.js.JsAsync
+import js.promise.await
 import kotlin.js.JsName
 
 /**
  * [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/compile_static)
  */
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun compile(
-    bytes: BufferSource,
-): Module
-
 @JsName("compile")
 external fun compileAsync(
     bytes: BufferSource,
 ): Promise<Module>
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun compile(
+    bytes: BufferSource,
+): Module {
+    return compileAsync(bytes = bytes).await()
+}

--- a/kotlin-web/src/commonMain/generated/web/assembly/compileStreaming.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/compileStreaming.kt
@@ -7,31 +7,33 @@ package web.assembly
 import js.import.JsQualifier
 import js.promise.Promise
 import js.promise.PromiseLike
-import seskar.js.JsAsync
+import js.promise.await
 import web.http.Response
 import kotlin.js.JsName
 
 /**
  * [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/compileStreaming_static)
  */
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun compileStreaming(
-    source: Response,
-): Module
-
 @JsName("compileStreaming")
 external fun compileStreamingAsync(
     source: Response,
 ): Promise<Module>
 
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun compileStreaming(
-    source: PromiseLike<Response>,
-): Module
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun compileStreaming(
+    source: Response,
+): Module {
+    return compileStreamingAsync(source = source).await()
+}
 
 @JsName("compileStreaming")
 external fun compileStreamingAsync(
     source: PromiseLike<Response>,
 ): Promise<Module>
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun compileStreaming(
+    source: PromiseLike<Response>,
+): Module {
+    return compileStreamingAsync(source = source).await()
+}

--- a/kotlin-web/src/commonMain/generated/web/assembly/instantiate.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/instantiate.kt
@@ -7,35 +7,57 @@ package web.assembly
 import js.buffer.BufferSource
 import js.import.JsQualifier
 import js.promise.Promise
-import seskar.js.JsAsync
+import js.promise.await
 import kotlin.js.JsName
 import kotlin.js.definedExternally
 
 /**
  * [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/instantiate_static)
  */
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun instantiate(
-    bytes: BufferSource,
-    importObject: Imports = definedExternally,
-): WebAssemblyInstantiatedSource
-
 @JsName("instantiate")
 external fun instantiateAsync(
     bytes: BufferSource,
     importObject: Imports = definedExternally,
 ): Promise<WebAssemblyInstantiatedSource>
 
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun instantiate(
-    moduleObject: Module,
-    importObject: Imports = definedExternally,
-): Instance
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiate(
+    bytes: BufferSource,
+    importObject: Imports,
+): WebAssemblyInstantiatedSource {
+    return instantiateAsync(
+        bytes = bytes,
+        importObject = importObject
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiate(
+    bytes: BufferSource,
+): WebAssemblyInstantiatedSource {
+    return instantiateAsync(bytes = bytes).await()
+}
 
 @JsName("instantiate")
 external fun instantiateAsync(
     moduleObject: Module,
     importObject: Imports = definedExternally,
 ): Promise<Instance>
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiate(
+    moduleObject: Module,
+    importObject: Imports,
+): Instance {
+    return instantiateAsync(
+        moduleObject = moduleObject,
+        importObject = importObject
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiate(
+    moduleObject: Module,
+): Instance {
+    return instantiateAsync(moduleObject = moduleObject).await()
+}

--- a/kotlin-web/src/commonMain/generated/web/assembly/instantiateStreaming.kt
+++ b/kotlin-web/src/commonMain/generated/web/assembly/instantiateStreaming.kt
@@ -7,7 +7,7 @@ package web.assembly
 import js.import.JsQualifier
 import js.promise.Promise
 import js.promise.PromiseLike
-import seskar.js.JsAsync
+import js.promise.await
 import web.http.Response
 import kotlin.js.JsName
 import kotlin.js.definedExternally
@@ -15,28 +15,50 @@ import kotlin.js.definedExternally
 /**
  * [MDN Reference](https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static)
  */
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun instantiateStreaming(
-    source: Response,
-    importObject: Imports = definedExternally,
-): WebAssemblyInstantiatedSource
-
 @JsName("instantiateStreaming")
 external fun instantiateStreamingAsync(
     source: Response,
     importObject: Imports = definedExternally,
 ): Promise<WebAssemblyInstantiatedSource>
 
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun instantiateStreaming(
-    source: PromiseLike<Response>,
-    importObject: Imports = definedExternally,
-): WebAssemblyInstantiatedSource
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiateStreaming(
+    source: Response,
+    importObject: Imports,
+): WebAssemblyInstantiatedSource {
+    return instantiateStreamingAsync(
+        source = source,
+        importObject = importObject
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiateStreaming(
+    source: Response,
+): WebAssemblyInstantiatedSource {
+    return instantiateStreamingAsync(source = source).await()
+}
 
 @JsName("instantiateStreaming")
 external fun instantiateStreamingAsync(
     source: PromiseLike<Response>,
     importObject: Imports = definedExternally,
 ): Promise<WebAssemblyInstantiatedSource>
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiateStreaming(
+    source: PromiseLike<Response>,
+    importObject: Imports,
+): WebAssemblyInstantiatedSource {
+    return instantiateStreamingAsync(
+        source = source,
+        importObject = importObject
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun instantiateStreaming(
+    source: PromiseLike<Response>,
+): WebAssemblyInstantiatedSource {
+    return instantiateStreamingAsync(source = source).await()
+}

--- a/kotlin-web/src/commonMain/generated/web/images/createImageBitmap.kt
+++ b/kotlin-web/src/commonMain/generated/web/images/createImageBitmap.kt
@@ -3,36 +3,36 @@
 package web.images
 
 import js.promise.Promise
-import seskar.js.JsAsync
+import js.promise.await
 import kotlin.js.JsName
 import kotlin.js.definedExternally
 
 /**
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/createImageBitmap)
  */
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun createImageBitmap(
-    image: ImageBitmapSource,
-    options: ImageBitmapOptions? = definedExternally,
-): ImageBitmap
-
 @JsName("createImageBitmap")
 external fun createImageBitmapAsync(
     image: ImageBitmapSource,
     options: ImageBitmapOptions? = definedExternally,
 ): Promise<ImageBitmap>
 
-@JsAsync
-@Suppress("WRONG_EXTERNAL_DECLARATION")
-external suspend fun createImageBitmap(
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun createImageBitmap(
     image: ImageBitmapSource,
-    sx: Int,
-    sy: Int,
-    sw: Int,
-    sh: Int,
-    options: ImageBitmapOptions? = definedExternally,
-): ImageBitmap
+    options: ImageBitmapOptions?,
+): ImageBitmap {
+    return createImageBitmapAsync(
+        image = image,
+        options = options
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun createImageBitmap(
+    image: ImageBitmapSource,
+): ImageBitmap {
+    return createImageBitmapAsync(image = image).await()
+}
 
 @JsName("createImageBitmap")
 external fun createImageBitmapAsync(
@@ -43,3 +43,39 @@ external fun createImageBitmapAsync(
     sh: Int,
     options: ImageBitmapOptions? = definedExternally,
 ): Promise<ImageBitmap>
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun createImageBitmap(
+    image: ImageBitmapSource,
+    sx: Int,
+    sy: Int,
+    sw: Int,
+    sh: Int,
+    options: ImageBitmapOptions?,
+): ImageBitmap {
+    return createImageBitmapAsync(
+        image = image,
+        sx = sx,
+        sy = sy,
+        sw = sw,
+        sh = sh,
+        options = options
+    ).await()
+}
+
+@Suppress("NON_EXTERNAL_DECLARATION_IN_INAPPROPRIATE_FILE")
+suspend inline fun createImageBitmap(
+    image: ImageBitmapSource,
+    sx: Int,
+    sy: Int,
+    sw: Int,
+    sh: Int,
+): ImageBitmap {
+    return createImageBitmapAsync(
+        image = image,
+        sx = sx,
+        sy = sy,
+        sw = sw,
+        sh = sh
+    ).await()
+}


### PR DESCRIPTION
There are no generated `@JsAsync` usages left in `js`, `web` and `browser` modules.