### PR TITLE
DO NOT MERGE: test proof code demonstrating Kotlin/JS ESM output is invalid: duplicate top-level set/get helpers emitted for csstype pseudo-builders

### DIFF
--- a/kotlin-js-proof/build.gradle.kts
+++ b/kotlin-js-proof/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("wrappersbuild.kotlin-library-conventions")
+}
+
+kotlin {
+    // useEsModules() is required to reproduce SyntaxError: Identifier 'set' has already been declared.
+    // Combined with kotlin.js.ir.output.granularity=per-file (gradle.properties), the IR backend
+    // emits duplicate top-level function set/function get helpers for each of the csstype builder
+    // types that inherit Record.set = definedExternally through multiple diamond interface paths.
+    js {
+        useEsModules()
+    }
+}
+
+dependencies {
+    webTestImplementation(projects.kotlinCsstype)
+    webTestImplementation(libs.kotlin.test)
+}
+
+// Explicit ESM syntax check — runs before jsNodeTest so a duplicate-helper regression surfaces
+// as a clear SyntaxError rather than a cryptic module-load crash from the test runner.
+val nodeCheckJsTestEsm by tasks.registering(Exec::class) {
+    group = "verification"
+    description = "Validates ESM syntax of proof .mjs to catch duplicate set/get helper regressions"
+    dependsOn("compileTestDevelopmentExecutableKotlinJs")
+    commandLine(
+        "node", "--check",
+        layout.buildDirectory
+            .file("compileSync/js/test/testDevelopmentExecutable/kotlin/${project.name}-test.mjs")
+            .get().asFile.absolutePath,
+    )
+}
+
+tasks.named("jsNodeTest").configure {
+    dependsOn(nodeCheckJsTestEsm)
+}

--- a/kotlin-js-proof/gradle.properties
+++ b/kotlin-js-proof/gradle.properties
@@ -1,0 +1,3 @@
+description=ESM duplicate set/get helper regression proof for kotlin-js (depends on kotlin-csstype)
+js.target=js
+js.platform=node

--- a/kotlin-js-proof/src/jsTest/kotlin/proof/CssTypeBuilderEsmProof.kt
+++ b/kotlin-js-proof/src/jsTest/kotlin/proof/CssTypeBuilderEsmProof.kt
@@ -1,0 +1,48 @@
+// Regression proof: KT-ESM-DUPLICATE-HELPERS
+//
+// PropertiesBuilder inherits Record<Selector, Any>.set = definedExternally through six
+// independent diamond-inheritance paths via: RuleBuilder, SimplePseudosRuleBuilder,
+// AdvancedPseudosRuleBuilder, NonStandardPseudosRuleBuilder, ExperimentalPseudosRuleBuilder,
+// and PseudosRuleBuilder. With useEsModules() + per-file IR granularity, the Kotlin/JS IR
+// backend emits a duplicate top-level `function set` helper for each path in the generated
+// .mjs, producing: SyntaxError: Identifier 'set' has already been declared.
+//
+// The node --check task in build.gradle.kts catches this before the test runner starts.
+// This @Test verifies round-trip set/get behavior at runtime.
+
+package proof
+
+import csstype.PropertiesBuilder
+import csstype.Rules
+import js.objects.unsafeJso
+import web.cssom.Selector
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class CssTypeBuilderEsmProof {
+
+    @Test
+    fun propertiesBuilderSetAndGetRoundTrip() {
+        // Instantiate PropertiesBuilder to force the IR backend to compile its full
+        // builder hierarchy. Before the fix, PropertiesBuilder.mjs has 6 duplicate
+        // top-level `function set` declarations and the ES module fails to load.
+        val styles = unsafeJso<PropertiesBuilder>()
+        val selector = Selector("--proof-prop")
+
+        styles[selector] = "proof-value"
+
+        assertNotNull(styles[selector])
+    }
+
+    @Test
+    fun rulesSetAndGetRoundTrip() {
+        // Rules = Record<Selector, Any>: the concrete type of each builder's map.
+        // Using it directly ensures Rules.mjs also compiles cleanly.
+        val rules = unsafeJso<Rules>()
+        val selector = Selector("--rules-prop")
+
+        rules[selector] = "rules-value"
+
+        assertNotNull(rules[selector])
+    }
+}

--- a/kotlin-js/build.gradle.kts
+++ b/kotlin-js/build.gradle.kts
@@ -4,6 +4,16 @@ plugins {
     id("wrappersbuild.kotlin-library-conventions")
 }
 
+kotlin {
+    // ESM output is required to reproduce SyntaxError: Identifier 'set'/'get' has already been declared.
+    // Combined with kotlin.js.ir.output.granularity=per-file (gradle.properties), multiple concrete
+    // implementors of external interfaces with `= definedExternally` operator bodies cause the IR backend
+    // to emit duplicate top-level function helpers in the generated .mjs.
+    js {
+        useEsModules()
+    }
+}
+
 dependencies {
     webMainApi(projects.kotlinJsCore)
 

--- a/kotlin-js/src/jsTest/kotlin/js/objects/EsmDuplicateHelperProofChain.kt
+++ b/kotlin-js/src/jsTest/kotlin/js/objects/EsmDuplicateHelperProofChain.kt
@@ -1,0 +1,25 @@
+// Proof for KT-ESM-DUPLICATE-HELPERS: Kotlin/JS IR emits duplicate top-level
+// `function set` helpers in the generated .mjs when multiple regular (non-external)
+// interfaces in the same compilation unit each directly inherit `Record.set = definedExternally`.
+//
+// Reproducing configuration: useEsModules() + kotlin.js.ir.output.granularity=per-file.
+// All five interfaces live in this single source file so per-file compilation bundles
+// them into ONE .mjs — five interfaces × one `function set` helper each =
+// five `function set` declarations in the output → SyntaxError before the fix.
+
+package js.objects
+
+import kotlin.js.JsAny
+import kotlin.js.JsString
+
+// Five regular (non-external) interfaces, each directly extending Record<JsString, JsAny?>.
+// Unlike external interfaces (erased at runtime), regular interfaces cause the Kotlin/JS IR
+// backend to emit a top-level `function set` helper per interface in the compiled .mjs.
+interface ProofBranchA : Record<JsString, JsAny?>
+interface ProofBranchB : Record<JsString, JsAny?>
+interface ProofBranchC : Record<JsString, JsAny?>
+interface ProofBranchD : Record<JsString, JsAny?>
+interface ProofBranchE : Record<JsString, JsAny?>
+
+// Factory forces this module to be imported at runtime, triggering any duplicate-set SyntaxError.
+fun createProofRecord(): ProofBranchA = unsafeJso()

--- a/kotlin-js/src/jsTest/kotlin/js/objects/RecordOperatorRoundTripTest.kt
+++ b/kotlin-js/src/jsTest/kotlin/js/objects/RecordOperatorRoundTripTest.kt
@@ -1,0 +1,44 @@
+package js.objects
+
+import kotlin.js.JsAny
+import kotlin.js.JsString
+import kotlin.js.toJsString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RecordOperatorRoundTripTest {
+
+    @Test
+    fun setAndGetRoundTrip() {
+        val record = unsafeJso<Record<JsString, JsAny?>>()
+        val key = "proof-key".toJsString()
+        val value = "proof-value".toJsString()
+
+        record[key] = value
+
+        assertEquals(value, record[key])
+    }
+
+    @Test
+    fun readonlyRecordGet() {
+        val record = unsafeJso<Record<JsString, JsAny?>>()
+        val key = "readonly-key".toJsString()
+        val value = "readonly-value".toJsString()
+
+        record[key] = value
+
+        val readOnly: ReadonlyRecord<JsString, JsAny?> = record
+        assertEquals(value, readOnly[key])
+    }
+
+    @Test
+    fun proofLevel5SetAndGet() {
+        val obj = createProofRecord()
+        val key = "chain-key".toJsString()
+        val value = "chain-value".toJsString()
+
+        obj[key] = value
+
+        assertEquals(value, obj[key])
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -133,6 +133,9 @@ include("kotlin-floating-ui-utils")
 // Kotlin/JS: APIs missing from the standard library
 include("kotlin-js")
 
+// Kotlin/JS: ESM duplicate-helper regression proof (depends on kotlin-csstype)
+include("kotlin-js-proof")
+
 // Kotlin/JS: Helper for `kotlin-js`
 include("kotlin-js-core")
 


### PR DESCRIPTION
## Title

  Kotlin/JS ESM output is invalid: duplicate top-level set/get helpers emitted for csstype pseudo-builders

## Summary

  With Kotlin/JS configured to emit ES modules, jsNodeTest fails before any tests run because the generated .mjs file is not valid ESM.

  Node throws:
```
  SyntaxError: Identifier 'set' has already been declared
```
  The generated module contains multiple identical top-level declarations like:
```
  function set(key, value) {
    var tmp = !(key == null) ? key : THROW_CCE();
    return this[tmp] = !(value == null) ? value : THROW_CCE();
  }
  function get(key) {
    return this[!(key == null) ? key : THROW_CCE()];
  }
```
  These helpers are emitted repeatedly around generated csstype pseudo-builder sections, for example:
```
  class AdvancedPseudosRuleBuilder {}
  ...
  function set(key, value) { ... }
  function get(key) { ... }
  class ExperimentalPseudosRuleBuilder {}
  ...
  function set(key, value) { ... }
  function get(key) { ... }
  class NonStandardPseudosRuleBuilder {}
  ...
  function set(key, value) { ... }
  function get(key) { ... }
  class SimplePseudosRuleBuilder {}
  ...
  function set(key, value) { ... }
  function get(key) { ... }
  class PseudosRuleBuilder {}
  function set(key, value) { ... }
  function get(key) { ... }
```
  That is valid in some non-module JS contexts, but invalid in an ES module, so Node aborts during import.

 ## Actual Behavior

  jsNodeTest fails during module loading with:
```
  Exception during run: SyntaxError: Identifier 'set' has already been declared
      at compileSourceTextModule (node:internal/modules/esm/utils:318:16)
      ...
  > Task :jsNodeTest FAILED
```
  A direct syntax check also fails:
```
  node --check <generated-test-bundle>.mjs
  SyntaxError: Identifier 'set' has already been declared
```
##  Expected Behavior

  The generated Kotlin/JS .mjs bundle should be valid ES module syntax and test execution should start normally.

  Configuration

  Project-side configuration:

  - Kotlin: 2.3.21
  - useEsModules() enabled
  - Kotlin wrappers catalog: 2026.4.12

  Relevant JS dependencies include Kotlin wrappers for:

  - react
  - react-dom
  - emotion.styled

  There is also a custom MUI dependency:

  - org.jetbrains.kotlin-wrappers.experimental:mui-7:7.3.10-pre.3

The immediate failure is not “two kotlin-csstype versions loaded at once”. The final JS output contains duplicate top-level set/get declarations within a single generated module, and Node rejects that module as invalid ESM.

  Suspected Root Cause

  Likely a Kotlin/JS IR or wrapper codegen issue affecting kotlin-csstype pseudo-builder generation when targeting ES modules, where shared helpers such as set/get are emitted repeatedly at
  top level instead of being deduplicated or scoped.

##  Why This Report Is Self-Contained

  The original repository and generated bundle are not available to the receiver. The issue can be understood from the generated output shape above: repeated top-level function set(...) /
  function get(...) declarations in the same .mjs file are sufficient to reproduce the SyntaxError.

##  Suggested Investigation Areas

  - kotlin-csstype pseudo-builder generation:
      - AdvancedPseudosRuleBuilder
      - ExperimentalPseudosRuleBuilder
      - NonStandardPseudosRuleBuilder
      - SimplePseudosRuleBuilder
      - PseudosRuleBuilder
  - Kotlin/JS IR ESM emission rules for top-level helper naming/deduplication

##  Impact

  Any project using this dependency shape with useEsModules() may fail before tests or application code start, because the generated module cannot be imported by Node at all.

## Fixing it in kotlin-wrappers

  What's actually happening                                                                                                                                                                                                         
                                                                
  ★ Insight ─────────────────────────────────────
  - In the generated .mjs, each set/get block is the exact body of Record.set / ReadonlyRecord.get — the two external interface members in kotlin-js/src/webMain/kotlin/js/objects/Record.kt:18–21 and ReadonlyRecord.kt:16–18 that
  are annotated = definedExternally with a file-level @Suppress("NON_ABSTRACT_MEMBER_OF_EXTERNAL_INTERFACE").                                                                                                                       
  - The Kotlin/JS IR backend materializes that "default body" once as a top-level helper per implementing class that sits in the inheritance chain. Here the chain is Record ← Rules ← RuleBuilder ← {Advanced, Experimental, 
  NonStandard, Simple, Pseudos}RuleBuilder ← PropertiesBuilder — exactly 6 classes, exactly 6 duplicate function set / function get pairs in the bundle.                                                                            
  - The IR collision-renamer (which produces set_0, set_1, …) isn't catching these six. That's almost certainly a compiler-side issue, but you don't have to wait on JetBrains — the cleaner Kotlin/JS idiom already sidesteps it.  
  ─────────────────────────────────────────────────                                                                                                                                                                               
                                                                                                                                                                                                                                    
  The two-file fix                                              
                                                                                                                                                                                                                                    
  Make the external operator members abstract instead of giving them a fake = definedExternally body. Abstract members of external interface are compiled to pure JS property access at the use sites (obj[key] / obj[key] = v) — no
   method body is needed or even emitted.                                                                                                                                                                                           
                                                                                                                                                                                                                                    
  kotlin-js/src/webMain/kotlin/js/objects/Record.kt:            
  package js.objects                                                                                                                                                                                                              
                                                                                                                                                                                                                                  
  import js.array.Tuple2                                                                                                                                                                                                            
  import js.array.component1
  import js.array.component2                                                                                                                                                                                                        
  import kotlin.js.JsAny                                                                                                                                                                                                            
  import kotlin.js.JsString     
  import kotlin.js.toJsString                                                                                                                                                                                                       
                                                                
  external interface Record<K : JsAny, V : JsAny?> :                                                                                                                                                                                
      ReadonlyRecord<K, V> {                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
      operator fun set(key: K, value: V)                                                                                                                                                                                            
  }                                                             
                                                                                                                                                                                                                                  
  Same shape for ReadonlyRecord.kt: drop the @file:Suppress, drop = definedExternally, drop the import kotlin.js.definedExternally.                                                                                                 
                                                                                                                                                                                                                                    
  Why the risk is low                                                                                                                                                                                                               
                                                                                                                                                                                                                                    
  - Every existing call site uses operator convention (r[k] = v, r[k]) or the inline operator fun extensions at lines 24 and 28 of Record.kt. Both compile to the same raw JS property access regardless of whether the interface   
  member has a default body.                                                                                                                                                                                                      
  - In the produced bundle, PropertiesBuilder already emits a proper class PropertiesBuilder { get(...) set(...) } (around line 23625 of the test bundle), so the class-level methods are generated correctly. The top-level        
  duplicates are vestigial dead code emitted only because of the definedExternally hint.                                                                                                                                            
  - I grep'd for non-operator .set( callers on Record — there are none outside the two inline extensions, which themselves use the operator form.
                                                                                                                                                                                                                                    
  What "done" looks like                                        
                                                                                                                                                                                                                                    
  1. Edit the two files (~6 line deletions total).                                                                                                                                                                                  
  2. Build kotlin-js and kotlin-csstype (csstype regenerates off the same interface).
  3. Re-run the failing project's jsNodeTest — the bundle should no longer contain top-level function set(/function get( declarations. node --check on the bundle should pass.                                                      
  4. Optional: file an upstream Kotlin ticket about the IR renamer missing these, so nobody reintroduces the footgun later.                                                                                                         
                                                                                                                                                                                                                                    
  Caveats on effort                                                                                                                                                                                                                 
                                                                                                                                                                                                                                    
  - If a downstream wrapper (emotion, mui, styled-next) has its own file with @Suppress("NON_ABSTRACT_MEMBER_OF_EXTERNAL_INTERFACE") and a definedExternally set/get, you'd need to clean those too. A quick grep -rn               
  "NON_ABSTRACT_MEMBER_OF_EXTERNAL_INTERFACE" --include=*.kt across the repo would catch them.                                                                                                                                    
  - The mixed-version graph (mui-7 pulling 2026.4.12 while others stay on 2026.4.10) didn't cause the duplication — it just made it visible. The fix is version-independent, but you'll still want to align versions eventually for 
  other reasons.                                                                                                                                                                                                                    
                                
  One-line verdict                                                                                                                                                                                                                  
                                                                
  This is a ~10‑minute edit in kotlin-js with low blast radius, followed by a build + one jsNodeTest run to confirm the duplicates are gone. The upstream IR renamer bug is the "real" bug, but you don't need to wait on JetBrains 
  to unblock your project.                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
