### PR TITLE
 JS. Add extension functions for converting maps, sequences, iterables into records

### DIFF
--- a/kotlin-js/src/webMain/kotlin/js/objects/ReadonlyRecord.kt
+++ b/kotlin-js/src/webMain/kotlin/js/objects/ReadonlyRecord.kt
@@ -24,23 +24,23 @@ inline operator fun <V : JsAny?> ReadonlyRecord<JsAny, V>.get(key: String): V? =
 inline operator fun <V : JsAny?> ReadonlyRecord<JsString, V>.get(key: String): V? =
     get(key.toJsString())
 
-fun <V : JsAny?> Sequence<Tuple2<JsString, V>>.toReadonlyRecord(): ReadonlyRecord<JsString, V> =
+fun <K: JsAny, V : JsAny?> Sequence<Tuple2<K, V>>.toReadonlyRecord(): ReadonlyRecord<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
-fun <V : JsAny?> Sequence<Pair<String, V>>.toReadonlyRecord(): ReadonlyRecord<JsString, V> =
+fun <K: JsAny, V : JsAny?> Sequence<Pair<K, V>>.toReadonlyRecord(): ReadonlyRecord<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
-fun <V : JsAny?> Iterable<Pair<String, V>>.toReadonlyRecord(): ReadonlyRecord<JsString, V> =
+fun <K: JsAny, V : JsAny?> Iterable<Pair<K, V>>.toReadonlyRecord(): ReadonlyRecord<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
 
-fun <V : JsAny?> Map<String, V>.toReadonlyRecord(): ReadonlyRecord<JsString, V> =
+fun <K: JsAny, V : JsAny?> Map<K, V>.toReadonlyRecord(): ReadonlyRecord<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }

--- a/kotlin-js/src/webMain/kotlin/js/objects/Record.kt
+++ b/kotlin-js/src/webMain/kotlin/js/objects/Record.kt
@@ -38,22 +38,22 @@ fun <K : JsAny, V : JsAny?> Record(
 ): Record<K, V> =
     unsafeJso(block)
 
-fun <V : JsAny> Sequence<Tuple2<JsString, V>>.toRecord(): Record<JsString, V> =
+fun <K: JsAny, V : JsAny?> Sequence<Tuple2<K, V>>.toRecord(): Record<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
-fun <V : JsAny> Sequence<Pair<String, V>>.toRecord(): Record<JsString, V> =
+fun <K: JsAny, V : JsAny?> Sequence<Pair<K, V>>.toRecord(): Record<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
-fun <V : JsAny> Iterable<Pair<String, V>>.toRecord(): Record<JsString, V> =
+fun <K: JsAny, V : JsAny?> Iterable<Pair<K, V>>.toRecord(): Record<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }
 
-fun <V : JsAny> Map<String, V>.toRecord(): Record<JsString, V> =
+fun <K: JsAny, V : JsAny?> Map<K, V>.toRecord(): Record<K, V> =
     Record {
         forEach { (key, value) -> set(key, value) }
     }


### PR DESCRIPTION
I wasn't sure where to put those extension functions. If you can think of a better location let me know.

With regards to creating maps from iterables and sequences, there is no guarantee to that multiple keys aren't the same. Right now, the last value in the chain is being kept (as implemented in Object.fromEntries), but if you want to add a version with a [merge function](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#toMap-java.util.function.Function-java.util.function.Function-java.util.function.BinaryOperator-) let me know.

Lastly I'm unsure if we have a way to test for data equality with regards to Records, so I went with JSON.stringify which is common in JS