### PR TITLE
Add AxialInset data class and related properties for inset handling

### DIFF
--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/Inset.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/Inset.kt
@@ -26,7 +26,14 @@ data class Inset(
     )
 }
 
-data class LinearInset(
+/**
+ * Inset for a specific axis.
+ * Axial insets are affected by the specified writing-mode and direction.
+ *
+ * @param start the inset at the start of the axis
+ * @param end the inset at the end of the axis
+ */
+data class AxialInset(
     val start: LinearDimension,
     val end: LinearDimension,
 ) : CssValue(
@@ -38,8 +45,8 @@ data class LinearInset(
 }
 
 @get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.inset: Inset by CssProperty()
-@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInline: LinearInset by CssProperty()
-@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlock: LinearInset by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInline: AxialInset by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlock: AxialInset by CssProperty()
 @get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInlineStart: LinearDimension by CssProperty()
 @get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInlineEnd: LinearDimension by CssProperty()
 @get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlockStart: LinearDimension by CssProperty()

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/Inset.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/Inset.kt
@@ -26,4 +26,21 @@ data class Inset(
     )
 }
 
+data class LinearInset(
+    val start: LinearDimension,
+    val end: LinearDimension,
+) : CssValue(
+    getShorthandValue(start, end)
+) {
+    override fun toString() = value
+
+    constructor(all: LinearDimension) : this(all, all)
+}
+
 @get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.inset: Inset by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInline: LinearInset by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlock: LinearInset by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInlineStart: LinearDimension by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetInlineEnd: LinearDimension by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlockStart: LinearDimension by CssProperty()
+@get:Deprecated("Write-only property", level = DeprecationLevel.HIDDEN) var StyledElement.insetBlockEnd: LinearDimension by CssProperty()

--- a/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
+++ b/kotlin-css/src/commonMain/kotlin/kotlinx/css/StyledElement.kt
@@ -264,3 +264,14 @@ internal fun getShorthandValue(
     }
 }
 
+internal fun getShorthandValue(
+    start: LinearDimension,
+    end: LinearDimension,
+): String {
+    return if (start == end) {
+        "$start"
+    } else {
+        "$start $end"
+    }
+}
+

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestBoxModelProperties.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestBoxModelProperties.kt
@@ -179,28 +179,28 @@ class TestBoxModelProperties {
                 inset-inline: 10px;
 
             """
-        ) { insetInline = LinearInset(10.px) },
+        ) { insetInline = AxialInset(10.px) },
 
         PropertyTestCase(
             """
                 inset-inline: 10px 20px;
 
             """
-        ) { insetInline = LinearInset(10.px, 20.px) },
+        ) { insetInline = AxialInset(10.px, 20.px) },
 
         PropertyTestCase(
             """
                 inset-block: 10px;
 
             """
-        ) { insetBlock = LinearInset(10.px) },
+        ) { insetBlock = AxialInset(10.px) },
 
         PropertyTestCase(
             """
                 inset-block: 10px 20px;
 
             """
-        ) { insetBlock = LinearInset(10.px, 20.px) },
+        ) { insetBlock = AxialInset(10.px, 20.px) },
 
 
         PropertyTestCase(

--- a/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestBoxModelProperties.kt
+++ b/kotlin-css/src/commonTest/kotlin/kotlinx/css/TestBoxModelProperties.kt
@@ -172,7 +172,65 @@ class TestBoxModelProperties {
                 inset: 10px 20px 30px 40px;
 
             """
-        ) { inset = Inset(10.px, 20.px, 30.px, 40.px) }
+        ) { inset = Inset(10.px, 20.px, 30.px, 40.px) },
+
+        PropertyTestCase(
+            """
+                inset-inline: 10px;
+
+            """
+        ) { insetInline = LinearInset(10.px) },
+
+        PropertyTestCase(
+            """
+                inset-inline: 10px 20px;
+
+            """
+        ) { insetInline = LinearInset(10.px, 20.px) },
+
+        PropertyTestCase(
+            """
+                inset-block: 10px;
+
+            """
+        ) { insetBlock = LinearInset(10.px) },
+
+        PropertyTestCase(
+            """
+                inset-block: 10px 20px;
+
+            """
+        ) { insetBlock = LinearInset(10.px, 20.px) },
+
+
+        PropertyTestCase(
+            """
+                inset-inline-start: 10px;
+
+            """
+        ) { insetInlineStart = 10.px },
+
+
+        PropertyTestCase(
+            """
+                inset-inline-end: 10px;
+
+            """
+        ) { insetInlineEnd = 10.px },
+
+        PropertyTestCase(
+            """
+                inset-block-start: 10px;
+
+            """
+        ) { insetBlockStart = 10.px },
+
+        PropertyTestCase(
+            """
+                inset-block-end: 10px;
+
+            """
+        ) { insetBlockEnd = 10.px },
     )
 
     /**


### PR DESCRIPTION
This adds support for `inset-inline`, `inset-block`, `inset-inline-start`, `inset-inline-end`, `inset-block-start` and `inset-block-end`

Docs for the CSS elements:
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-inline
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-block
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-inline-start
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-inline-end
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-block-start
 - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-block-end