### PR TITLE
React: Add `useRefCallbackWithCleanup`

### DIFF
--- a/kotlin-react-core/src/jsMain/kotlin/react/RefCallback.kt
+++ b/kotlin-react-core/src/jsMain/kotlin/react/RefCallback.kt
@@ -2,6 +2,7 @@ package react
 
 import js.reflect.unsafeCast
 import kotlinx.coroutines.CoroutineScope
+import react.internal.buildCleanupCallback
 import react.internal.createCleanupCallback
 import react.raw.useCallbackRaw
 
@@ -21,3 +22,15 @@ fun <T : Any> useRefCallback(
     block: suspend CoroutineScope.(T) -> Unit,
 ): RefCallback<T> =
     useCallbackRaw(RefCallback(block), dependencies)
+
+fun <T : Any> useRefCallbackWithCleanup(
+    vararg dependencies: Any?,
+    block: CleanupBuilder.(T) -> Unit,
+): RefCallback<T> {
+    val callback = { value: T ->
+        val cleanupCallback = buildCleanupCallback { block(value) }
+        cleanupCallback()
+    }.unsafeCast<RefCallback<T>>()
+
+    return useCallbackRaw(callback, dependencies)
+}


### PR DESCRIPTION
Since React 19+ supports [cleanup functions for refs](https://react.dev/blog/2024/12/05/react-19#cleanup-functions-for-refs) it's nice to have `useRefCallbackWithCleanup` like we have `useEffectWithCleanup`.
