### PR TITLE
CSS. Add `clip` to `Overflow` enum

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyleEnums.kt
@@ -677,7 +677,7 @@ enum class OutlineStyle {
 enum class Overflow {
     inherit, initial, revert, revertLayer, unset,
 
-    visible, hidden, scroll, auto;
+    visible, hidden, clip, scroll, auto;
 
     override fun toString() = name.hyphenize()
 }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow#values for an explanation of what the clip value does