### PR TITLE
Add extension functions for converting maps, sequences, iterables into records

### DIFF
--- a/kotlin-js/src/webMain/kotlin/js/objects/Extensions.kt
+++ b/kotlin-js/src/webMain/kotlin/js/objects/Extensions.kt
@@ -1,0 +1,29 @@
+package js.objects
+
+import js.array.JsTuple2
+import js.array.toTypedArray
+import js.array.tupleOf
+
+fun <V> Iterable<Pair<String, V>>.toRecord(): ReadonlyRecord<String, V> =
+    Object.fromEntries(map { (key, value) -> tupleOf(key, value) }.toTypedArray())
+
+fun <V> Iterable<Pair<String, V>>.toMutableRecord(): Record<String, V> =
+    toRecord().unsafeCast<Record<String, V>>()
+
+fun <V> Sequence<JsTuple2<String, V>>.toRecord(): ReadonlyRecord<String, V> =
+    Object.fromEntries(toTypedArray())
+
+fun <V> Sequence<JsTuple2<String, V>>.toMutableRecord(): Record<String, V> =
+    toRecord().unsafeCast<Record<String, V>>()
+
+fun <V> Sequence<Pair<String, V>>.toRecord(): ReadonlyRecord<String, V> =
+    Object.fromEntries(map { (key, value) -> tupleOf(key, value) }.toTypedArray())
+
+fun <V> Sequence<Pair<String, V>>.toMutableRecord(): Record<String, V> =
+    toRecord().unsafeCast<Record<String, V>>()
+
+fun <V> Map<String, V>.toRecord(): ReadonlyRecord<String, V> =
+    Object.fromEntries(map { (key, value) -> tupleOf(key, value) }.toTypedArray())
+
+fun <V> Map<String, V>.toMutableRecord(): Record<String, V> =
+    toRecord().unsafeCast<Record<String, V>>()

--- a/kotlin-js/src/webTest/kotlin/js/objects/ExtensionsTest.kt
+++ b/kotlin-js/src/webTest/kotlin/js/objects/ExtensionsTest.kt
@@ -1,0 +1,61 @@
+package js.objects
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExtensionsTest {
+
+    @Test
+    fun pairSequenceToRecord() {
+        val expected = recordOf(
+            "one" to 1,
+            "two" to 2,
+        )
+        val actual = sequenceOf(
+            "one" to 1,
+            "two" to 2,
+        ).toMutableRecord()
+
+        assertEquals(JSON.stringify(expected), JSON.stringify(actual))
+    }
+
+    @Test
+    fun jsTupleSequenceToRecord() {
+        val expected = recordOf(
+            "one" to 1,
+            "two" to 2,
+        )
+        val actual = Object.entries(expected).asSequence()
+            .toMutableRecord()
+
+        assertEquals(JSON.stringify(expected), JSON.stringify(actual))
+    }
+
+    @Test
+    fun tupleIterableToRecord() {
+        val expected = recordOf(
+            "one" to 1,
+            "two" to 2,
+        )
+        val actual = Object.entries(expected)
+            .map { (first, second) -> first to second }
+            .toMutableRecord()
+
+        assertEquals(JSON.stringify(expected), JSON.stringify(actual))
+    }
+
+    @Test
+    fun mapToRecord() {
+        val expected = recordOf(
+            "one" to 1,
+            "two" to 2,
+        )
+        val actual = mapOf(
+            "one" to 1,
+            "two" to 2,
+        ).toMutableRecord()
+
+        assertEquals(JSON.stringify(expected), JSON.stringify(actual))
+    }
+
+}


### PR DESCRIPTION
I wasn't sure where to put those extension functions. If you can think of a better location let me know.

With regards to creating maps from iterables and sequences, there is no guarantee to that multiple keys aren't the same. Right now, the last value in the chain is being kept (as implemented in Object.fromEntries), but if you want to add a version with a [merge function](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#toMap-java.util.function.Function-java.util.function.Function-java.util.function.BinaryOperator-) let me know.

Lastly I'm unsure if we have a way to test for data equality with regards to Records, so I went with JSON.stringify which is common in JS

PS: looks like my master is out of date, will fix it