### PR TITLE
feat: enhance test example to use dependency injection, useEffect, and scope.launch()

### DIFF
--- a/examples/tanstack-react-router-nodejs-test/README.md
+++ b/examples/tanstack-react-router-nodejs-test/README.md
@@ -33,6 +33,7 @@
       requires
       `mocha-support/append-jsdom-to-user-agent-name.js`
     - This workaround may not be needed if you use coroutine-test and micromanage your test coroutines.
+    - issue: https://github.com/Kotlin/kotlinx.coroutines/issues/4640
 
 ## Other considerations
 

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/App.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/App.kt
@@ -1,13 +1,32 @@
 package example
 
+import example.di.Di
+import example.di.DiConstants.SCOPE
+import example.di.DiConstants.TOPIC_SERVICE
+import example.di.DiContextProvider
+import kotlinx.coroutines.MainScope
 import react.FC
 import react.use.useConstant
 import tanstack.react.router.RouterProvider
 
+fun createProductionDi(): Di {
+    return object: Di {
+        val map = mapOf(
+            SCOPE to MainScope(),
+            TOPIC_SERVICE to TopicServiceImpl()
+        )
+
+        override fun get(key: String) = map[key]
+    }
+}
+
 val App = FC {
     val appRouter = useConstant(::createAppRouter)
 
-    RouterProvider {
-        router = appRouter
+    DiContextProvider {
+        di = createProductionDi()
+        RouterProvider {
+            router = appRouter
+        }
     }
 }

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/App.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/App.kt
@@ -1,24 +1,14 @@
 package example
 
 import example.di.Di
-import example.di.DiConstants.SCOPE
-import example.di.DiConstants.TOPIC_SERVICE
 import example.di.DiContextProvider
 import kotlinx.coroutines.MainScope
 import react.FC
 import react.use.useConstant
 import tanstack.react.router.RouterProvider
 
-fun createProductionDi(): Di {
-    return object: Di {
-        val map = mapOf(
-            SCOPE to MainScope(),
-            TOPIC_SERVICE to TopicServiceImpl()
-        )
-
-        override fun get(key: String) = map[key]
-    }
-}
+fun createProductionDi() = Di(scope = MainScope(),
+            topicService = TopicServiceImpl())
 
 val App = FC {
     val appRouter = useConstant(::createAppRouter)

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/TopicService.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/TopicService.kt
@@ -1,0 +1,18 @@
+package example
+
+import example.testsupport.TOPIC_LINK_COMPONENTS_ID
+import example.testsupport.TOPIC_LINK_PROPS_V_STATE_ID
+import web.dom.DataTestId
+
+data class TopicItem(val name: String, val path: String, val testId: DataTestId)
+
+interface TopicService {
+    suspend fun getTopics(): List<TopicItem>
+}
+
+class TopicServiceImpl : TopicService {
+    override suspend fun getTopics() = listOf(
+        TopicItem("Components", "components", TOPIC_LINK_COMPONENTS_ID),
+        TopicItem("Props v. State", "props-v-state", TOPIC_LINK_PROPS_V_STATE_ID)
+    )
+}

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/Topics.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/Topics.kt
@@ -1,17 +1,35 @@
 package example
 
+import example.di.Di
+import example.di.DiConstants.SCOPE
+import example.di.DiConstants.TOPIC_SERVICE
+import example.di.DiContext
 import example.testsupport.TOPICS_CONTAINER_ID
-import example.testsupport.TOPIC_LINK_COMPONENTS_ID
-import example.testsupport.TOPIC_LINK_PROPS_V_STATE_ID
 import js.objects.recordOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import react.FC
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h2
 import react.dom.html.ReactHTML.li
 import react.dom.html.ReactHTML.ul
+import react.use
+import react.useEffect
+import react.useState
 import tanstack.react.router.Link
 
 val Topics = FC {
+    val di: Di = use(DiContext)!!
+    val scope: CoroutineScope = di[SCOPE] as CoroutineScope
+    val topicService: TopicService = di[TOPIC_SERVICE] as TopicService
+    var topics by useState<List<TopicItem>?>(null)
+
+    useEffect {
+        scope.launch {
+            topics = topicService.getTopics()
+        }
+    }
+
     div {
         dataTestId = TOPICS_CONTAINER_ID
         h2 {
@@ -19,26 +37,17 @@ val Topics = FC {
         }
 
         ul {
-            li {
-                Link {
-                    dataTestId = TOPIC_LINK_COMPONENTS_ID
-                    to = TOPIC_PATH
-                    params = recordOf(
-                        TOPIC_ID_PARAM to "components",
-                    )
+            topics?.forEach { topicItem ->
+                li {
+                    Link {
+                        dataTestId = topicItem.testId
+                        to = TOPIC_PATH
+                        params = recordOf(
+                            TOPIC_ID_PARAM to topicItem.path,
+                        )
 
-                    +"Components"
-                }
-            }
-            li {
-                Link {
-                    dataTestId = TOPIC_LINK_PROPS_V_STATE_ID
-                    to = TOPIC_PATH
-                    params = recordOf(
-                        TOPIC_ID_PARAM to "props-v-state",
-                    )
-
-                    +"Props v. State"
+                        +topicItem.name
+                    }
                 }
             }
         }

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/Topics.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/Topics.kt
@@ -1,8 +1,6 @@
 package example
 
 import example.di.Di
-import example.di.DiConstants.SCOPE
-import example.di.DiConstants.TOPIC_SERVICE
 import example.di.DiContext
 import example.testsupport.TOPICS_CONTAINER_ID
 import js.objects.recordOf
@@ -20,8 +18,8 @@ import tanstack.react.router.Link
 
 val Topics = FC {
     val di: Di = use(DiContext)!!
-    val scope: CoroutineScope = di[SCOPE] as CoroutineScope
-    val topicService: TopicService = di[TOPIC_SERVICE] as TopicService
+    val scope: CoroutineScope = di.scope
+    val topicService: TopicService = di.topicService
     var topics by useState<List<TopicItem>?>(null)
 
     useEffect {

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/Di.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/Di.kt
@@ -1,0 +1,12 @@
+package example.di
+
+object DiConstants {
+    const val SCOPE = "CoroutineScope"
+    const val TOPIC_SERVICE = "TopicService"
+}
+
+// For demonstration purposes only
+// In a real project, use kodein or another dependency injection framework
+interface Di {
+    operator fun get(key: String): Any?
+}

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/Di.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/Di.kt
@@ -1,12 +1,8 @@
 package example.di
 
-object DiConstants {
-    const val SCOPE = "CoroutineScope"
-    const val TOPIC_SERVICE = "TopicService"
-}
+import example.TopicService
+import kotlinx.coroutines.CoroutineScope
 
 // For demonstration purposes only
 // In a real project, use kodein or another dependency injection framework
-interface Di {
-    operator fun get(key: String): Any?
-}
+data class Di(val scope: CoroutineScope, val topicService: TopicService)

--- a/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/DiContext.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsMain/kotlin/example/di/DiContext.kt
@@ -1,0 +1,18 @@
+package example.di
+
+import react.FC
+import react.PropsWithChildren
+import react.createContext
+
+val DiContext = createContext<Di>()
+
+external interface DiContextProviderProps : PropsWithChildren {
+    var di : Di
+}
+
+val DiContextProvider = FC<DiContextProviderProps> { props ->
+    DiContext.Provider {
+        value = props.di
+        +props.children
+    }
+}

--- a/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/TestApp.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/TestApp.kt
@@ -1,6 +1,9 @@
 package example
 
+import example.di.Di
+import example.di.DiContextProvider
 import react.FC
+import react.Props
 import react.use.useConstant
 import tanstack.history.CreateMemoryHistoryOpts
 import tanstack.history.createMemoryHistory
@@ -25,11 +28,18 @@ private fun createTestAppRouter(): Router {
     )
 }
 
-val TestApp = FC {
+external interface TestAppProps: Props {
+    var di: Di
+}
+
+val TestApp = FC<TestAppProps> { props ->
     val appRouter: Router = useConstant(::createTestAppRouter)
 
-    RouterProvider {
-        router = appRouter
+    DiContextProvider {
+        di = props.di
+        RouterProvider {
+            router = appRouter
+        }
     }
 }
 

--- a/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinesdefaultdispatcher/RouterTest.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinesdefaultdispatcher/RouterTest.kt
@@ -1,11 +1,16 @@
 package example.withcoroutinesdefaultdispatcher
 
 import example.TestApp
+import example.TopicServiceImpl
+import example.di.Di
+import example.di.DiConstants.SCOPE
+import example.di.DiConstants.TOPIC_SERVICE
 import example.testsupport.*
 import js.coroutines.promise
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import react.ReactNode
 import react.create
 import testing.library.dom.screen
 import testing.library.dom.within
@@ -14,7 +19,6 @@ import testing.library.react.render
 import testing.library.user.event.userEvent
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 // Run tests with the Default coroutine dispatcher
@@ -26,20 +30,37 @@ class RouterTestWithoutCoroutinesTestDependency {
             SupervisorJob() + Dispatchers.Default
     }
 
+    private fun createTestApp(testScope: CoroutineScope): ReactNode {
+        val testDI = object : Di {
+            override fun get(key: String) = when (key) {
+                SCOPE -> testScope
+                TOPIC_SERVICE -> TopicServiceImpl()
+                else -> throw Exception("Unknown Di key '$key'")
+            }
+        }
+
+        val testApp = TestApp.create {
+            di = testDI
+        }
+        return testApp
+    }
+
     @AfterTest
     fun afterTest() {
         cleanup()
     }
 
     private fun doTest() = JsTestScope.promise {
+        val testApp = createTestApp(JsTestScope)
+
         // given
         val user = userEvent.setup()
 
         // when
-        render(TestApp.create())
+        render(testApp)
 
         // then
-        val indexContainer = screen.findByTestId(INDEX_CONTAINER_ID)
+        screen.findByTestId(INDEX_CONTAINER_ID)
 
         val topicsLink = screen.queryByTestId(INDEX_LINK_TOPICS_ID)
         assertNotNull(topicsLink, "link to topics on index page")
@@ -56,7 +77,7 @@ class RouterTestWithoutCoroutinesTestDependency {
 
         user.click(componentTopicLink)
 
-        val topicContainer = screen.findByTestId(TOPIC_CONTAINER_ID)
+        screen.findByTestId(TOPIC_CONTAINER_ID)
     }
 
     @Test

--- a/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinesdefaultdispatcher/RouterTest.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinesdefaultdispatcher/RouterTest.kt
@@ -3,8 +3,6 @@ package example.withcoroutinesdefaultdispatcher
 import example.TestApp
 import example.TopicServiceImpl
 import example.di.Di
-import example.di.DiConstants.SCOPE
-import example.di.DiConstants.TOPIC_SERVICE
 import example.testsupport.*
 import js.coroutines.promise
 import kotlinx.coroutines.CoroutineScope
@@ -31,16 +29,8 @@ class RouterTestWithoutCoroutinesTestDependency {
     }
 
     private fun createTestApp(testScope: CoroutineScope): ReactNode {
-        val testDI = object : Di {
-            override fun get(key: String) = when (key) {
-                SCOPE -> testScope
-                TOPIC_SERVICE -> TopicServiceImpl()
-                else -> throw Exception("Unknown Di key '$key'")
-            }
-        }
-
         val testApp = TestApp.create {
-            di = testDI
+            di = Di(testScope, TopicServiceImpl())
         }
         return testApp
     }

--- a/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinestest/RouterTest.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinestest/RouterTest.kt
@@ -1,8 +1,15 @@
 package example.withcoroutinestest
 
 import example.TestApp
+import example.TopicServiceImpl
+import example.di.Di
+import example.di.DiConstants.SCOPE
+import example.di.DiConstants.TOPIC_SERVICE
 import example.testsupport.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import react.ReactNode
 import react.create
 import testing.library.dom.screen
 import testing.library.dom.within
@@ -11,24 +18,41 @@ import testing.library.react.render
 import testing.library.user.event.userEvent
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class RouterTest {
+    private fun createTestApp(testScope: CoroutineScope): ReactNode {
+        val testDI = object : Di {
+            override fun get(key: String) = when (key) {
+                SCOPE -> testScope
+                TOPIC_SERVICE -> TopicServiceImpl()
+                else -> throw Exception("Unknown Di key '$key'")
+            }
+        }
+
+        val testApp = TestApp.create {
+            di = testDI
+        }
+        return testApp
+    }
+
     @AfterTest
     fun afterTest() {
         cleanup()
     }
 
     private fun doTest() = runTest {
+        val testScope: TestScope = this
+        val testApp = createTestApp(testScope)
+
         // given
         val user = userEvent.setup()
 
         // when
-        render(TestApp.create())
+        render(testApp)
 
         // then
-        val indexContainer = screen.findByTestId(INDEX_CONTAINER_ID)
+        screen.findByTestId(INDEX_CONTAINER_ID)
 
         val topicsLink = screen.queryByTestId(INDEX_LINK_TOPICS_ID)
         assertNotNull(topicsLink, "link to topics on index page")
@@ -45,7 +69,7 @@ class RouterTest {
 
         user.click(componentTopicLink)
 
-        val topicContainer = screen.findByTestId(TOPIC_CONTAINER_ID)
+        screen.findByTestId(TOPIC_CONTAINER_ID)
     }
 
     @Test

--- a/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinestest/RouterTest.kt
+++ b/examples/tanstack-react-router-nodejs-test/src/jsTest/kotlin/example/withcoroutinestest/RouterTest.kt
@@ -3,8 +3,6 @@ package example.withcoroutinestest
 import example.TestApp
 import example.TopicServiceImpl
 import example.di.Di
-import example.di.DiConstants.SCOPE
-import example.di.DiConstants.TOPIC_SERVICE
 import example.testsupport.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestScope
@@ -22,16 +20,8 @@ import kotlin.test.assertNotNull
 
 class RouterTest {
     private fun createTestApp(testScope: CoroutineScope): ReactNode {
-        val testDI = object : Di {
-            override fun get(key: String) = when (key) {
-                SCOPE -> testScope
-                TOPIC_SERVICE -> TopicServiceImpl()
-                else -> throw Exception("Unknown Di key '$key'")
-            }
-        }
-
         val testApp = TestApp.create {
-            di = testDI
+            di = Di(testScope, TopicServiceImpl())
         }
         return testApp
     }


### PR DESCRIPTION
The current example React testing code is too minimal to reflect real-world usage patterns, which makes it harder to validate and demonstrate correct behavior in production-like scenarios.

Enhancing the examples to include:

- **Dependency Injection**  
  Allows components to receive services (API clients, stores, etc.) in a testable way. This avoids hidden globals and makes it possible to substitute mocks/fakes cleanly in tests.

- **`useEffect` usage**  
  Most non-trivial React components rely on side effects (data loading, subscriptions, initialization). Including `useEffect` ensures examples cover lifecycle behavior and async updates, which are often the source of bugs.

- **Avoiding `MainScope` usage in tests / using test-controlled coroutine scope**  
  Using `MainScope` (or other default, unmanaged scopes) inside components makes tests unreliable because:
  - the lifecycle is not tied to the test, so coroutines may outlive the test or leak
  - tests cannot easily control or advance coroutine execution (for the case of runTest)

Together, these changes make the examples:
- more representative of real applications  
- easier to test reliably  

This will significantly improve the usefulness of the examples as a reference for users building non-trivial applications.




_.... And it will also make it easier to provide a reproducible environment for the coroutines issue, but that's not enough justification by itself._